### PR TITLE
PAE-265: adr for project structure

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -59,7 +59,7 @@ Within a specific route's folder the files will not repeat the name of the folde
 
 Different components will be kept in different folders in a flat structure, i.e. all components will live directly under `components/`. This allows us to start with the simplest approach, which is also the one with the least cognitive load for the developer, in line with best practices.
 
-This implies that sub-component is a dynamic concept, i.e. a component becomes a sub-component of another when referenced inside another component and not dictated by the folder structure. This is meant to facilitate refactoring.
+This implies that sub-component is a dynamic concept, i.e. a component becomes a sub-component of another when it's referenced (inside the parent component) and not dictated by the folder structure. This is meant to facilitate refactoring.
 
 ```
 project-root/


### PR DESCRIPTION
Ticket: [PAE-265](https://eaflood.atlassian.net/browse/PAE-265)

Proposal for project structure:

Main differences with the CDP frontend template:

- Routes live in `/server/routes` with a hierarchical structure that replicates path structures.
- Components live in `/server/components/ with each component living in its own folder and no sub-folders
- Integration tests live in `src/integration`
- Placement of unit tests is prescribed, not implied
- Use of kebab-case is prescribed, not implied
- File structure for routes is prescribed, not implied
- File structure for components is prescribed, not implied
- File structure for helpers (utils) is prescribed, not implied


[PAE-265]: https://eaflood.atlassian.net/browse/PAE-265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ