### PR TITLE
PAE-1330: Remove FEATURE_FLAG_SUMMARY_LOG_FILE_DOWNLOAD from admin-frontend

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -292,12 +292,6 @@ export const config = convict({
       format: Boolean,
       default: false,
       env: 'FEATURE_FLAG_OVERSEAS_SITES'
-    },
-    summaryLogFileDownload: {
-      doc: 'Enable summary log file download from system logs',
-      format: Boolean,
-      default: false,
-      env: 'FEATURE_FLAG_SUMMARY_LOG_FILE_DOWNLOAD'
     }
   },
   cdpUploaderUrl: {

--- a/src/server/routes/system-logs/controller.get.js
+++ b/src/server/routes/system-logs/controller.get.js
@@ -1,5 +1,4 @@
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
-import { config } from '#config/config.js'
 import isEqual from 'lodash/isEqual.js'
 import isArray from 'lodash/isArray.js'
 import isObject from 'lodash/isObject.js'
@@ -30,8 +29,7 @@ export const systemLogGetController = {
             }
           : null,
         pagination: {},
-        page: 1,
-        showFileDownload: config.get('featureFlags.summaryLogFileDownload')
+        page: 1
       })
     }
 
@@ -68,8 +66,7 @@ export const systemLogGetController = {
       },
       error: null,
       pagination,
-      page,
-      showFileDownload: config.get('featureFlags.summaryLogFileDownload')
+      page
     })
   }
 }

--- a/src/server/routes/system-logs/get.integration.test.js
+++ b/src/server/routes/system-logs/get.integration.test.js
@@ -152,7 +152,7 @@ describe('GET /system-logs', () => {
         }
       }
 
-      it('does not render a download link when feature flag is off', async () => {
+      it('renders a download link when context has summaryLogId', async () => {
         stubBackendReponse(
           HttpResponse.json({
             systemLogs: [systemLogWithFile]
@@ -165,63 +165,36 @@ describe('GET /system-logs', () => {
 
         expect(statusCode).toBe(statusCodes.ok)
 
-        const downloadLink = $('a[href*="/system-logs/download/"]')
-        expect(downloadLink).toHaveLength(0)
+        const downloadLink = $(
+          'a[href="/system-logs/download/org-123/reg-456/sl-789"]'
+        )
+        expect(downloadLink).toHaveLength(1)
+        expect(downloadLink.text().trim()).toBe('Download file')
       })
 
-      describe('when feature flag is on', () => {
-        beforeAll(() => {
-          config.set('featureFlags.summaryLogFileDownload', true)
-        })
-
-        afterAll(() => {
-          config.set('featureFlags.summaryLogFileDownload', false)
-        })
-
-        it('renders a download link when context has summaryLogId', async () => {
-          stubBackendReponse(
-            HttpResponse.json({
-              systemLogs: [systemLogWithFile]
-            })
-          )
-
-          const { $, statusCode } = await loadPage(
-            new URLSearchParams({ referenceNumber: 'ORG-123' })
-          )
-
-          expect(statusCode).toBe(statusCodes.ok)
-
-          const downloadLink = $(
-            'a[href="/system-logs/download/org-123/reg-456/sl-789"]'
-          )
-          expect(downloadLink).toHaveLength(1)
-          expect(downloadLink.text().trim()).toBe('Download file')
-        })
-
-        it('does not render a download link when context has no summaryLogId', async () => {
-          stubBackendReponse(
-            HttpResponse.json({
-              systemLogs: [
-                {
-                  createdBy: {},
-                  event: {},
-                  context: {
-                    someOtherField: 'value'
-                  }
+      it('does not render a download link when context has no summaryLogId', async () => {
+        stubBackendReponse(
+          HttpResponse.json({
+            systemLogs: [
+              {
+                createdBy: {},
+                event: {},
+                context: {
+                  someOtherField: 'value'
                 }
-              ]
-            })
-          )
+              }
+            ]
+          })
+        )
 
-          const { $, statusCode } = await loadPage(
-            new URLSearchParams({ referenceNumber: 'ORG-123' })
-          )
+        const { $, statusCode } = await loadPage(
+          new URLSearchParams({ referenceNumber: 'ORG-123' })
+        )
 
-          expect(statusCode).toBe(statusCodes.ok)
+        expect(statusCode).toBe(statusCodes.ok)
 
-          const downloadLink = $('a[href*="/system-logs/download/"]')
-          expect(downloadLink).toHaveLength(0)
-        })
+        const downloadLink = $('a[href*="/system-logs/download/"]')
+        expect(downloadLink).toHaveLength(0)
       })
     })
 

--- a/src/server/routes/system-logs/index.njk
+++ b/src/server/routes/system-logs/index.njk
@@ -82,7 +82,7 @@
             {% set rows = rows.concat([ { key: { text: "Context" }, value: { html: contextHtml } } ]) %}
           {% endif %}
 
-          {% if showFileDownload and systemLog.context.summaryLogId %}
+          {% if systemLog.context.summaryLogId %}
             {% set downloadHref = '/system-logs/download/' ~ (systemLog.context.organisationId | urlencode) ~ '/' ~ (systemLog.context.registrationId | urlencode) ~ '/' ~ (systemLog.context.summaryLogId | urlencode) %}
             {% set downloadHtml = '<a href="' ~ downloadHref ~ '" class="govuk-link">Download file</a>' %}
             {% set rows = rows.concat([ { key: { text: "File" }, value: { html: downloadHtml } } ]) %}


### PR DESCRIPTION
Ticket: [PAE-1330](https://eaflood.atlassian.net/browse/PAE-1330)
## Summary

Remove the `FEATURE_FLAG_SUMMARY_LOG_FILE_DOWNLOAD` feature flag, making the summary log file download in system logs unconditional.

- Remove convict config entry for `summaryLogFileDownload`
- Remove `showFileDownload` view property from the system logs controller
- Simplify Nunjucks template condition to render the download link whenever `summaryLogId` is present in context
- Update tests to reflect the feature being always-on

Part of PAE-1330 (remove obsolete feature flags).

[PAE-1330]: https://eaflood.atlassian.net/browse/PAE-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ