### PR TITLE
PAE-1293 handle rendering of reports.delete system logs

### DIFF
--- a/src/server/routes/system-logs/controller.get.js
+++ b/src/server/routes/system-logs/controller.get.js
@@ -102,12 +102,17 @@ function buildPagination({ data, referenceNumber, cursor, page }) {
 
 function contextWithDeltaBetweenPreviousAndNextExtracted({ context }) {
   const { previous, next, ...remainingContext } = context
-  if ('previous' in context && 'next' in context) {
+  const hasPrevious = 'previous' in context
+  const hasNext = 'next' in context
+  if (hasPrevious || hasNext) {
     return {
       renderDelta: {
         previous,
-        next,
-        difference: difference(previous, next) || 'no differences'
+        ...(hasPrevious ? { previous } : {}),
+        ...(hasNext ? { next } : {}),
+        ...(hasPrevious && hasNext
+          ? { difference: difference(previous, next) || 'no differences' }
+          : {})
       },
       context: { ...remainingContext }
     }

--- a/src/server/routes/system-logs/get.integration.test.js
+++ b/src/server/routes/system-logs/get.integration.test.js
@@ -552,6 +552,55 @@ describe('GET /system-logs', () => {
           expect(diff).toEqual(expectedDifference)
         }
       )
+
+      it.each([
+        [
+          'only previous is present',
+          { previous: { value: 1 } },
+          { rendered: 'Previous', notRendered: 'Next' }
+        ],
+        [
+          'only next is present',
+          { next: { value: 2 } },
+          { rendered: 'Next', notRendered: 'Previous' }
+        ]
+      ])(
+        'does not render the difference row when %s',
+        async (_description, context, { rendered, notRendered }) => {
+          stubBackendReponse(
+            HttpResponse.json({
+              systemLogs: [
+                {
+                  createdBy: {},
+                  event: {},
+                  context
+                }
+              ]
+            })
+          )
+
+          const { $, statusCode } = await loadPage(
+            new URLSearchParams({ referenceNumber: 'ORG-123' })
+          )
+
+          expect(statusCode).toBe(statusCodes.ok)
+
+          const renderedRow = $(
+            '.govuk-summary-card .govuk-summary-list__row'
+          ).has(`dt:contains("${rendered}")`)
+          expect(renderedRow).toHaveLength(1)
+
+          const notRenderedRow = $(
+            '.govuk-summary-card .govuk-summary-list__row'
+          ).has(`dt:contains("${notRendered}")`)
+          expect(notRenderedRow).toHaveLength(0)
+
+          const differenceRow = $(
+            '.govuk-summary-card .govuk-summary-list__row'
+          ).has('dt:contains("Difference")')
+          expect(differenceRow).toHaveLength(0)
+        }
+      )
     })
 
     describe('search parameters', () => {

--- a/src/server/routes/system-logs/index.njk
+++ b/src/server/routes/system-logs/index.njk
@@ -91,18 +91,25 @@
           {% if 'renderDelta' in systemLog %}
             {#
               Whitespace added at the start of the contents of <code> elements so the rendered opening brace aligns
-              The summaryList component calls nunjucks indent function to render supplied html
-              - this indents every line (expect the first!) by 6 spaces
+              The summaryList component calls nunjucks indent function to render supplied html - this indents every
+              line (except the first!) by 6 spaces
             #}
-            {% set previousHtml = govukDetails({ summaryText: "Show", html: '<code class="app-json-display">          ' ~ systemLog.renderDelta.previous | dump(2) ~ '</code>' }) %}
-            {% set nextHtml = govukDetails({ summaryText: "Show", html: '<code class="app-json-display">          ' ~ systemLog.renderDelta.next | dump(2) ~ '</code>' }) %}
-            {% set differenceHtml = '<code class="app-json-display">          ' ~ systemLog.renderDelta.difference | dump(2) ~ '</code>' %}
 
-            {% set rows = rows.concat([
-              { key: { text: "Previous" }, value: { html: previousHtml } },
-              { key: { text: "Next" }, value: { html: nextHtml } },
-              { key: { text: "Difference" }, value: { html: differenceHtml } }
-            ]) %}
+            {% if systemLog.renderDelta.previous %}
+            {% set previousHtml = govukDetails({ summaryText: "Show", html: '<code class="app-json-display">          ' ~ systemLog.renderDelta.previous | dump(2) ~ '</code>' }) %}
+            {% set rows = rows.concat({ key: { text: "Previous" }, value: { html: previousHtml } }) %}
+            {% endif %}
+            
+            {% if systemLog.renderDelta.next %}
+            {% set nextHtml = govukDetails({ summaryText: "Show", html: '<code class="app-json-display">          ' ~ systemLog.renderDelta.next | dump(2) ~ '</code>' }) %}
+            {% set rows = rows.concat({ key: { text: "Next" }, value: { html: nextHtml } }) %}
+            {% endif %}
+
+            {% if systemLog.renderDelta.difference %}
+            {% set differenceHtml = '<code class="app-json-display">          ' ~ systemLog.renderDelta.difference | dump(2) ~ '</code>' %}
+            {% set rows = rows.concat({ key: { text: "Difference" }, value: { html: differenceHtml } }) %}
+            {% endif %}
+
           {% endif %}
 
           {{ govukSummaryList({


### PR DESCRIPTION
Ticket: [PAE-1293](https://eaflood.atlassian.net/browse/PAE-1293)
## Description

improve previous/next/diff rendering in system logs to
- always render previous/next via details when present
- only render the difference when both present and next are present

This caters for the system log recorded for the (hard) delete of reports, where previous exists, but next does not

Before:
<img width="1355" height="668" alt="image" src="https://github.com/user-attachments/assets/800f5b5f-351c-4110-a4ea-e3e3f5086564" />


After:
<img width="1332" height="458" alt="image" src="https://github.com/user-attachments/assets/19d5223d-cba6-4bac-a12c-50637e4ca4ec" />


---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1293]: https://eaflood.atlassian.net/browse/PAE-1293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ