### PR TITLE
PAE-1396: Add defra-id-reconciliation to system logs event type filter

### DIFF
--- a/src/server/routes/system-logs/index.njk
+++ b/src/server/routes/system-logs/index.njk
@@ -72,6 +72,7 @@
               },
               items: [
                 { value: "", text: "All event types", selected: not searchTerms.subCategory },
+                { value: "defra-id-reconciliation", text: "Defra ID reconciliation", selected: searchTerms.subCategory == "defra-id-reconciliation" },
                 { value: "download", text: "Download", selected: searchTerms.subCategory == "download" },
                 { value: "epr-organisations", text: "Organisations", selected: searchTerms.subCategory == "epr-organisations" },
                 { value: "overseas-sites", text: "Overseas sites", selected: searchTerms.subCategory == "overseas-sites" },

--- a/src/server/routes/system-logs/post.integration.test.js
+++ b/src/server/routes/system-logs/post.integration.test.js
@@ -295,6 +295,7 @@ describe('POST /system-logs', () => {
 
         expect(options).toEqual([
           '',
+          'defra-id-reconciliation',
           'download',
           'epr-organisations',
           'overseas-sites',


### PR DESCRIPTION
Ticket: [PAE-1396](https://eaflood.atlassian.net/browse/PAE-1396)
## Summary

- Adds `defra-id-reconciliation` as a new option in the system logs event type dropdown, allowing admins to filter audit events for Defra ID reconciliation
- The new option is inserted in alphabetical order between "All event types" and "Download"

<img width="1714" height="1096" alt="image" src="https://github.com/user-attachments/assets/a65a4822-70b9-48cb-93ee-bcd19a4e7405" />


[PAE-1396]: https://eaflood.atlassian.net/browse/PAE-1396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ