### PR TITLE
PAE-1360: Tighten admin-frontend hostname regex to floci-only

### DIFF
--- a/src/server/routes/public-register/controller.post.js
+++ b/src/server/routes/public-register/controller.post.js
@@ -5,7 +5,7 @@ const ALLOWED_URL_PATTERNS = [
   /^https:\/\/s3\.[a-z0-9-]+\.amazonaws\.com\//,
   /^https:\/\/[a-z0-9-]+\.s3\.amazonaws\.com\//,
   /^http:\/\/localhost:4566\//,
-  /^http:\/\/(localstack|floci):4566\//
+  /^http:\/\/floci:4566\//
 ]
 
 function isAllowedDownloadUrl(url) {

--- a/src/server/routes/public-register/controller.post.test.js
+++ b/src/server/routes/public-register/controller.post.test.js
@@ -76,31 +76,13 @@ describe('public-register POST controller', () => {
     )
   })
 
-  test('Should accept LocalStack URLs with localhost', async () => {
+  test('Should accept localhost URLs', async () => {
     const mockDownloadUrl = 'http://localhost:4566/bucket/public-register.csv'
     const mockCsvContent = 'csv,content'
 
     fetchJsonFromBackend.mockResolvedValue({ downloadUrl: mockDownloadUrl })
     mswServer.use(
       http.get(mockDownloadUrl, () => new HttpResponse(mockCsvContent))
-    )
-
-    await publicRegisterPostController.handler(mockRequest, mockH)
-
-    expect(mockH.response).toHaveBeenCalledWith(mockCsvContent)
-  })
-
-  test('Should accept LocalStack URLs with Docker hostname', async () => {
-    const mockDownloadUrl =
-      'http://localstack:4566/bucket/public-register.csv?signed=abc'
-    const mockCsvContent = 'csv,content'
-
-    fetchJsonFromBackend.mockResolvedValue({ downloadUrl: mockDownloadUrl })
-    mswServer.use(
-      http.get(
-        'http://localstack:4566/bucket/public-register.csv',
-        () => new HttpResponse(mockCsvContent)
-      )
     )
 
     await publicRegisterPostController.handler(mockRequest, mockH)

--- a/src/server/routes/system-logs/controller.download.js
+++ b/src/server/routes/system-logs/controller.download.js
@@ -5,7 +5,7 @@ const ALLOWED_URL_PATTERNS = [
   /^https:\/\/s3\.[a-z0-9-]+\.amazonaws\.com\//,
   /^https:\/\/[a-z0-9-]+\.s3\.amazonaws\.com\//,
   /^http:\/\/localhost:4566\//,
-  /^http:\/\/(localstack|floci):4566\//
+  /^http:\/\/floci:4566\//
 ]
 
 function isAllowedDownloadUrl(url) {

--- a/src/server/routes/system-logs/controller.download.test.js
+++ b/src/server/routes/system-logs/controller.download.test.js
@@ -77,7 +77,7 @@ describe('system-log download controller', () => {
     )
   })
 
-  test('accepts LocalStack URLs', async () => {
+  test('accepts localhost URLs', async () => {
     const presignedUrl = 'http://localhost:4566/bucket/file.xlsx'
     const binaryContent = new Uint8Array([0x50, 0x4b, 0x03, 0x04])
 


### PR DESCRIPTION
## Summary

Removes the `localstack` fallback from the SSRF allow-list regex in the admin-frontend download controllers, leaving `floci:4566` as the only Docker-network hostname accepted alongside the existing `localhost:4566` and AWS S3 patterns.

## Why

[PR #349](https://github.com/DEFRA/epr-re-ex-admin-frontend/pull/349) widened the regex to `(localstack|floci):4566` as a transition window during the [PAE-1360](https://eaflood.atlassian.net/browse/PAE-1360) LocalStack → Floci migration. Every compose stack and testcontainers fixture now uses Floci ([epr-backend PR #1094](https://github.com/DEFRA/epr-backend/pull/1094) was the final piece), so no live deployment can produce a `localstack` host any more and the alternation is dead code.

## Changes

- `src/server/routes/system-logs/controller.download.js` — narrow regex to `^http://floci:4566/`
- `src/server/routes/public-register/controller.post.js` — narrow regex to `^http://floci:4566/`
- `src/server/routes/public-register/controller.post.test.js` — drop the redundant LocalStack Docker-hostname test case; rename the localhost test to remove the LocalStack reference
- `src/server/routes/system-logs/controller.download.test.js` — rename the localhost test to remove the LocalStack reference

The `localhost:4566` and AWS S3 patterns are unchanged.

[PAE-1360]: https://eaflood.atlassian.net/browse/PAE-1360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ