### PR TITLE
PAE-1330: Remove FEATURE_FLAG_OVERSEAS_SITES from admin-frontend

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -286,14 +286,6 @@ export const config = convict({
     default: 'http://localhost:3001',
     env: 'EPR_BACKEND_URL'
   },
-  featureFlags: {
-    overseasSites: {
-      doc: 'Enable overseas sites (ORS uploads) feature',
-      format: Boolean,
-      default: false,
-      env: 'FEATURE_FLAG_OVERSEAS_SITES'
-    }
-  },
   cdpUploaderUrl: {
     doc: 'CDP Uploader service URL (browser-visible, used in CSP form-action)',
     format: String,

--- a/src/config/nunjucks/context/build-navigation.js
+++ b/src/config/nunjucks/context/build-navigation.js
@@ -1,63 +1,23 @@
-export function buildNavigation(request) {
-  const navigation = [
-    {
-      text: 'Home',
-      href: '/',
-      current: request?.path === '/'
-    },
-    {
-      text: 'Organisations',
-      href: '/organisations',
-      current: request?.path === '/organisations'
-    },
-    {
-      text: 'Linked organisations',
-      href: '/linked-organisations',
-      current: request?.path === '/linked-organisations'
-    },
-    {
-      text: 'Public register',
-      href: '/public-register',
-      current: request?.path === '/public-register'
-    },
-    {
-      text: 'Tonnage monitoring',
-      href: '/tonnage-monitoring',
-      current: request?.path === '/tonnage-monitoring'
-    },
-    {
-      text: 'Waste balance availability',
-      href: '/waste-balance-availability',
-      current: request?.path === '/waste-balance-availability'
-    },
-    {
-      text: 'Summary log uploads',
-      href: '/summary-log',
-      current: request?.path === '/summary-log'
-    },
-    {
-      text: 'Overseas sites',
-      href: '/overseas-sites',
-      current:
-        request?.path === '/overseas-sites' ||
-        request?.path?.startsWith('/overseas-sites/')
-    },
-    {
-      text: 'PRN activity',
-      href: '/prn-activity',
-      current: request?.path === '/prn-activity'
-    },
-    {
-      text: 'PRN tonnage',
-      href: '/prn-tonnage',
-      current: request?.path === '/prn-tonnage'
-    },
-    {
-      text: 'System logs',
-      href: '/system-logs',
-      current: request?.path === '/system-logs'
-    }
-  ]
+const navItems = [
+  { text: 'Home', href: '/' },
+  { text: 'Organisations', href: '/organisations' },
+  { text: 'Linked organisations', href: '/linked-organisations' },
+  { text: 'Public register', href: '/public-register' },
+  { text: 'Tonnage monitoring', href: '/tonnage-monitoring' },
+  { text: 'Waste balance availability', href: '/waste-balance-availability' },
+  { text: 'Summary log uploads', href: '/summary-log' },
+  { text: 'Overseas sites', href: '/overseas-sites', matchSubPaths: true },
+  { text: 'PRN activity', href: '/prn-activity' },
+  { text: 'PRN tonnage', href: '/prn-tonnage' },
+  { text: 'System logs', href: '/system-logs' }
+]
 
-  return navigation
+export function buildNavigation(request) {
+  return navItems.map(({ text, href, matchSubPaths }) => ({
+    text,
+    href,
+    current:
+      request?.path === href ||
+      (matchSubPaths === true && request?.path?.startsWith(`${href}/`))
+  }))
 }

--- a/src/config/nunjucks/context/build-navigation.js
+++ b/src/config/nunjucks/context/build-navigation.js
@@ -1,18 +1,4 @@
-import { config } from '#config/config.js'
-
 export function buildNavigation(request) {
-  const orsNavigation = config.get('featureFlags.overseasSites')
-    ? [
-        {
-          text: 'Overseas sites',
-          href: '/overseas-sites',
-          current:
-            request?.path === '/overseas-sites' ||
-            request?.path?.startsWith('/overseas-sites/')
-        }
-      ]
-    : []
-
   const navigation = [
     {
       text: 'Home',
@@ -49,7 +35,13 @@ export function buildNavigation(request) {
       href: '/summary-log',
       current: request?.path === '/summary-log'
     },
-    ...orsNavigation,
+    {
+      text: 'Overseas sites',
+      href: '/overseas-sites',
+      current:
+        request?.path === '/overseas-sites' ||
+        request?.path?.startsWith('/overseas-sites/')
+    },
     {
       text: 'PRN activity',
       href: '/prn-activity',

--- a/src/config/nunjucks/context/build-navigation.test.js
+++ b/src/config/nunjucks/context/build-navigation.test.js
@@ -1,21 +1,10 @@
 import { buildNavigation } from './build-navigation.js'
-import { config } from '#config/config.js'
-
-vi.mock('#config/config.js', () => ({
-  config: {
-    get: vi.fn()
-  }
-}))
 
 function mockRequest(options) {
   return { ...options }
 }
 
 describe('#buildNavigation', () => {
-  beforeEach(() => {
-    config.get.mockReturnValue(false)
-  })
-
   test('Should provide expected navigation details', () => {
     expect(
       buildNavigation(mockRequest({ path: '/non-existent-path' }))
@@ -54,6 +43,11 @@ describe('#buildNavigation', () => {
         current: false,
         text: 'Summary log uploads',
         href: '/summary-log'
+      },
+      {
+        current: false,
+        text: 'Overseas sites',
+        href: '/overseas-sites'
       },
       {
         current: false,
@@ -112,6 +106,11 @@ describe('#buildNavigation', () => {
       },
       {
         current: false,
+        text: 'Overseas sites',
+        href: '/overseas-sites'
+      },
+      {
+        current: false,
         text: 'PRN activity',
         href: '/prn-activity'
       },
@@ -129,8 +128,6 @@ describe('#buildNavigation', () => {
   })
 
   test('Should highlight overseas sites for status pages', () => {
-    config.get.mockReturnValue(true)
-
     expect(
       buildNavigation(
         mockRequest({ path: '/overseas-sites/imports/import-123' })
@@ -146,9 +143,7 @@ describe('#buildNavigation', () => {
     )
   })
 
-  test('Should include overseas sites when feature flag enabled', () => {
-    config.get.mockReturnValue(true)
-
+  test('Should place overseas sites after summary log uploads', () => {
     const navigation = buildNavigation(
       mockRequest({ path: '/non-existent-path' })
     )
@@ -159,21 +154,10 @@ describe('#buildNavigation', () => {
       (item) => item.text === 'Overseas sites'
     )
 
-    expect(navigation).toEqual(
-      expect.arrayContaining([
-        {
-          current: false,
-          text: 'Overseas sites',
-          href: '/overseas-sites'
-        }
-      ])
-    )
     expect(overseasSitesIndex).toBe(summaryLogIndex + 1)
   })
 
   test('Should include overseas sites when request is undefined', () => {
-    config.get.mockReturnValue(true)
-
     const navigation = buildNavigation()
     const overseasSites = navigation.find(
       (item) => item.text === 'Overseas sites'

--- a/src/config/nunjucks/context/context.test.js
+++ b/src/config/nunjucks/context/context.test.js
@@ -1,9 +1,6 @@
 import { vi } from 'vitest'
 import { mockUserSession } from '#server/common/test-helpers/fixtures.js'
 
-const originalOverseasSitesFlag = process.env.FEATURE_FLAG_OVERSEAS_SITES
-process.env.FEATURE_FLAG_OVERSEAS_SITES = 'false'
-
 const mockGetUserSession = vi.fn().mockResolvedValue(mockUserSession)
 
 vi.mock('#server/common/helpers/auth/get-user-session.js', () => ({
@@ -27,14 +24,6 @@ vi.mock('#server/common/helpers/logging/logger.js', () => ({
 }))
 
 describe('context and cache', () => {
-  afterAll(() => {
-    if (originalOverseasSitesFlag === undefined) {
-      delete process.env.FEATURE_FLAG_OVERSEAS_SITES
-    } else {
-      process.env.FEATURE_FLAG_OVERSEAS_SITES = originalOverseasSitesFlag
-    }
-  })
-
   beforeEach(() => {
     mockReadFileSync.mockReset()
     mockLoggerError.mockReset()
@@ -106,6 +95,11 @@ describe('context and cache', () => {
             },
             {
               current: false,
+              text: 'Overseas sites',
+              href: '/overseas-sites'
+            },
+            {
+              current: false,
               text: 'PRN activity',
               href: '/prn-activity'
             },
@@ -133,29 +127,6 @@ describe('context and cache', () => {
             '/public/javascripts/application.js'
           )
         })
-      })
-
-      test('Should include overseas sites when feature flag is enabled', async () => {
-        process.env.FEATURE_FLAG_OVERSEAS_SITES = 'true'
-        vi.resetModules()
-
-        const contextImportWithFlag = await import('./context.js')
-        const contextWithFlag = await contextImportWithFlag.context({
-          path: '/overseas-sites/imports'
-        })
-
-        expect(contextWithFlag.navigation).toEqual(
-          expect.arrayContaining([
-            {
-              current: true,
-              text: 'Overseas sites',
-              href: '/overseas-sites'
-            }
-          ])
-        )
-
-        process.env.FEATURE_FLAG_OVERSEAS_SITES = 'false'
-        vi.resetModules()
       })
 
       describe('With invalid asset path', () => {
@@ -302,6 +273,11 @@ describe('context and cache', () => {
               current: false,
               text: 'Summary log uploads',
               href: '/summary-log'
+            },
+            {
+              current: false,
+              text: 'Overseas sites',
+              href: '/overseas-sites'
             },
             {
               current: false,

--- a/src/server/common/helpers/content-security-policy.js
+++ b/src/server/common/helpers/content-security-policy.js
@@ -1,15 +1,7 @@
 import Blankie from 'blankie'
 import { config } from '#config/config.js'
 
-export function cspFormAction({
-  isProduction,
-  cdpUploaderUrl,
-  isOverseasSitesFeatureEnabled
-}) {
-  if (!isOverseasSitesFeatureEnabled) {
-    return ['self']
-  }
-
+export function cspFormAction({ isProduction, cdpUploaderUrl }) {
   if (isProduction) {
     return ['self']
   }
@@ -44,8 +36,7 @@ const contentSecurityPolicy = {
     frameAncestors: ['none'],
     formAction: cspFormAction({
       isProduction: config.get('isProduction'),
-      cdpUploaderUrl: config.get('cdpUploaderUrl'),
-      isOverseasSitesFeatureEnabled: config.get('featureFlags.overseasSites')
+      cdpUploaderUrl: config.get('cdpUploaderUrl')
     }),
     manifestSrc: ['self'],
     generateNonces: false

--- a/src/server/common/helpers/content-security-policy.test.js
+++ b/src/server/common/helpers/content-security-policy.test.js
@@ -9,8 +9,7 @@ describe(cspFormAction, () => {
       'non-production',
       {
         isProduction: false,
-        cdpUploaderUrl: 'http://localhost:7337',
-        isOverseasSitesFeatureEnabled: true
+        cdpUploaderUrl: 'http://localhost:7337'
       },
       ['self', 'localhost:*', 'http://localhost:7337']
     ],
@@ -18,8 +17,7 @@ describe(cspFormAction, () => {
       'non-production with custom port',
       {
         isProduction: false,
-        cdpUploaderUrl: 'http://localhost:9000',
-        isOverseasSitesFeatureEnabled: true
+        cdpUploaderUrl: 'http://localhost:9000'
       },
       ['self', 'localhost:*', 'http://localhost:9000']
     ],
@@ -27,17 +25,7 @@ describe(cspFormAction, () => {
       'production',
       {
         isProduction: true,
-        cdpUploaderUrl: 'https://cdp-uploader.prod.example.gov.uk',
-        isOverseasSitesFeatureEnabled: true
-      },
-      ['self']
-    ],
-    [
-      'feature disabled',
-      {
-        isProduction: false,
-        cdpUploaderUrl: 'http://localhost:7337',
-        isOverseasSitesFeatureEnabled: false
+        cdpUploaderUrl: 'https://cdp-uploader.prod.example.gov.uk'
       },
       ['self']
     ]
@@ -67,8 +55,7 @@ describe('#contentSecurityPolicy', () => {
 
     const expectedFormAction = cspFormAction({
       isProduction: config.get('isProduction'),
-      cdpUploaderUrl: config.get('cdpUploaderUrl'),
-      isOverseasSitesFeatureEnabled: config.get('featureFlags.overseasSites')
+      cdpUploaderUrl: config.get('cdpUploaderUrl')
     })
 
     const csp = resp.headers['content-security-policy']

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -15,7 +15,6 @@ import { linkedOrganisations } from './routes/linked-organisations/index.js'
 import { prnActivity } from './routes/prn-activity/index.js'
 import { summaryLogUploadsReport } from './routes/summary-log/index.js'
 import { orsUpload } from './routes/ors-upload/index.js'
-import { config } from '#config/config.js'
 
 import { serveStaticFiles } from './common/helpers/serve-static-files.js'
 
@@ -42,12 +41,9 @@ export const router = {
         wasteBalanceAvailability,
         linkedOrganisations,
         prnActivity,
-        summaryLogUploadsReport
+        summaryLogUploadsReport,
+        orsUpload
       ])
-
-      if (config.get('featureFlags.overseasSites')) {
-        await server.register([orsUpload])
-      }
 
       await server.register([serveStaticFiles])
     }

--- a/src/server/router.test.js
+++ b/src/server/router.test.js
@@ -1,16 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { router } from './router.js'
 
-const { mockConfigGet } = vi.hoisted(() => ({
-  mockConfigGet: vi.fn((key) => {
-    if (key === 'featureFlags.overseasSites') {
-      return false
-    }
-
-    return undefined
-  })
-}))
-
 const { mockInert } = vi.hoisted(() => ({
   mockInert: { plugin: { name: 'inert' } }
 }))
@@ -29,12 +19,6 @@ const { mockOrsUpload } = vi.hoisted(() => ({
 
 vi.mock('@hapi/inert', () => ({
   default: mockInert
-}))
-
-vi.mock('#config/config.js', () => ({
-  config: {
-    get: mockConfigGet
-  }
 }))
 
 vi.mock('./routes/home/index.js', () => ({
@@ -98,35 +82,12 @@ describe('router plugin', () => {
     }
   })
 
-  test('does not register ORS upload routes when feature flag is disabled', async () => {
-    mockConfigGet.mockImplementation((key) => {
-      if (key === 'featureFlags.overseasSites') {
-        return false
-      }
-
-      return undefined
-    })
-
+  test('registers all route plugins including ORS upload', async () => {
     await router.plugin.register(server)
 
     expect(server.register).toHaveBeenCalledTimes(4)
-    expect(mockConfigGet).toHaveBeenCalledWith('featureFlags.overseasSites')
-    expect(server.register).not.toHaveBeenCalledWith([mockOrsUpload])
-  })
-
-  test('registers ORS upload routes when feature flag is enabled', async () => {
-    mockConfigGet.mockImplementation((key) => {
-      if (key === 'featureFlags.overseasSites') {
-        return true
-      }
-
-      return undefined
-    })
-
-    await router.plugin.register(server)
-
-    expect(server.register).toHaveBeenCalledTimes(5)
-    expect(mockConfigGet).toHaveBeenCalledWith('featureFlags.overseasSites')
-    expect(server.register).toHaveBeenCalledWith([mockOrsUpload])
+    expect(server.register).toHaveBeenCalledWith(
+      expect.arrayContaining([mockOrsUpload])
+    )
   })
 })

--- a/src/server/routes/ors-upload/download.integration.test.js
+++ b/src/server/routes/ors-upload/download.integration.test.js
@@ -17,19 +17,9 @@ vi.mock('#server/common/helpers/auth/get-user-session.js', () => ({
 describe('ors-upload download integration', () => {
   const backendUrl = config.get('eprBackendUrl')
   const pagePath = '/overseas-sites'
-  const originalConfigGet = config.get.bind(config)
-  let configGetSpy
   let server
 
   beforeAll(async () => {
-    configGetSpy = vi.spyOn(config, 'get').mockImplementation((key) => {
-      if (key === 'featureFlags.overseasSites') {
-        return true
-      }
-
-      return originalConfigGet(key)
-    })
-
     createMockOidcServer()
     server = await createServer()
     await server.initialize()
@@ -37,7 +27,6 @@ describe('ors-upload download integration', () => {
 
   afterAll(async () => {
     await server.stop({ timeout: 0 })
-    configGetSpy.mockRestore()
   })
 
   afterEach(() => {

--- a/src/server/routes/ors-upload/index.js
+++ b/src/server/routes/ors-upload/index.js
@@ -3,17 +3,12 @@ import { orsDownloadController } from './controller.download.js'
 import { orsListGetController } from './controller.list.get.js'
 import { orsUploadStatusGetController } from './controller.status.get.js'
 import { orsUploadRoutes } from './constants.js'
-import { config } from '#config/config.js'
 import Joi from 'joi'
 
 export const orsUpload = {
   plugin: {
     name: 'ors-upload',
     register(server) {
-      if (!config.get('featureFlags.overseasSites')) {
-        return
-      }
-
       server.route([
         {
           method: 'GET',

--- a/src/server/routes/ors-upload/index.test.js
+++ b/src/server/routes/ors-upload/index.test.js
@@ -1,5 +1,4 @@
-import { vi, beforeEach, afterEach, describe, test, expect } from 'vitest'
-import { config } from '#config/config.js'
+import { vi, beforeEach, describe, test, expect } from 'vitest'
 import { orsUpload } from './index.js'
 import { orsUploadRoutes } from './constants.js'
 
@@ -7,24 +6,9 @@ describe('#ors-upload routes plugin', () => {
   const mockServer = {
     route: vi.fn()
   }
-  const originalConfigGet = config.get.bind(config)
-  let configGetSpy
 
   beforeEach(() => {
     vi.clearAllMocks()
-
-    configGetSpy = vi.spyOn(config, 'get').mockImplementation((key) => {
-      if (key === 'featureFlags.overseasSites') {
-        return true
-      }
-
-      return originalConfigGet(key)
-    })
-  })
-
-  afterEach(() => {
-    configGetSpy.mockRestore()
-    vi.resetAllMocks()
   })
 
   test('Should have correct plugin name', () => {
@@ -34,24 +18,8 @@ describe('#ors-upload routes plugin', () => {
   test('Should register routes', () => {
     orsUpload.plugin.register(mockServer)
 
-    expect(configGetSpy).toHaveBeenCalledWith('featureFlags.overseasSites')
     expect(mockServer.route).toHaveBeenCalledTimes(1)
     expect(mockServer.route).toHaveBeenCalledWith(expect.any(Array))
-  })
-
-  test('Should not register routes when overseas-sites feature flag is disabled', () => {
-    configGetSpy.mockImplementation((key) => {
-      if (key === 'featureFlags.overseasSites') {
-        return false
-      }
-
-      return originalConfigGet(key)
-    })
-
-    orsUpload.plugin.register(mockServer)
-
-    expect(configGetSpy).toHaveBeenCalledWith('featureFlags.overseasSites')
-    expect(mockServer.route).not.toHaveBeenCalled()
   })
 
   test('Should register upload and status routes', () => {


### PR DESCRIPTION
Ticket: [PAE-1330](https://eaflood.atlassian.net/browse/PAE-1330)
## Summary

Remove the `FEATURE_FLAG_OVERSEAS_SITES` feature flag from epr-re-ex-admin-frontend, making overseas sites (ORS uploads) unconditionally available.

- Remove the `featureFlags.overseasSites` convict config entry
- Register the ORS upload plugin unconditionally in the router
- Remove the feature flag guard from the ORS upload route plugin
- Make the "Overseas sites" navigation item always visible
- Simplify the CSP `formAction` helper — it no longer needs a flag parameter to decide whether to allow the uploader origin
- Update all affected tests to remove flag mocking and reflect the unconditional behaviour

[PAE-1330]: https://eaflood.atlassian.net/browse/PAE-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ