### PR TITLE
PAE-1366: add eqeqeq rule and is-nil helper

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,11 +1,18 @@
 import neostandard from 'neostandard'
 
-export default neostandard({
-  env: ['node', 'vitest'],
-  ignores: [
-    ...neostandard.resolveIgnoresFromGitignore(),
-    'src/server/common/schemas'
-  ],
-  noJsx: true,
-  noStyle: true
-})
+export default [
+  ...neostandard({
+    env: ['node', 'vitest'],
+    ignores: [
+      ...neostandard.resolveIgnoresFromGitignore(),
+      'src/server/common/schemas'
+    ],
+    noJsx: true,
+    noStyle: true
+  }),
+  {
+    rules: {
+      eqeqeq: ['error', 'always']
+    }
+  }
+]

--- a/src/client/javascripts/jsoneditor.inflate.js
+++ b/src/client/javascripts/jsoneditor.inflate.js
@@ -119,7 +119,7 @@ function inflateRecursive(data, schema) {
  * @returns {*} Data with null objects inflated, or the original data if inputs are invalid
  */
 export function inflateNullObjects(data, schema) {
-  if (data == null || !schema) {
+  if (data === null || data === undefined || !schema) {
     return data
   }
   return inflateRecursive(data, schema)

--- a/src/server/common/helpers/is-nil.js
+++ b/src/server/common/helpers/is-nil.js
@@ -1,3 +1,7 @@
+/**
+ * @param {unknown} value
+ * @returns {value is null | undefined}
+ */
 const isNil = (value) => value === null || value === undefined
 
 export { isNil }

--- a/src/server/common/helpers/is-nil.js
+++ b/src/server/common/helpers/is-nil.js
@@ -1,0 +1,3 @@
+const isNil = (value) => value === null || value === undefined
+
+export { isNil }

--- a/src/server/common/helpers/is-nil.test.js
+++ b/src/server/common/helpers/is-nil.test.js
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { isNil } from './is-nil.js'
+
+describe('is-nil', () => {
+  it.each([
+    { value: null, label: 'null' },
+    { value: undefined, label: 'undefined' }
+  ])('should return true for $label', ({ value }) => {
+    expect(isNil(value)).toBe(true)
+  })
+
+  it.each([
+    { value: 0, label: '0' },
+    { value: '', label: 'empty string' },
+    { value: false, label: 'false' },
+    { value: NaN, label: 'NaN' },
+    { value: {}, label: 'empty object' },
+    { value: [], label: 'empty array' }
+  ])('should return false for $label', ({ value }) => {
+    expect(isNil(value)).toBe(false)
+  })
+})

--- a/src/server/routes/ors-upload/controller.download.js
+++ b/src/server/routes/ors-upload/controller.download.js
@@ -1,6 +1,7 @@
 import { writeToString } from '@fast-csv/format'
 import { formatDate } from '#config/nunjucks/filters/format-date.js'
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
+import { isNil } from '#server/common/helpers/is-nil.js'
 import { sanitizeFormulaInjection } from '#server/common/helpers/sanitize-formula-injection.js'
 import { buildBackendPath } from './helpers.js'
 
@@ -8,7 +9,7 @@ const dateFormat = 'd MMMM yyyy'
 const utf8Bom = '\uFEFF'
 
 function toCsvValue(value) {
-  if (value === null || value === undefined || value === '') {
+  if (isNil(value) || value === '') {
     return ''
   }
 
@@ -16,7 +17,7 @@ function toCsvValue(value) {
 }
 
 function toValidFromCsvValue(value) {
-  if (value === null || value === undefined || value === '') {
+  if (isNil(value) || value === '') {
     return ''
   }
 

--- a/src/server/routes/ors-upload/controller.list.get.js
+++ b/src/server/routes/ors-upload/controller.list.get.js
@@ -1,6 +1,7 @@
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
 import { formatDate } from '#config/nunjucks/filters/format-date.js'
 import { createLogger } from '#server/common/helpers/logging/logger.js'
+import { isNil } from '#server/common/helpers/is-nil.js'
 import {
   buildBackendPath,
   buildPageHref,
@@ -11,11 +12,11 @@ import {
 const logger = createLogger()
 
 function toDisplayValue(value) {
-  return value === null || value === undefined || value === '' ? '-' : value
+  return isNil(value) || value === '' ? '-' : value
 }
 
 function toValidFromDisplayValue(value) {
-  if (value === null || value === undefined || value === '') {
+  if (isNil(value) || value === '') {
     return '-'
   }
 

--- a/src/server/routes/system-logs/controller.get.js
+++ b/src/server/routes/system-logs/controller.get.js
@@ -1,4 +1,5 @@
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
+import { isNil } from '#server/common/helpers/is-nil.js'
 import isEqual from 'lodash/isEqual.js'
 import isArray from 'lodash/isArray.js'
 import isObject from 'lodash/isObject.js'
@@ -159,5 +160,5 @@ function renderChange(a, b) {
 }
 
 function isSimple(x) {
-  return x === undefined || x === null || (!isObject(x) && !isArray(x))
+  return isNil(x) || (!isObject(x) && !isArray(x))
 }

--- a/src/server/routes/tonnage-monitoring/formatters.js
+++ b/src/server/routes/tonnage-monitoring/formatters.js
@@ -1,3 +1,5 @@
+import { isNil } from '#server/common/helpers/is-nil.js'
+
 const materialDisplayNames = {
   aluminium: 'Aluminium',
   fibre: 'Fibre based composite',
@@ -21,7 +23,7 @@ export function formatMaterialName(material) {
 }
 
 export function formatTonnage(tonnage) {
-  if (tonnage === undefined || tonnage === null) {
+  if (isNil(tonnage)) {
     return ''
   }
   return tonnage.toFixed(2)
@@ -30,7 +32,7 @@ export function formatTonnage(tonnage) {
 export function materialRowHeading(row) {
   if (row.material) {
     return formatMaterialName(row.material)
-  } else if (row.type === null || row.type === undefined) {
+  } else if (isNil(row.type)) {
     return 'Total'
   } else {
     return ''


### PR DESCRIPTION
Ticket: [PAE-1366](https://eaflood.atlassian.net/browse/PAE-1366)
add strict eqeqeq eslint rule and isNil type guard helper to replace loose equality checks against null/undefined

- override neostandard's `eqeqeq: { null: 'ignore' }` to strict `['error', 'always']`
- add `isNil` helper with JSDoc type predicate for type narrowing
- inline strict equality in client-side `jsoneditor.inflate.js` (no module imports in client code)

[PAE-1366]: https://eaflood.atlassian.net/browse/PAE-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ