### PR TITLE
PAE-1398: Use POST /v1/system-logs/search in GET route

### DIFF
--- a/src/server/routes/system-logs/controller.get.js
+++ b/src/server/routes/system-logs/controller.get.js
@@ -33,18 +33,16 @@ export const systemLogGetController = {
       })
     }
 
-    const params = new URLSearchParams({
-      organisationId: searchTermReferenceNumber
-    })
+    const body = { organisationId: searchTermReferenceNumber }
 
     if (cursor) {
-      params.set('cursor', cursor)
+      body.cursor = cursor
     }
 
-    const data = await fetchJsonFromBackend(
-      request,
-      `/v1/system-logs?${params.toString()}`
-    )
+    const data = await fetchJsonFromBackend(request, '/v1/system-logs/search', {
+      method: 'POST',
+      body: JSON.stringify(body)
+    })
 
     const pagination = buildPagination({
       data,

--- a/src/server/routes/system-logs/get.integration.test.js
+++ b/src/server/routes/system-logs/get.integration.test.js
@@ -32,11 +32,11 @@ describe('GET /system-logs', () => {
   const stubBackendReponse = (response) => {
     const calls = []
     mswServer.use(
-      http.get(
-        `${config.get('eprBackendUrl')}/v1/system-logs`,
-        ({ request }) => {
-          const url = new URL(request.url)
-          calls.push({ url })
+      http.post(
+        `${config.get('eprBackendUrl')}/v1/system-logs/search`,
+        async ({ request }) => {
+          const body = await request.json()
+          calls.push({ body })
           return response
         }
       )
@@ -596,11 +596,9 @@ describe('GET /system-logs', () => {
 
         expect(statusCode).toEqual(statusCodes.ok)
 
-        // backend called with expected query
+        // backend called with expected body
         expect(backendCalls).toHaveLength(1)
-        expect(backendCalls[0].url.searchParams).toEqual(
-          new URLSearchParams({ organisationId: 12345 })
-        )
+        expect(backendCalls[0].body).toEqual({ organisationId: '12345' })
 
         // reference Number rendered in search form
         expect($('form input[name=referenceNumber]').val()).toEqual('12345')
@@ -642,12 +640,8 @@ describe('GET /system-logs', () => {
         )
 
         expect(backendCalls).toHaveLength(1)
-        expect(backendCalls[0].url.searchParams.get('cursor')).toBe(
-          'abc123def456abc123def456'
-        )
-        expect(backendCalls[0].url.searchParams.get('organisationId')).toBe(
-          '12345'
-        )
+        expect(backendCalls[0].body.cursor).toBe('abc123def456abc123def456')
+        expect(backendCalls[0].body.organisationId).toBe('12345')
       })
 
       it('renders Next pagination link when backend returns hasMore and nextCursor', async () => {


### PR DESCRIPTION
Ticket: [PAE-1398](https://eaflood.atlassian.net/browse/PAE-1398)

## Summary

The backend is removing `GET /v1/system-logs` (PR #1118) in favour of `POST /v1/system-logs/search`, which keeps PII (email, organisation ID) out of URLs.

The system logs GET route (`/system-logs?referenceNumber=...`) used the old GET endpoint for cursor-based pagination. This switches it to `POST /v1/system-logs/search` with a JSON request body, keeping the frontend's pagination links as query params (they still use GET) but ensuring the backend call uses the new endpoint.

The GET integration test is updated to intercept the POST endpoint and assert against request body fields rather than URL search params.

[PAE-1398]: https://eaflood.atlassian.net/browse/PAE-1398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ