### PR TITLE
PAE-250: Fix postcss vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11378,9 +11378,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     },
     "stylelint-config-gds": {
       "stylelint": "$stylelint"
-    }
+    },
+    "postcss": "8.5.10"
   }
 }


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## Summary

Pins `postcss` to 8.5.10 via `overrides` to fix [`GHSA-qx2v-qp2m-jg93`](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) — moderate XSS via unescaped `</style>` in CSS stringify output. The vulnerable version is pulled in transitively through the webpack toolchain (`autoprefixer`, `cssnano`, `postcss-loader`) and the vitest toolchain (`vite`).

No simple overrides existed in `package.json` to evaluate for staleness.

## Verification

`npm audit` reports `0 vulnerabilities`; `snyk test` reports no vulnerable paths.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ