### PR TITLE
PAE-1374: Add summary logs section to registration overview page

### DIFF
--- a/src/server/routes/registration-overview/controller.get.js
+++ b/src/server/routes/registration-overview/controller.get.js
@@ -2,15 +2,51 @@ import Boom from '@hapi/boom'
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
 import { fetchOrganisationOverview } from '#server/common/helpers/fetch-organisation-overview.js'
 
+const STATUS_DISPLAY = {
+  submitted: { label: 'Success', className: 'govuk-tag--green' },
+  rejected: { label: 'Failed (Rejected)', className: 'govuk-tag--red' },
+  invalid: { label: 'Failed (Invalid)', className: 'govuk-tag--red' },
+  validation_failed: {
+    label: 'Failed (Validation)',
+    className: 'govuk-tag--red'
+  },
+  submission_failed: {
+    label: 'Failed (Submission)',
+    className: 'govuk-tag--red'
+  }
+}
+
+const toSummaryLogTableRow =
+  (organisationId, registrationId) => (summaryLog) => {
+    const { summaryLogId, uploadedAt, status } = summaryLog
+
+    const { label, className } = STATUS_DISPLAY[status]
+
+    const downloadUrl = `/system-logs/download/${organisationId}/${registrationId}/${summaryLogId}`
+
+    return [
+      { text: uploadedAt },
+      { html: `<strong class="govuk-tag ${className}">${label}</strong>` },
+      {
+        html: `<a class="govuk-link govuk-link--no-visited-state" href="${downloadUrl}">Download</a>`
+      }
+    ]
+  }
+
 export const registrationOverviewGETController = {
   async handler(request, h) {
     const { organisationId, registrationId } = request.params
 
-    const [overview, calendar] = await Promise.all([
+    const [overview, calendar, { summaryLogs }] = await Promise.all([
       fetchOrganisationOverview(request, organisationId),
       fetchJsonFromBackend(
         request,
         `/v1/organisations/${organisationId}/registrations/${registrationId}/reports/calendar`,
+        {}
+      ),
+      fetchJsonFromBackend(
+        request,
+        `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs`,
         {}
       )
     ])
@@ -27,6 +63,10 @@ export const registrationOverviewGETController = {
 
     const heading = `${overview.companyName} - ${registration.registrationNumber ?? registration.id}`
 
+    const summaryLogRows = summaryLogs.map(
+      toSummaryLogTableRow(organisationId, registrationId)
+    )
+
     return h.view('routes/registration-overview/index', {
       breadcrumbs: [
         { text: 'Organisations', href: '/organisations' },
@@ -41,7 +81,8 @@ export const registrationOverviewGETController = {
       registrationId,
       registration,
       cadence: calendar.cadence,
-      reportingPeriods: calendar.reportingPeriods
+      reportingPeriods: calendar.reportingPeriods,
+      summaryLogRows
     })
   }
 }

--- a/src/server/routes/registration-overview/controller.get.js
+++ b/src/server/routes/registration-overview/controller.get.js
@@ -2,18 +2,15 @@ import Boom from '@hapi/boom'
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
 import { fetchOrganisationOverview } from '#server/common/helpers/fetch-organisation-overview.js'
 
+const GREEN_TAG = 'govuk-tag--green'
+const RED_TAG = 'govuk-tag--red'
+
 const STATUS_DISPLAY = {
-  submitted: { label: 'Success', className: 'govuk-tag--green' },
-  rejected: { label: 'Failed (Rejected)', className: 'govuk-tag--red' },
-  invalid: { label: 'Failed (Invalid)', className: 'govuk-tag--red' },
-  validation_failed: {
-    label: 'Failed (Validation)',
-    className: 'govuk-tag--red'
-  },
-  submission_failed: {
-    label: 'Failed (Submission)',
-    className: 'govuk-tag--red'
-  }
+  submitted: { label: 'Success', className: GREEN_TAG },
+  rejected: { label: 'Failed (Rejected)', className: RED_TAG },
+  invalid: { label: 'Failed (Invalid)', className: RED_TAG },
+  validation_failed: { label: 'Failed (Validation)', className: RED_TAG },
+  submission_failed: { label: 'Failed (Submission)', className: RED_TAG }
 }
 
 const toSummaryLogTableRow =

--- a/src/server/routes/registration-overview/get.integration.test.js
+++ b/src/server/routes/registration-overview/get.integration.test.js
@@ -82,9 +82,29 @@ describe('#registrationOverviewController', () => {
     ]
   }
 
+  const mockSubmittedSummaryLog = {
+    summaryLogId: 'sl-submitted',
+    filename: 'jan.xlsx',
+    uploadedAt: '2026-01-01T11:00:00.000Z',
+    status: 'submitted'
+  }
+
+  const mockValidationFailedSummaryLog = {
+    summaryLogId: 'sl-validation-failed',
+    filename: 'feb.xlsx',
+    uploadedAt: '2026-01-04T11:00:00.000Z',
+    status: 'validation_failed'
+  }
+
+  const findSummaryLogsTable = ($) =>
+    $('table').filter(
+      (_, t) => $(t).find('caption').text().trim() === 'Summary logs'
+    )
+
   const useMockBackend = (
     overviewResponse = mockOverview,
-    calendarResponse = mockCalendar
+    calendarResponse = mockCalendar,
+    summaryLogsResponse = { summaryLogs: [] }
   ) => {
     mswServer.use(
       http.get(
@@ -94,6 +114,10 @@ describe('#registrationOverviewController', () => {
       http.get(
         `${backendUrl}/v1/organisations/${organisationId}/registrations/${registrationId}/reports/calendar`,
         () => HttpResponse.json(calendarResponse)
+      ),
+      http.get(
+        `${backendUrl}/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs`,
+        () => HttpResponse.json(summaryLogsResponse)
       )
     )
   }
@@ -276,6 +300,155 @@ describe('#registrationOverviewController', () => {
         $(secondRowCells[3]).find('strong.govuk-tag').text().trim()
       ).toEqual('Due')
       expect($(secondRowCells[4]).find('a')).toHaveLength(0)
+    })
+
+    test('Should render the Summary logs table with column headers when summary logs exist', async () => {
+      useMockBackend(mockOverview, mockCalendar, {
+        summaryLogs: [mockSubmittedSummaryLog]
+      })
+
+      const { result } = await server.inject({
+        method: 'GET',
+        url,
+        auth: { strategy: 'session', credentials: mockUserSession }
+      })
+
+      const $ = cheerio.load(result)
+      const slTable = findSummaryLogsTable($)
+      expect(slTable).toHaveLength(1)
+
+      const headers = slTable.find('thead tr th')
+      expect($(headers[0]).text().trim()).toEqual('Uploaded at')
+      expect($(headers[1]).text().trim()).toEqual('Status')
+      expect($(headers[2]).text().trim()).toEqual('Actions')
+    })
+
+    test('Should render a green Success tag and Download link for a submitted log', async () => {
+      useMockBackend(mockOverview, mockCalendar, {
+        summaryLogs: [mockSubmittedSummaryLog]
+      })
+
+      const { result } = await server.inject({
+        method: 'GET',
+        url,
+        auth: { strategy: 'session', credentials: mockUserSession }
+      })
+
+      const $ = cheerio.load(result)
+      const slTable = findSummaryLogsTable($)
+      const cells = slTable.find('tbody tr').first().find('td')
+
+      expect($(cells[0]).text().trim()).toEqual('2026-01-01T11:00:00.000Z')
+
+      const tag = $(cells[1]).find('strong.govuk-tag')
+      expect(tag.text().trim()).toEqual('Success')
+      expect(tag.hasClass('govuk-tag--green')).toBe(true)
+
+      const downloadLink = $(cells[2]).find('a')
+      expect(downloadLink.text().trim()).toEqual('Download')
+      expect(downloadLink.attr('href')).toEqual(
+        `/system-logs/download/${organisationId}/${registrationId}/${mockSubmittedSummaryLog.summaryLogId}`
+      )
+    })
+
+    test.each([
+      ['rejected', 'Failed (Rejected)'],
+      ['invalid', 'Failed (Invalid)'],
+      ['validation_failed', 'Failed (Validation)'],
+      ['submission_failed', 'Failed (Submission)']
+    ])(
+      'Should render a red "%s" tag labelled "%s"',
+      async (status, expectedLabel) => {
+        useMockBackend(mockOverview, mockCalendar, {
+          summaryLogs: [{ ...mockValidationFailedSummaryLog, status }]
+        })
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        const $ = cheerio.load(result)
+        const slTable = $('table').filter(
+          (_, t) => $(t).find('caption').text().trim() === 'Summary logs'
+        )
+        const tag = slTable.find('tbody tr').first().find('strong.govuk-tag')
+
+        expect(tag.text().trim()).toEqual(expectedLabel)
+        expect(tag.hasClass('govuk-tag--red')).toBe(true)
+      }
+    )
+
+    test('Should render multiple summary-log rows newest-first', async () => {
+      useMockBackend(mockOverview, mockCalendar, {
+        summaryLogs: [
+          mockSubmittedSummaryLog,
+          mockValidationFailedSummaryLog
+        ]
+      })
+
+      const { result } = await server.inject({
+        method: 'GET',
+        url,
+        auth: { strategy: 'session', credentials: mockUserSession }
+      })
+
+      const $ = cheerio.load(result)
+      const slTable = findSummaryLogsTable($)
+      const rows = slTable.find('tbody tr')
+      expect(rows).toHaveLength(2)
+
+      expect($(rows[0]).find('td').first().text().trim()).toEqual(
+        '2026-01-01T11:00:00.000Z'
+      )
+      expect($(rows[1]).find('td').first().text().trim()).toEqual(
+        '2026-01-04T11:00:00.000Z'
+      )
+    })
+
+    test('Should render "No summary logs" when the summary-logs list is empty', async () => {
+      useMockBackend()
+
+      const { result } = await server.inject({
+        method: 'GET',
+        url,
+        auth: { strategy: 'session', credentials: mockUserSession }
+      })
+
+      const $ = cheerio.load(result)
+      const slTable = findSummaryLogsTable($)
+      expect(slTable).toHaveLength(0)
+      expect(result).toContain('No summary logs')
+    })
+
+    test('Should show 500 error page when the summary-logs backend returns a non-OK response', async () => {
+      mswServer.use(
+        http.get(
+          `${backendUrl}/v1/organisations/${organisationId}/overview`,
+          () => HttpResponse.json(mockOverview)
+        ),
+        http.get(
+          `${backendUrl}/v1/organisations/${organisationId}/registrations/${registrationId}/reports/calendar`,
+          () => HttpResponse.json(mockCalendar)
+        ),
+        http.get(
+          `${backendUrl}/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs`,
+          () => {
+            throw HttpResponse.text('', { status: 500 })
+          }
+        )
+      )
+
+      const { result } = await server.inject({
+        method: 'GET',
+        url,
+        auth: { strategy: 'session', credentials: mockUserSession }
+      })
+
+      expect(result).toEqual(
+        expect.stringContaining('Sorry, there is a problem with the service')
+      )
     })
 
     test('Should return 404 when registration is not found', async () => {

--- a/src/server/routes/registration-overview/get.integration.test.js
+++ b/src/server/routes/registration-overview/get.integration.test.js
@@ -382,10 +382,7 @@ describe('#registrationOverviewController', () => {
 
     test('Should render multiple summary-log rows newest-first', async () => {
       useMockBackend(mockOverview, mockCalendar, {
-        summaryLogs: [
-          mockSubmittedSummaryLog,
-          mockValidationFailedSummaryLog
-        ]
+        summaryLogs: [mockSubmittedSummaryLog, mockValidationFailedSummaryLog]
       })
 
       const { result } = await server.inject({

--- a/src/server/routes/registration-overview/index.njk
+++ b/src/server/routes/registration-overview/index.njk
@@ -62,5 +62,23 @@
         {% endif %}
       </div>
     </div>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        {% if summaryLogRows and summaryLogRows.length %}
+          {{ govukTable({
+            caption: "Summary logs",
+            captionClasses: "govuk-table__caption--m",
+            head: [
+              { text: "Uploaded at" },
+              { text: "Status" },
+              { text: "Actions" }
+            ],
+            rows: summaryLogRows
+          }) }}
+        {% else %}
+          <p class="govuk-body">No summary logs</p>
+        {% endif %}
+      </div>
+    </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
Ticket: [PAE-1374](https://eaflood.atlassian.net/browse/PAE-1374)
## Summary
Adds a Summary Logs table to the per-registration overview page in the Admin UI, giving service maintainers a single place to see every completed summary-log upload for a registration and re-download any of them.

## What Changed
- New "Summary logs" section on the registration overview page with columns: Uploaded at, Status, Actions
- Status rendered as a green "Success" tag for submitted logs, or a red "Failed (Reason)" tag for each of the four failure states (Rejected / Invalid / Validation / Submission)
- Download links reuse the existing audited `/system-logs/download/...` admin route, so every access is logged by the backend
- Empty state displays "No summary logs" when there are no completed uploads
- Controller fetches the existing summary-logs endpoint in parallel with the overview and reports-calendar calls, and pre-builds the govukTable row shape so the template stays logic-free

## Why
Maintainers investigating support requests (typically "why did X's upload fail?") previously had to cross-reference multiple places in the Admin UI. The summary logs now sit alongside the registration details and reports calendar, on the page a maintainer naturally lands on after navigating from the organisation overview.

## Screenshot
<img width="1428" height="1056" alt="Screenshot 2026-04-23 at 09 40 34" src="https://github.com/user-attachments/assets/8ed99265-f935-46c7-82bd-a052820708a1" />

[PAE-1374]: https://eaflood.atlassian.net/browse/PAE-1374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ