### PR TITLE
PAE-000: Resolve Snyk code analysis finding

### DIFF
--- a/src/server/routes/system-logs/controller.get.js
+++ b/src/server/routes/system-logs/controller.get.js
@@ -10,11 +10,11 @@ export const systemLogGetController = {
       request.query,
       'referenceNumber'
     )
-    const rawRef = request.query?.referenceNumber
+    const rawRef = request.query.referenceNumber
     const searchTermReferenceNumber =
       typeof rawRef === 'string' ? rawRef.trim() : ''
-    const cursor = request.query?.cursor || null
-    const page = Number(request.query?.page) || 1
+    const cursor = request.query.cursor ?? null
+    const page = request.query.page
 
     if (!searchTermReferenceNumber) {
       return h.view('routes/system-logs/index', {

--- a/src/server/routes/system-logs/index.js
+++ b/src/server/routes/system-logs/index.js
@@ -30,6 +30,13 @@ export const systemLogs = {
           path: '/system-logs',
           ...systemLogGetController,
           options: {
+            validate: {
+              query: Joi.object({
+                referenceNumber: Joi.string().allow('').optional(),
+                cursor: Joi.string().optional(),
+                page: Joi.number().integer().min(1).optional().default(1)
+              })
+            },
             app: { pageTitle: 'System logs' }
           }
         }


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
## What

Resolve Snyk SAST finding: **Improper Type Validation** (CWE-1287) in `src/server/routes/system-logs/controller.get.js`.

## Code analysis findings

| File | Line | Issue Type | Severity | Fix Applied |
|------|------|-----------|----------|-------------|
| `src/server/routes/system-logs/controller.get.js` | 14 | Improper Type Validation | Low | Added Joi query schema + explicit `typeof` guard |

### Changes

1. **`src/server/routes/system-logs/index.js`** — Added Joi `validate.query` schema to the `/system-logs` GET route, enforcing types for `referenceNumber` (string), `cursor` (string), and `page` (integer ≥ 1, default 1). Matches existing pattern from `linked-organisations`.

2. **`src/server/routes/system-logs/controller.get.js`** — Simplified query parameter access now that Joi guarantees types. Retained explicit `typeof` guard on `referenceNumber` for Snyk static analysis compliance.

## Verification

- `snyk code test` — 0 issues
- `npm test` (system-logs suite) — 42/42 tests pass
