### PR TITLE
PAE-1360: Accept floci:4566 in SSRF URL allowlist

### DIFF
--- a/src/server/routes/public-register/controller.post.js
+++ b/src/server/routes/public-register/controller.post.js
@@ -5,7 +5,7 @@ const ALLOWED_URL_PATTERNS = [
   /^https:\/\/s3\.[a-z0-9-]+\.amazonaws\.com\//,
   /^https:\/\/[a-z0-9-]+\.s3\.amazonaws\.com\//,
   /^http:\/\/localhost:4566\//,
-  /^http:\/\/localstack:4566\//
+  /^http:\/\/(localstack|floci):4566\//
 ]
 
 function isAllowedDownloadUrl(url) {

--- a/src/server/routes/public-register/controller.post.test.js
+++ b/src/server/routes/public-register/controller.post.test.js
@@ -108,6 +108,24 @@ describe('public-register POST controller', () => {
     expect(mockH.response).toHaveBeenCalledWith(mockCsvContent)
   })
 
+  test('Should accept Floci URLs with Docker hostname', async () => {
+    const mockDownloadUrl =
+      'http://floci:4566/bucket/public-register.csv?signed=abc'
+    const mockCsvContent = 'csv,content'
+
+    fetchJsonFromBackend.mockResolvedValue({ downloadUrl: mockDownloadUrl })
+    mswServer.use(
+      http.get(
+        'http://floci:4566/bucket/public-register.csv',
+        () => new HttpResponse(mockCsvContent)
+      )
+    )
+
+    await publicRegisterPostController.handler(mockRequest, mockH)
+
+    expect(mockH.response).toHaveBeenCalledWith(mockCsvContent)
+  })
+
   test('Should reject invalid download URLs to prevent SSRF', async () => {
     const maliciousUrl = 'https://evil-site.com/steal-data'
 

--- a/src/server/routes/system-logs/controller.download.js
+++ b/src/server/routes/system-logs/controller.download.js
@@ -5,7 +5,7 @@ const ALLOWED_URL_PATTERNS = [
   /^https:\/\/s3\.[a-z0-9-]+\.amazonaws\.com\//,
   /^https:\/\/[a-z0-9-]+\.s3\.amazonaws\.com\//,
   /^http:\/\/localhost:4566\//,
-  /^http:\/\/localstack:4566\//
+  /^http:\/\/(localstack|floci):4566\//
 ]
 
 function isAllowedDownloadUrl(url) {

--- a/src/server/routes/system-logs/controller.download.test.js
+++ b/src/server/routes/system-logs/controller.download.test.js
@@ -91,6 +91,20 @@ describe('system-log download controller', () => {
     expect([...responseArg]).toEqual([...binaryContent])
   })
 
+  test('accepts Floci URLs', async () => {
+    const presignedUrl = 'http://floci:4566/bucket/file.xlsx'
+    const binaryContent = new Uint8Array([0x50, 0x4b, 0x03, 0x04])
+
+    fetchRedirectFromBackend.mockResolvedValue(presignedUrl)
+    mswServer.use(http.get(presignedUrl, () => new HttpResponse(binaryContent)))
+
+    await systemLogDownloadController.handler(mockRequest, mockH)
+
+    const responseArg = mockH.response.mock.calls[0][0]
+    expect(Buffer.isBuffer(responseArg)).toBe(true)
+    expect([...responseArg]).toEqual([...binaryContent])
+  })
+
   test('rejects invalid download URLs to prevent SSRF', async () => {
     fetchRedirectFromBackend.mockResolvedValue(
       'https://evil-site.com/steal-data'


### PR DESCRIPTION
Ticket: [PAE-1360](https://eaflood.atlassian.net/browse/PAE-1360)
## Summary

Widens the SSRF URL allowlist in the admin frontend to accept both `http://localstack:4566/` and `http://floci:4566/` pre-signed URLs during the Floci migration window.

The allowlists are in the two controllers that validate S3 pre-signed download URLs returned from the backend before fetching:

- `src/server/routes/system-logs/controller.download.js`
- `src/server/routes/public-register/controller.post.js`

Each `localstack:4566` pattern becomes `(localstack|floci):4566` so the admin frontend works against any compose stack, whether the emulator service is still called `localstack` or has been renamed to `floci`. Tests for the new hostname are added alongside the existing LocalStack tests.

## Why

Part of the [PAE-1357](https://eaflood.atlassian.net/browse/PAE-1357) LocalStack → Floci migration. Different compose stacks (`epr-re-ex-service`, `epr-frontend-journey-tests`, `epr-re-ex-admin-frontend-tests`, etc.) will migrate at different times; the admin frontend needs to accept both hostnames until all stacks are on Floci. Once the epic completes, the regex folds back to `floci:4566` only as part of the planned cleanup.

[PAE-1360]: https://eaflood.atlassian.net/browse/PAE-1360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PAE-1357]: https://eaflood.atlassian.net/browse/PAE-1357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ