### PR TITLE
PAE-269: fix dev syncing in docker compose

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,6 +169,10 @@ docker run -e PORT=3002 -p 3002:3002 epr-re-ex-admin-frontend
 
 ### Docker Compose
 
+> [!IMPORTANT]
+>
+> Please ensure you have at least version 2.22.0 of Docker Compose installed.
+
 A local environment with:
 
 - Localstack for AWS services (S3, SQS)
@@ -177,7 +181,7 @@ A local environment with:
 - A commented out backend example.
 
 ```bash
-docker compose up --build -d
+docker compose up --build -d --watch
 ```
 
 See the running services with:

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,23 @@
+ARG PARENT_VERSION=2.5.2-node22.13.1
+ARG PORT=3002
+ARG PORT_DEBUG=9229
+
+FROM defradigital/node-development:${PARENT_VERSION}
+
+WORKDIR /app
+
+ENV TZ="Europe/London"
+
+ARG PARENT_VERSION
+LABEL uk.gov.defra.ffc.parent-image=defradigital/node-development:${PARENT_VERSION}
+
+ARG PORT
+ARG PORT_DEBUG
+ENV PORT=${PORT}
+EXPOSE ${PORT} ${PORT_DEBUG}
+
+COPY --chown=node:node --chmod=755 package*.json nodemon.json babel.config.cjs webpack.config.js .browserslistrc ./
+COPY --chown=node:node --chmod=755 src/ ./src/
+RUN npm install --ignore-scripts
+
+CMD [ "npm", "run", "dev" ]

--- a/compose.yml
+++ b/compose.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   localstack:
     image: localstack/localstack:3.0.2
@@ -31,25 +30,34 @@ services:
     networks:
       - cdp-tenant
 
-  mongodb:
-    image: mongo:6.0.13
-    networks:
-      - cdp-tenant
-    ports:
-      - '27017:27017'
-    volumes:
-      - mongodb-data:/data
-    restart: always
+################################################################################
 
-  ################################################################################
-
-  your-frontend:
-    build: ./
+  ui:
+    build:
+      context: .
+      dockerfile: Dockerfile.local
     ports:
       - '3002:3002'
     links:
       - 'localstack:localstack'
       - 'redis:redis'
+    develop:
+      watch:
+        - path: src/
+          action: sync
+          target: /app/src/
+          ignore:
+            - node_modules/
+        - path: .browserslistrc
+          action: rebuild
+        - path: babel.config.cjs
+          action: rebuild
+        - path: nodemon.json
+          action: rebuild
+        - path: package.json
+          action: rebuild
+        - path: webpack.config.js
+          action: rebuild
     depends_on:
       localstack:
         condition: service_healthy
@@ -88,9 +96,6 @@ services:
   #     - cdp-tenant
 
 ################################################################################
-
-volumes:
-  mongodb-data:
 
 networks:
   cdp-tenant:


### PR DESCRIPTION
Ticket: [PAE-269](https://eaflood.atlassian.net/browse/PAE-269)

## Description

1. Create local Dockerfile that doesn't rely on built artifacts
2. Add Docker Compose `watch` config for hot-reloading
3. Update docs to highlight Docker Compose required version

Implements same logic as https://github.com/DEFRA/epr-frontend/pull/63

[PAE-269]: https://eaflood.atlassian.net/browse/PAE-269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ