### PR TITLE
chore: remove FEATURE_FLAG_OVERSEAS_SITES feature flag

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -287,12 +287,6 @@ export const config = convict({
     env: 'EPR_BACKEND_URL'
   },
   featureFlags: {
-    overseasSites: {
-      doc: 'Enable overseas sites (ORS uploads) feature',
-      format: Boolean,
-      default: false,
-      env: 'FEATURE_FLAG_OVERSEAS_SITES'
-    },
     summaryLogFileDownload: {
       doc: 'Enable summary log file download from system logs',
       format: Boolean,

--- a/src/config/nunjucks/context/build-navigation.js
+++ b/src/config/nunjucks/context/build-navigation.js
@@ -1,18 +1,4 @@
-import { config } from '#config/config.js'
-
 export function buildNavigation(request) {
-  const orsNavigation = config.get('featureFlags.overseasSites')
-    ? [
-        {
-          text: 'Overseas sites',
-          href: '/overseas-sites',
-          current:
-            request?.path === '/overseas-sites' ||
-            request?.path?.startsWith('/overseas-sites/')
-        }
-      ]
-    : []
-
   const navigation = [
     {
       text: 'Home',
@@ -49,7 +35,13 @@ export function buildNavigation(request) {
       href: '/summary-log',
       current: request?.path === '/summary-log'
     },
-    ...orsNavigation,
+    {
+      text: 'Overseas sites',
+      href: '/overseas-sites',
+      current:
+        request?.path === '/overseas-sites' ||
+        request?.path?.startsWith('/overseas-sites/')
+    },
     {
       text: 'PRN activity',
       href: '/prn-activity',

--- a/src/config/nunjucks/context/build-navigation.test.js
+++ b/src/config/nunjucks/context/build-navigation.test.js
@@ -1,21 +1,10 @@
 import { buildNavigation } from './build-navigation.js'
-import { config } from '#config/config.js'
-
-vi.mock('#config/config.js', () => ({
-  config: {
-    get: vi.fn()
-  }
-}))
 
 function mockRequest(options) {
   return { ...options }
 }
 
 describe('#buildNavigation', () => {
-  beforeEach(() => {
-    config.get.mockReturnValue(false)
-  })
-
   test('Should provide expected navigation details', () => {
     expect(
       buildNavigation(mockRequest({ path: '/non-existent-path' }))
@@ -54,6 +43,11 @@ describe('#buildNavigation', () => {
         current: false,
         text: 'Summary log uploads',
         href: '/summary-log'
+      },
+      {
+        current: false,
+        text: 'Overseas sites',
+        href: '/overseas-sites'
       },
       {
         current: false,
@@ -112,6 +106,11 @@ describe('#buildNavigation', () => {
       },
       {
         current: false,
+        text: 'Overseas sites',
+        href: '/overseas-sites'
+      },
+      {
+        current: false,
         text: 'PRN activity',
         href: '/prn-activity'
       },
@@ -129,8 +128,6 @@ describe('#buildNavigation', () => {
   })
 
   test('Should highlight overseas sites for status pages', () => {
-    config.get.mockReturnValue(true)
-
     expect(
       buildNavigation(
         mockRequest({ path: '/overseas-sites/imports/import-123' })
@@ -146,9 +143,7 @@ describe('#buildNavigation', () => {
     )
   })
 
-  test('Should include overseas sites when feature flag enabled', () => {
-    config.get.mockReturnValue(true)
-
+  test('Should include overseas sites after summary log uploads', () => {
     const navigation = buildNavigation(
       mockRequest({ path: '/non-existent-path' })
     )
@@ -172,8 +167,6 @@ describe('#buildNavigation', () => {
   })
 
   test('Should include overseas sites when request is undefined', () => {
-    config.get.mockReturnValue(true)
-
     const navigation = buildNavigation()
     const overseasSites = navigation.find(
       (item) => item.text === 'Overseas sites'

--- a/src/config/nunjucks/context/context.test.js
+++ b/src/config/nunjucks/context/context.test.js
@@ -1,9 +1,6 @@
 import { vi } from 'vitest'
 import { mockUserSession } from '#server/common/test-helpers/fixtures.js'
 
-const originalOverseasSitesFlag = process.env.FEATURE_FLAG_OVERSEAS_SITES
-process.env.FEATURE_FLAG_OVERSEAS_SITES = 'false'
-
 const mockGetUserSession = vi.fn().mockResolvedValue(mockUserSession)
 
 vi.mock('#server/common/helpers/auth/get-user-session.js', () => ({
@@ -27,14 +24,6 @@ vi.mock('#server/common/helpers/logging/logger.js', () => ({
 }))
 
 describe('context and cache', () => {
-  afterAll(() => {
-    if (originalOverseasSitesFlag === undefined) {
-      delete process.env.FEATURE_FLAG_OVERSEAS_SITES
-    } else {
-      process.env.FEATURE_FLAG_OVERSEAS_SITES = originalOverseasSitesFlag
-    }
-  })
-
   beforeEach(() => {
     mockReadFileSync.mockReset()
     mockLoggerError.mockReset()
@@ -106,6 +95,11 @@ describe('context and cache', () => {
             },
             {
               current: false,
+              text: 'Overseas sites',
+              href: '/overseas-sites'
+            },
+            {
+              current: false,
               text: 'PRN activity',
               href: '/prn-activity'
             },
@@ -135,16 +129,15 @@ describe('context and cache', () => {
         })
       })
 
-      test('Should include overseas sites when feature flag is enabled', async () => {
-        process.env.FEATURE_FLAG_OVERSEAS_SITES = 'true'
+      test('Should include overseas sites in navigation', async () => {
         vi.resetModules()
 
-        const contextImportWithFlag = await import('./context.js')
-        const contextWithFlag = await contextImportWithFlag.context({
+        const contextImportFresh = await import('./context.js')
+        const contextFresh = await contextImportFresh.context({
           path: '/overseas-sites/imports'
         })
 
-        expect(contextWithFlag.navigation).toEqual(
+        expect(contextFresh.navigation).toEqual(
           expect.arrayContaining([
             {
               current: true,
@@ -153,9 +146,6 @@ describe('context and cache', () => {
             }
           ])
         )
-
-        process.env.FEATURE_FLAG_OVERSEAS_SITES = 'false'
-        vi.resetModules()
       })
 
       describe('With invalid asset path', () => {
@@ -302,6 +292,11 @@ describe('context and cache', () => {
               current: false,
               text: 'Summary log uploads',
               href: '/summary-log'
+            },
+            {
+              current: false,
+              text: 'Overseas sites',
+              href: '/overseas-sites'
             },
             {
               current: false,

--- a/src/server/common/helpers/content-security-policy.js
+++ b/src/server/common/helpers/content-security-policy.js
@@ -1,15 +1,7 @@
 import Blankie from 'blankie'
 import { config } from '#config/config.js'
 
-export function cspFormAction({
-  isProduction,
-  cdpUploaderUrl,
-  isOverseasSitesFeatureEnabled
-}) {
-  if (!isOverseasSitesFeatureEnabled) {
-    return ['self']
-  }
-
+export function cspFormAction({ isProduction, cdpUploaderUrl }) {
   if (isProduction) {
     return ['self']
   }
@@ -44,8 +36,7 @@ const contentSecurityPolicy = {
     frameAncestors: ['none'],
     formAction: cspFormAction({
       isProduction: config.get('isProduction'),
-      cdpUploaderUrl: config.get('cdpUploaderUrl'),
-      isOverseasSitesFeatureEnabled: config.get('featureFlags.overseasSites')
+      cdpUploaderUrl: config.get('cdpUploaderUrl')
     }),
     manifestSrc: ['self'],
     generateNonces: false

--- a/src/server/common/helpers/content-security-policy.test.js
+++ b/src/server/common/helpers/content-security-policy.test.js
@@ -9,8 +9,7 @@ describe(cspFormAction, () => {
       'non-production',
       {
         isProduction: false,
-        cdpUploaderUrl: 'http://localhost:7337',
-        isOverseasSitesFeatureEnabled: true
+        cdpUploaderUrl: 'http://localhost:7337'
       },
       ['self', 'localhost:*', 'http://localhost:7337']
     ],
@@ -18,8 +17,7 @@ describe(cspFormAction, () => {
       'non-production with custom port',
       {
         isProduction: false,
-        cdpUploaderUrl: 'http://localhost:9000',
-        isOverseasSitesFeatureEnabled: true
+        cdpUploaderUrl: 'http://localhost:9000'
       },
       ['self', 'localhost:*', 'http://localhost:9000']
     ],
@@ -27,17 +25,7 @@ describe(cspFormAction, () => {
       'production',
       {
         isProduction: true,
-        cdpUploaderUrl: 'https://cdp-uploader.prod.example.gov.uk',
-        isOverseasSitesFeatureEnabled: true
-      },
-      ['self']
-    ],
-    [
-      'feature disabled',
-      {
-        isProduction: false,
-        cdpUploaderUrl: 'http://localhost:7337',
-        isOverseasSitesFeatureEnabled: false
+        cdpUploaderUrl: 'https://cdp-uploader.prod.example.gov.uk'
       },
       ['self']
     ]
@@ -67,8 +55,7 @@ describe('#contentSecurityPolicy', () => {
 
     const expectedFormAction = cspFormAction({
       isProduction: config.get('isProduction'),
-      cdpUploaderUrl: config.get('cdpUploaderUrl'),
-      isOverseasSitesFeatureEnabled: config.get('featureFlags.overseasSites')
+      cdpUploaderUrl: config.get('cdpUploaderUrl')
     })
 
     const csp = resp.headers['content-security-policy']

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -15,7 +15,6 @@ import { linkedOrganisations } from './routes/linked-organisations/index.js'
 import { prnActivity } from './routes/prn-activity/index.js'
 import { summaryLogUploadsReport } from './routes/summary-log/index.js'
 import { orsUpload } from './routes/ors-upload/index.js'
-import { config } from '#config/config.js'
 
 import { serveStaticFiles } from './common/helpers/serve-static-files.js'
 
@@ -42,12 +41,9 @@ export const router = {
         wasteBalanceAvailability,
         linkedOrganisations,
         prnActivity,
-        summaryLogUploadsReport
+        summaryLogUploadsReport,
+        orsUpload
       ])
-
-      if (config.get('featureFlags.overseasSites')) {
-        await server.register([orsUpload])
-      }
 
       await server.register([serveStaticFiles])
     }

--- a/src/server/router.test.js
+++ b/src/server/router.test.js
@@ -1,16 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { router } from './router.js'
 
-const { mockConfigGet } = vi.hoisted(() => ({
-  mockConfigGet: vi.fn((key) => {
-    if (key === 'featureFlags.overseasSites') {
-      return false
-    }
-
-    return undefined
-  })
-}))
-
 const { mockInert } = vi.hoisted(() => ({
   mockInert: { plugin: { name: 'inert' } }
 }))
@@ -29,12 +19,6 @@ const { mockOrsUpload } = vi.hoisted(() => ({
 
 vi.mock('@hapi/inert', () => ({
   default: mockInert
-}))
-
-vi.mock('#config/config.js', () => ({
-  config: {
-    get: mockConfigGet
-  }
 }))
 
 vi.mock('./routes/home/index.js', () => ({
@@ -98,35 +82,12 @@ describe('router plugin', () => {
     }
   })
 
-  test('does not register ORS upload routes when feature flag is disabled', async () => {
-    mockConfigGet.mockImplementation((key) => {
-      if (key === 'featureFlags.overseasSites') {
-        return false
-      }
-
-      return undefined
-    })
-
+  test('registers all route plugins including ORS upload', async () => {
     await router.plugin.register(server)
 
     expect(server.register).toHaveBeenCalledTimes(4)
-    expect(mockConfigGet).toHaveBeenCalledWith('featureFlags.overseasSites')
-    expect(server.register).not.toHaveBeenCalledWith([mockOrsUpload])
-  })
-
-  test('registers ORS upload routes when feature flag is enabled', async () => {
-    mockConfigGet.mockImplementation((key) => {
-      if (key === 'featureFlags.overseasSites') {
-        return true
-      }
-
-      return undefined
-    })
-
-    await router.plugin.register(server)
-
-    expect(server.register).toHaveBeenCalledTimes(5)
-    expect(mockConfigGet).toHaveBeenCalledWith('featureFlags.overseasSites')
-    expect(server.register).toHaveBeenCalledWith([mockOrsUpload])
+    expect(server.register).toHaveBeenCalledWith(
+      expect.arrayContaining([mockOrsUpload])
+    )
   })
 })

--- a/src/server/routes/ors-upload/download.integration.test.js
+++ b/src/server/routes/ors-upload/download.integration.test.js
@@ -17,19 +17,9 @@ vi.mock('#server/common/helpers/auth/get-user-session.js', () => ({
 describe('ors-upload download integration', () => {
   const backendUrl = config.get('eprBackendUrl')
   const pagePath = '/overseas-sites'
-  const originalConfigGet = config.get.bind(config)
-  let configGetSpy
   let server
 
   beforeAll(async () => {
-    configGetSpy = vi.spyOn(config, 'get').mockImplementation((key) => {
-      if (key === 'featureFlags.overseasSites') {
-        return true
-      }
-
-      return originalConfigGet(key)
-    })
-
     createMockOidcServer()
     server = await createServer()
     await server.initialize()
@@ -37,7 +27,6 @@ describe('ors-upload download integration', () => {
 
   afterAll(async () => {
     await server.stop({ timeout: 0 })
-    configGetSpy.mockRestore()
   })
 
   afterEach(() => {

--- a/src/server/routes/ors-upload/index.js
+++ b/src/server/routes/ors-upload/index.js
@@ -3,17 +3,12 @@ import { orsDownloadController } from './controller.download.js'
 import { orsListGetController } from './controller.list.get.js'
 import { orsUploadStatusGetController } from './controller.status.get.js'
 import { orsUploadRoutes } from './constants.js'
-import { config } from '#config/config.js'
 import Joi from 'joi'
 
 export const orsUpload = {
   plugin: {
     name: 'ors-upload',
     register(server) {
-      if (!config.get('featureFlags.overseasSites')) {
-        return
-      }
-
       server.route([
         {
           method: 'GET',

--- a/src/server/routes/ors-upload/index.test.js
+++ b/src/server/routes/ors-upload/index.test.js
@@ -1,5 +1,4 @@
-import { vi, beforeEach, afterEach, describe, test, expect } from 'vitest'
-import { config } from '#config/config.js'
+import { vi, beforeEach, describe, test, expect } from 'vitest'
 import { orsUpload } from './index.js'
 import { orsUploadRoutes } from './constants.js'
 
@@ -7,24 +6,9 @@ describe('#ors-upload routes plugin', () => {
   const mockServer = {
     route: vi.fn()
   }
-  const originalConfigGet = config.get.bind(config)
-  let configGetSpy
 
   beforeEach(() => {
     vi.clearAllMocks()
-
-    configGetSpy = vi.spyOn(config, 'get').mockImplementation((key) => {
-      if (key === 'featureFlags.overseasSites') {
-        return true
-      }
-
-      return originalConfigGet(key)
-    })
-  })
-
-  afterEach(() => {
-    configGetSpy.mockRestore()
-    vi.resetAllMocks()
   })
 
   test('Should have correct plugin name', () => {
@@ -34,24 +18,8 @@ describe('#ors-upload routes plugin', () => {
   test('Should register routes', () => {
     orsUpload.plugin.register(mockServer)
 
-    expect(configGetSpy).toHaveBeenCalledWith('featureFlags.overseasSites')
     expect(mockServer.route).toHaveBeenCalledTimes(1)
     expect(mockServer.route).toHaveBeenCalledWith(expect.any(Array))
-  })
-
-  test('Should not register routes when overseas-sites feature flag is disabled', () => {
-    configGetSpy.mockImplementation((key) => {
-      if (key === 'featureFlags.overseasSites') {
-        return false
-      }
-
-      return originalConfigGet(key)
-    })
-
-    orsUpload.plugin.register(mockServer)
-
-    expect(configGetSpy).toHaveBeenCalledWith('featureFlags.overseasSites')
-    expect(mockServer.route).not.toHaveBeenCalled()
   })
 
   test('Should register upload and status routes', () => {


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
## Summary

- Removed `FEATURE_FLAG_OVERSEAS_SITES` feature flag — overseas sites feature is now permanently enabled
- 11 files changed, 184 lines of dead code removed

## Changes

| File | Change |
|---|---|
| `src/config/config.js` | Removed `overseasSites` flag from featureFlags config |
| `src/server/router.js` | Removed conditional registration — `orsUpload` always registered |
| `src/server/router.test.js` | Removed flag-disabled test cases |
| `src/config/nunjucks/context/build-navigation.js` | Removed conditional — ORS navigation always included |
| `src/config/nunjucks/context/build-navigation.test.js` | Simplified tests (no flag toggling) |
| `src/config/nunjucks/context/context.test.js` | Removed `FEATURE_FLAG_OVERSEAS_SITES` env var manipulation |
| `src/server/common/helpers/content-security-policy.js` | Removed flag-gated CSP rules |
| `src/server/common/helpers/content-security-policy.test.js` | Simplified CSP tests |
| `src/server/routes/ors-upload/index.js` | Removed early-return guard when flag disabled |
| `src/server/routes/ors-upload/index.test.js` | Removed flag-disabled test cases |
| `src/server/routes/ors-upload/download.integration.test.js` | Removed flag mock from config stub |

## Test plan

- [x] All 796 tests pass with 100% coverage locally
- [ ] CI pipeline passes