### PR TITLE
PAE-1398: Add email and event type filters to system logs

### DIFF
--- a/src/server/routes/system-logs/controller.get.js
+++ b/src/server/routes/system-logs/controller.get.js
@@ -1,8 +1,5 @@
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
-import { isNil } from '#server/common/helpers/is-nil.js'
-import isEqual from 'lodash/isEqual.js'
-import isArray from 'lodash/isArray.js'
-import isObject from 'lodash/isObject.js'
+import { transformSystemLog } from './transform-system-log.js'
 
 export const systemLogGetController = {
   async handler(request, h) {
@@ -21,7 +18,9 @@ export const systemLogGetController = {
         pageTitle: request.route.settings.app.pageTitle,
         systemLogs: [],
         searchTerms: {
-          referenceNumber: ''
+          referenceNumber: '',
+          email: '',
+          subCategory: ''
         },
         error: hasReferenceNumberQuery
           ? {
@@ -56,14 +55,11 @@ export const systemLogGetController = {
 
     return h.view('routes/system-logs/index', {
       pageTitle: request.route.settings.app.pageTitle,
-      systemLogs: data.systemLogs.map((systemLog) => ({
-        timestamp: systemLog.createdAt,
-        event: systemLog.event,
-        user: systemLog.createdBy,
-        ...contextWithDeltaBetweenPreviousAndNextExtracted(systemLog)
-      })),
+      systemLogs: data.systemLogs.map(transformSystemLog),
       searchTerms: {
-        referenceNumber: searchTermReferenceNumber
+        referenceNumber: searchTermReferenceNumber,
+        email: '',
+        subCategory: ''
       },
       error: null,
       pagination,
@@ -96,69 +92,4 @@ function buildPagination({ data, referenceNumber, cursor, page }) {
   }
 
   return pagination
-}
-
-function contextWithDeltaBetweenPreviousAndNextExtracted({ context }) {
-  const { previous, next, ...remainingContext } = context
-  const hasPrevious = 'previous' in context
-  const hasNext = 'next' in context
-  if (hasPrevious || hasNext) {
-    return {
-      renderDelta: {
-        previous,
-        ...(hasPrevious ? { previous } : {}),
-        ...(hasNext ? { next } : {}),
-        ...(hasPrevious && hasNext
-          ? { difference: difference(previous, next) || 'no differences' }
-          : {})
-      },
-      context: { ...remainingContext }
-    }
-  }
-
-  return { context }
-}
-
-function difference(previous, next) {
-  if (isEqual(previous, next)) {
-    return undefined
-  }
-  if (isSimple(previous) || isSimple(next)) {
-    return renderChange(previous, next)
-  }
-
-  const allKeysDeDuped = [...new Set([previous, next].flatMap(Object.keys))]
-  return allKeysDeDuped.reduce((acc, key) => {
-    const diff = difference(previous[key], next[key])
-    if (diff) {
-      acc[key] = diff
-    }
-    return acc
-  }, {})
-}
-
-function renderChange(a, b) {
-  if (isSimple(a) && isSimple(b)) {
-    if (!a) {
-      return { _added: b }
-    }
-    if (!b) {
-      return { _removed: a }
-    }
-    return { _changed: `${a} -> ${b}` }
-  }
-
-  if (!a) {
-    return { _added: b }
-  }
-
-  if (!b) {
-    return { _removed: a }
-  }
-
-  return { _previous: a, _next: b }
-}
-
-function isSimple(x) {
-  return isNil(x) || (!isObject(x) && !isArray(x))
 }

--- a/src/server/routes/system-logs/controller.post.js
+++ b/src/server/routes/system-logs/controller.post.js
@@ -7,7 +7,7 @@ export const systemLogPostController = {
     const email = request.payload?.email?.trim() || ''
     const subCategory = request.payload?.subCategory || ''
 
-    const hasAnyFilter = referenceNumber || email || subCategory
+    const hasAnyFilter = referenceNumber || email
 
     if (!hasAnyFilter) {
       return h.view('routes/system-logs/index', {
@@ -15,7 +15,7 @@ export const systemLogPostController = {
         systemLogs: [],
         searchTerms: { referenceNumber, email, subCategory },
         error: {
-          text: 'Enter at least one search term',
+          text: 'Enter an organisation reference number or email address',
           href: '#referenceNumber'
         }
       })

--- a/src/server/routes/system-logs/controller.post.js
+++ b/src/server/routes/system-logs/controller.post.js
@@ -1,0 +1,47 @@
+import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
+import { transformSystemLog } from './transform-system-log.js'
+
+export const systemLogPostController = {
+  async handler(request, h) {
+    const referenceNumber = request.payload?.referenceNumber?.trim() || ''
+    const email = request.payload?.email?.trim() || ''
+    const subCategory = request.payload?.subCategory || ''
+
+    const hasAnyFilter = referenceNumber || email || subCategory
+
+    if (!hasAnyFilter) {
+      return h.view('routes/system-logs/index', {
+        pageTitle: request.route.settings.app.pageTitle,
+        systemLogs: [],
+        searchTerms: { referenceNumber, email, subCategory },
+        error: {
+          text: 'Enter at least one search term',
+          href: '#referenceNumber'
+        }
+      })
+    }
+
+    const body = {}
+    if (referenceNumber) {
+      body.organisationId = referenceNumber
+    }
+    if (email) {
+      body.email = email
+    }
+    if (subCategory) {
+      body.subCategory = subCategory
+    }
+
+    const data = await fetchJsonFromBackend(request, '/v1/system-logs/search', {
+      method: 'POST',
+      body: JSON.stringify(body)
+    })
+
+    return h.view('routes/system-logs/index', {
+      pageTitle: request.route.settings.app.pageTitle,
+      systemLogs: data.systemLogs.map(transformSystemLog),
+      searchTerms: { referenceNumber, email, subCategory },
+      error: null
+    })
+  }
+}

--- a/src/server/routes/system-logs/index.js
+++ b/src/server/routes/system-logs/index.js
@@ -1,5 +1,6 @@
 import Joi from 'joi'
 import { systemLogGetController } from './controller.get.js'
+import { systemLogPostController } from './controller.post.js'
 import { systemLogDownloadController } from './controller.download.js'
 
 const idParam = Joi.string()
@@ -29,6 +30,14 @@ export const systemLogs = {
           method: 'GET',
           path: '/system-logs',
           ...systemLogGetController,
+          options: {
+            app: { pageTitle: 'System logs' }
+          }
+        },
+        {
+          method: 'POST',
+          path: '/system-logs',
+          ...systemLogPostController,
           options: {
             app: { pageTitle: 'System logs' }
           }

--- a/src/server/routes/system-logs/index.njk
+++ b/src/server/routes/system-logs/index.njk
@@ -4,6 +4,7 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 
@@ -26,7 +27,8 @@
 
         <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
 
-        <form method="get" class="app-filters">
+        <form method="post" class="app-filters">
+          <input type="hidden" name="crumb" value="{{ crumb }}" />
           <h2 class="govuk-heading-m">Search system logs by</h2>
           <div class="govuk-form-group">
             {{ govukInput({
@@ -44,11 +46,46 @@
             }) }}
           </div>
 
+          <div class="govuk-form-group">
+            {{ govukInput({
+              label: {
+                text: "User email",
+                classes: "govuk-label--s"
+              },
+              id: "email",
+              name: "email",
+              type: "email",
+              value: searchTerms.email,
+              autocomplete: "off",
+              classes: "govuk-input--width-20"
+            }) }}
+          </div>
+
+          <div class="govuk-form-group">
+            {{ govukSelect({
+              id: "subCategory",
+              name: "subCategory",
+              label: {
+                text: "Event type",
+                classes: "govuk-label--s"
+              },
+              items: [
+                { value: "", text: "All event types", selected: not searchTerms.subCategory },
+                { value: "Organisations", text: "Organisations", selected: searchTerms.subCategory == "Organisations" },
+                { value: "Overseas sites", text: "Overseas sites", selected: searchTerms.subCategory == "Overseas sites" },
+                { value: "Summary log", text: "Summary log", selected: searchTerms.subCategory == "Summary log" },
+                { value: "Reconciliation", text: "Reconciliation", selected: searchTerms.subCategory == "Reconciliation" },
+                { value: "Public register", text: "Public register", selected: searchTerms.subCategory == "Public register" },
+                { value: "Download", text: "Download", selected: searchTerms.subCategory == "Download" }
+              ]
+            }) }}
+          </div>
+
           <div class="govuk-button-group">
 
             {{ govukButton({ text: "Search" }) }}
 
-            <a href="?" class="govuk-button govuk-button--inverse">Clear search</a>
+            <a href="/system-logs" class="govuk-button govuk-button--inverse">Clear search</a>
           </div>
         </form>
 

--- a/src/server/routes/system-logs/index.njk
+++ b/src/server/routes/system-logs/index.njk
@@ -56,6 +56,7 @@
               name: "email",
               type: "email",
               value: searchTerms.email,
+              errorMessage: error if error,
               autocomplete: "off",
               classes: "govuk-input--width-20"
             }) }}
@@ -71,12 +72,13 @@
               },
               items: [
                 { value: "", text: "All event types", selected: not searchTerms.subCategory },
-                { value: "Organisations", text: "Organisations", selected: searchTerms.subCategory == "Organisations" },
-                { value: "Overseas sites", text: "Overseas sites", selected: searchTerms.subCategory == "Overseas sites" },
-                { value: "Summary log", text: "Summary log", selected: searchTerms.subCategory == "Summary log" },
-                { value: "Reconciliation", text: "Reconciliation", selected: searchTerms.subCategory == "Reconciliation" },
-                { value: "Public register", text: "Public register", selected: searchTerms.subCategory == "Public register" },
-                { value: "Download", text: "Download", selected: searchTerms.subCategory == "Download" }
+                { value: "download", text: "Download", selected: searchTerms.subCategory == "download" },
+                { value: "epr-organisations", text: "Organisations", selected: searchTerms.subCategory == "epr-organisations" },
+                { value: "overseas-sites", text: "Overseas sites", selected: searchTerms.subCategory == "overseas-sites" },
+                { value: "packaging-recycling-notes", text: "Packaging recycling notes", selected: searchTerms.subCategory == "packaging-recycling-notes" },
+                { value: "reports", text: "Reports", selected: searchTerms.subCategory == "reports" },
+                { value: "summary-log", text: "Summary log", selected: searchTerms.subCategory == "summary-log" },
+                { value: "waste-balance", text: "Waste balance", selected: searchTerms.subCategory == "waste-balance" }
               ]
             }) }}
           </div>

--- a/src/server/routes/system-logs/index.njk
+++ b/src/server/routes/system-logs/index.njk
@@ -27,7 +27,7 @@
 
         <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
 
-        <form method="post" class="app-filters">
+        <form method="post" action="/system-logs" class="app-filters">
           <input type="hidden" name="crumb" value="{{ crumb }}" />
           <h2 class="govuk-heading-m">Search system logs by</h2>
           <div class="govuk-form-group">

--- a/src/server/routes/system-logs/post.integration.test.js
+++ b/src/server/routes/system-logs/post.integration.test.js
@@ -107,16 +107,20 @@ describe('POST /system-logs', () => {
         expect(backendCalls[0].body).toEqual({ email: 'alice@example.com' })
       })
 
-      test('passes subCategory to backend when searching by event type', async () => {
+      test('passes subCategory to backend alongside email', async () => {
         const backendCalls = stubBackendResponse(
           HttpResponse.json({ systemLogs: [] })
         )
 
-        await submitSearch({ subCategory: 'Reconciliation' })
+        await submitSearch({
+          email: 'alice@example.com',
+          subCategory: 'summary-log'
+        })
 
         expect(backendCalls).toHaveLength(1)
         expect(backendCalls[0].body).toEqual({
-          subCategory: 'Reconciliation'
+          email: 'alice@example.com',
+          subCategory: 'summary-log'
         })
       })
 
@@ -139,14 +143,14 @@ describe('POST /system-logs', () => {
         await submitSearch({
           referenceNumber: 'ORG-123',
           email: 'alice@example.com',
-          subCategory: 'Reconciliation'
+          subCategory: 'summary-log'
         })
 
         expect(backendCalls).toHaveLength(1)
         expect(backendCalls[0].body).toEqual({
           organisationId: 'ORG-123',
           email: 'alice@example.com',
-          subCategory: 'Reconciliation'
+          subCategory: 'summary-log'
         })
       })
 
@@ -167,7 +171,7 @@ describe('POST /system-logs', () => {
     })
 
     describe('validation', () => {
-      test('shows error when no filters are provided', async () => {
+      test('shows error on both fields when no filters are provided', async () => {
         const { $, statusCode } = await submitSearch({
           referenceNumber: '',
           email: '',
@@ -176,7 +180,28 @@ describe('POST /system-logs', () => {
 
         expect(statusCode).toBe(statusCodes.ok)
         expect($.text()).toContain('There is a problem')
-        expect($.text()).toContain('Enter at least one search term')
+        expect($.text()).toContain(
+          'Enter an organisation reference number or email address'
+        )
+        expect($('#referenceNumber-error').text()).toContain(
+          'Enter an organisation reference number or email address'
+        )
+        expect($('#email-error').text()).toContain(
+          'Enter an organisation reference number or email address'
+        )
+      })
+
+      test('shows error when only subCategory is provided', async () => {
+        const { $, statusCode } = await submitSearch({
+          referenceNumber: '',
+          email: '',
+          subCategory: 'summary-log'
+        })
+
+        expect(statusCode).toBe(statusCodes.ok)
+        expect($.text()).toContain(
+          'Enter an organisation reference number or email address'
+        )
       })
 
       test('does not call backend when no filters are provided', async () => {
@@ -188,6 +213,20 @@ describe('POST /system-logs', () => {
           referenceNumber: '',
           email: '',
           subCategory: ''
+        })
+
+        expect(backendCalls).toHaveLength(0)
+      })
+
+      test('does not call backend when only subCategory is provided', async () => {
+        const backendCalls = stubBackendResponse(
+          HttpResponse.json({ systemLogs: [] })
+        )
+
+        await submitSearch({
+          referenceNumber: '',
+          email: '',
+          subCategory: 'summary-log'
         })
 
         expect(backendCalls).toHaveLength(0)
@@ -256,12 +295,13 @@ describe('POST /system-logs', () => {
 
         expect(options).toEqual([
           '',
-          'Organisations',
-          'Overseas sites',
-          'Summary log',
-          'Reconciliation',
-          'Public register',
-          'Download'
+          'download',
+          'epr-organisations',
+          'overseas-sites',
+          'packaging-recycling-notes',
+          'reports',
+          'summary-log',
+          'waste-balance'
         ])
       })
 
@@ -272,9 +312,9 @@ describe('POST /system-logs', () => {
               {
                 createdBy: { email: 'alice@example.com' },
                 event: {
-                  category: 'cat',
-                  subCategory: 'Reconciliation',
-                  action: 'act'
+                  category: 'entity',
+                  subCategory: 'summary-log',
+                  action: 'create'
                 },
                 context: {}
               }
@@ -285,13 +325,13 @@ describe('POST /system-logs', () => {
         const { $ } = await submitSearch({
           referenceNumber: 'ORG-123',
           email: 'alice@example.com',
-          subCategory: 'Reconciliation'
+          subCategory: 'summary-log'
         })
 
         expect($('input[name="referenceNumber"]').val()).toBe('ORG-123')
         expect($('input[name="email"]').val()).toBe('alice@example.com')
         expect($('select[name="subCategory"] option[selected]').val()).toBe(
-          'Reconciliation'
+          'summary-log'
         )
       })
 
@@ -320,8 +360,8 @@ describe('POST /system-logs', () => {
                 createdAt: '2025-03-15T10:00:00Z',
                 createdBy: { email: 'alice@example.com' },
                 event: {
-                  category: 'Admin',
-                  subCategory: 'Reconciliation',
+                  category: 'entity',
+                  subCategory: 'epr-organisations',
                   action: 'create'
                 },
                 context: {}
@@ -337,7 +377,7 @@ describe('POST /system-logs', () => {
         expect(statusCode).toBe(statusCodes.ok)
         expect($('.govuk-summary-card')).toHaveLength(1)
         expect($('.govuk-summary-card__title').text().trim()).toBe(
-          'Admin, Reconciliation, create'
+          'entity, epr-organisations, create'
         )
       })
 

--- a/src/server/routes/system-logs/post.integration.test.js
+++ b/src/server/routes/system-logs/post.integration.test.js
@@ -1,0 +1,371 @@
+import { vi } from 'vitest'
+import { createServer } from '#server/server.js'
+import { config } from '#config/config.js'
+import { statusCodes } from '#server/common/constants/status-codes.js'
+import { mockUserSession } from '#server/common/test-helpers/fixtures.js'
+import { getUserSession } from '#server/common/helpers/auth/get-user-session.js'
+import { createMockOidcServer } from '#server/common/test-helpers/mock-oidc.js'
+import { http, server as mswServer, HttpResponse } from '#vite/setup-msw.js'
+import * as cheerio from 'cheerio'
+
+vi.mock('#server/common/helpers/auth/get-user-session.js', () => ({
+  getUserSession: vi.fn().mockReturnValue(null)
+}))
+
+describe('POST /system-logs', () => {
+  let server
+
+  beforeAll(async () => {
+    createMockOidcServer()
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    await server.stop({ timeout: 0 })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const stubBackendResponse = (response) => {
+    const calls = []
+    mswServer.use(
+      http.post(
+        `${config.get('eprBackendUrl')}/v1/system-logs/search`,
+        async ({ request }) => {
+          const body = await request.json()
+          calls.push({ body })
+          return response
+        }
+      )
+    )
+    return calls
+  }
+
+  const getCrumb = async () => {
+    getUserSession.mockReturnValue(mockUserSession)
+    const { result } = await server.inject({
+      method: 'GET',
+      url: '/system-logs',
+      auth: {
+        strategy: 'session',
+        credentials: mockUserSession
+      }
+    })
+    const $ = cheerio.load(result)
+    return $('input[name="crumb"]').val()
+  }
+
+  describe('When user is unauthenticated', () => {
+    test('Should return unauthorised status code', async () => {
+      const { statusCode } = await server.inject({
+        method: 'POST',
+        url: '/system-logs',
+        payload: { email: 'test@example.com' }
+      })
+
+      expect(statusCode).toBe(statusCodes.unauthorised)
+    })
+  })
+
+  describe('When user is authenticated', () => {
+    let crumb
+
+    beforeEach(async () => {
+      getUserSession.mockReturnValue(mockUserSession)
+      crumb = await getCrumb()
+    })
+
+    const submitSearch = async (payload = {}) => {
+      const { result, statusCode } = await server.inject({
+        method: 'POST',
+        url: '/system-logs',
+        payload: { crumb, ...payload },
+        auth: {
+          strategy: 'session',
+          credentials: mockUserSession
+        },
+        headers: {
+          cookie: `crumb=${crumb}`
+        }
+      })
+
+      return { $: cheerio.load(result), statusCode }
+    }
+
+    describe('search filters', () => {
+      test('passes email to backend when searching by email', async () => {
+        const backendCalls = stubBackendResponse(
+          HttpResponse.json({ systemLogs: [] })
+        )
+
+        await submitSearch({ email: 'alice@example.com' })
+
+        expect(backendCalls).toHaveLength(1)
+        expect(backendCalls[0].body).toEqual({ email: 'alice@example.com' })
+      })
+
+      test('passes subCategory to backend when searching by event type', async () => {
+        const backendCalls = stubBackendResponse(
+          HttpResponse.json({ systemLogs: [] })
+        )
+
+        await submitSearch({ subCategory: 'Reconciliation' })
+
+        expect(backendCalls).toHaveLength(1)
+        expect(backendCalls[0].body).toEqual({
+          subCategory: 'Reconciliation'
+        })
+      })
+
+      test('passes organisationId to backend when searching by reference number', async () => {
+        const backendCalls = stubBackendResponse(
+          HttpResponse.json({ systemLogs: [] })
+        )
+
+        await submitSearch({ referenceNumber: 'ORG-123' })
+
+        expect(backendCalls).toHaveLength(1)
+        expect(backendCalls[0].body).toEqual({ organisationId: 'ORG-123' })
+      })
+
+      test('passes combined filters to backend', async () => {
+        const backendCalls = stubBackendResponse(
+          HttpResponse.json({ systemLogs: [] })
+        )
+
+        await submitSearch({
+          referenceNumber: 'ORG-123',
+          email: 'alice@example.com',
+          subCategory: 'Reconciliation'
+        })
+
+        expect(backendCalls).toHaveLength(1)
+        expect(backendCalls[0].body).toEqual({
+          organisationId: 'ORG-123',
+          email: 'alice@example.com',
+          subCategory: 'Reconciliation'
+        })
+      })
+
+      test('omits empty filter values from backend request', async () => {
+        const backendCalls = stubBackendResponse(
+          HttpResponse.json({ systemLogs: [] })
+        )
+
+        await submitSearch({
+          referenceNumber: '',
+          email: 'alice@example.com',
+          subCategory: ''
+        })
+
+        expect(backendCalls).toHaveLength(1)
+        expect(backendCalls[0].body).toEqual({ email: 'alice@example.com' })
+      })
+    })
+
+    describe('validation', () => {
+      test('shows error when no filters are provided', async () => {
+        const { $, statusCode } = await submitSearch({
+          referenceNumber: '',
+          email: '',
+          subCategory: ''
+        })
+
+        expect(statusCode).toBe(statusCodes.ok)
+        expect($.text()).toContain('There is a problem')
+        expect($.text()).toContain('Enter at least one search term')
+      })
+
+      test('does not call backend when no filters are provided', async () => {
+        const backendCalls = stubBackendResponse(
+          HttpResponse.json({ systemLogs: [] })
+        )
+
+        await submitSearch({
+          referenceNumber: '',
+          email: '',
+          subCategory: ''
+        })
+
+        expect(backendCalls).toHaveLength(0)
+      })
+    })
+
+    describe('form rendering', () => {
+      test('renders form with POST method', async () => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: '/system-logs',
+          auth: {
+            strategy: 'session',
+            credentials: mockUserSession
+          }
+        })
+        const $ = cheerio.load(result)
+
+        expect($('form.app-filters').attr('method')).toBe('post')
+      })
+
+      test('renders CSRF crumb hidden input', async () => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: '/system-logs',
+          auth: {
+            strategy: 'session',
+            credentials: mockUserSession
+          }
+        })
+        const $ = cheerio.load(result)
+
+        expect($('input[name="crumb"]')).toHaveLength(1)
+        expect($('input[name="crumb"]').attr('type')).toBe('hidden')
+      })
+
+      test('renders all three search fields', async () => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: '/system-logs',
+          auth: {
+            strategy: 'session',
+            credentials: mockUserSession
+          }
+        })
+        const $ = cheerio.load(result)
+
+        expect($('input[name="referenceNumber"]')).toHaveLength(1)
+        expect($('input[name="email"]')).toHaveLength(1)
+        expect($('select[name="subCategory"]')).toHaveLength(1)
+      })
+
+      test('renders event type dropdown with expected options', async () => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: '/system-logs',
+          auth: {
+            strategy: 'session',
+            credentials: mockUserSession
+          }
+        })
+        const $ = cheerio.load(result)
+        const options = $('select[name="subCategory"] option')
+          .map((_, el) => $(el).val())
+          .get()
+
+        expect(options).toEqual([
+          '',
+          'Organisations',
+          'Overseas sites',
+          'Summary log',
+          'Reconciliation',
+          'Public register',
+          'Download'
+        ])
+      })
+
+      test('preserves search values in form after search', async () => {
+        stubBackendResponse(
+          HttpResponse.json({
+            systemLogs: [
+              {
+                createdBy: { email: 'alice@example.com' },
+                event: {
+                  category: 'cat',
+                  subCategory: 'Reconciliation',
+                  action: 'act'
+                },
+                context: {}
+              }
+            ]
+          })
+        )
+
+        const { $ } = await submitSearch({
+          referenceNumber: 'ORG-123',
+          email: 'alice@example.com',
+          subCategory: 'Reconciliation'
+        })
+
+        expect($('input[name="referenceNumber"]').val()).toBe('ORG-123')
+        expect($('input[name="email"]').val()).toBe('alice@example.com')
+        expect($('select[name="subCategory"] option[selected]').val()).toBe(
+          'Reconciliation'
+        )
+      })
+
+      test('clear search link resets all filters', async () => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: '/system-logs',
+          auth: {
+            strategy: 'session',
+            credentials: mockUserSession
+          }
+        })
+        const $ = cheerio.load(result)
+        const clearLink = $('a.govuk-button--inverse')
+
+        expect(clearLink.attr('href')).toBe('/system-logs')
+      })
+    })
+
+    describe('results rendering', () => {
+      test('renders system logs returned from backend', async () => {
+        stubBackendResponse(
+          HttpResponse.json({
+            systemLogs: [
+              {
+                createdAt: '2025-03-15T10:00:00Z',
+                createdBy: { email: 'alice@example.com' },
+                event: {
+                  category: 'Admin',
+                  subCategory: 'Reconciliation',
+                  action: 'create'
+                },
+                context: {}
+              }
+            ]
+          })
+        )
+
+        const { $, statusCode } = await submitSearch({
+          email: 'alice@example.com'
+        })
+
+        expect(statusCode).toBe(statusCodes.ok)
+        expect($('.govuk-summary-card')).toHaveLength(1)
+        expect($('.govuk-summary-card__title').text().trim()).toBe(
+          'Admin, Reconciliation, create'
+        )
+      })
+
+      test('shows empty state when no logs match', async () => {
+        stubBackendResponse(HttpResponse.json({ systemLogs: [] }))
+
+        const { $ } = await submitSearch({ email: 'nobody@example.com' })
+
+        expect($('.govuk-summary-card')).toHaveLength(0)
+        expect($.text()).toContain('No system logs found')
+      })
+    })
+
+    describe('error handling', () => {
+      test('renders error page when backend returns server error', async () => {
+        stubBackendResponse(
+          HttpResponse.json(
+            { error: 'Server error' },
+            { status: statusCodes.internalServerError }
+          )
+        )
+
+        const { statusCode } = await submitSearch({
+          email: 'test@example.com'
+        })
+
+        expect(statusCode).toBe(statusCodes.internalServerError)
+      })
+    })
+  })
+})

--- a/src/server/routes/system-logs/transform-system-log.js
+++ b/src/server/routes/system-logs/transform-system-log.js
@@ -1,0 +1,77 @@
+import { isNil } from '#server/common/helpers/is-nil.js'
+import isEqual from 'lodash/isEqual.js'
+import isArray from 'lodash/isArray.js'
+import isObject from 'lodash/isObject.js'
+
+export function transformSystemLog(systemLog) {
+  return {
+    timestamp: systemLog.createdAt,
+    event: systemLog.event,
+    user: systemLog.createdBy,
+    ...contextWithDeltaBetweenPreviousAndNextExtracted(systemLog)
+  }
+}
+
+function contextWithDeltaBetweenPreviousAndNextExtracted({ context }) {
+  const { previous, next, ...remainingContext } = context
+  const hasPrevious = 'previous' in context
+  const hasNext = 'next' in context
+  if (hasPrevious || hasNext) {
+    return {
+      renderDelta: {
+        ...(hasPrevious ? { previous } : {}),
+        ...(hasNext ? { next } : {}),
+        ...(hasPrevious && hasNext
+          ? { difference: difference(previous, next) || 'no differences' }
+          : {})
+      },
+      context: { ...remainingContext }
+    }
+  }
+
+  return { context }
+}
+
+function difference(previous, next) {
+  if (isEqual(previous, next)) {
+    return undefined
+  }
+  if (isSimple(previous) || isSimple(next)) {
+    return renderChange(previous, next)
+  }
+
+  const allKeysDeDuped = [...new Set([previous, next].flatMap(Object.keys))]
+  return allKeysDeDuped.reduce((acc, key) => {
+    const diff = difference(previous[key], next[key])
+    if (diff) {
+      acc[key] = diff
+    }
+    return acc
+  }, {})
+}
+
+function renderChange(a, b) {
+  if (isSimple(a) && isSimple(b)) {
+    if (!a) {
+      return { _added: b }
+    }
+    if (!b) {
+      return { _removed: a }
+    }
+    return { _changed: `${a} -> ${b}` }
+  }
+
+  if (!a) {
+    return { _added: b }
+  }
+
+  if (!b) {
+    return { _removed: a }
+  }
+
+  return { _previous: a, _next: b }
+}
+
+function isSimple(x) {
+  return isNil(x) || (!isObject(x) && !isArray(x))
+}


### PR DESCRIPTION
Ticket: [PAE-1398](https://eaflood.atlassian.net/browse/PAE-1398)
## Summary
- Adds user email text input and event type dropdown alongside the existing organisation reference field
- All filters are optional but at least one is required (GDS error summary on empty submission)
- Calls new backend `POST /v1/system-logs/search` endpoint with filters in request body
- Converts system logs search form from GET to POST to keep PII (email addresses) out of browser URLs and logs
- Extracts `transformSystemLog` into a shared module to avoid duplication between GET and POST controllers

## Test plan
- [ ] POST search with each filter individually and combined
- [ ] Validation error when no filters provided
- [ ] Form renders all three fields with correct types
- [ ] CSRF crumb present in POST form
- [ ] Search values preserved in form after submission
- [ ] Clear search resets all filters
- [ ] GET with `?referenceNumber=` still works (organisations page link)
- [ ] Existing GET integration tests pass unchanged

<img width="1098" height="1273" alt="Screenshot 2026-04-23 at 20 51 00" src="https://github.com/user-attachments/assets/43ce6c9c-8f70-4d1b-b1af-41c1b2b0b3b3" />


[PAE-1398]: https://eaflood.atlassian.net/browse/PAE-1398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ