### PR TITLE
PAE-1412: extract is-production-environment helper to config

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -295,3 +295,6 @@ export const config = convict({
 })
 
 config.validate({ allowed: 'strict' })
+
+export const isProductionEnvironment = () =>
+  config.get('cdpEnvironment') === 'prod'

--- a/src/config/config.test.js
+++ b/src/config/config.test.js
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
+
+import { config, isProductionEnvironment } from './config.js'
 
 describe('#config', () => {
   beforeEach(() => {
@@ -26,6 +28,32 @@ describe('#config', () => {
 
       const redactPaths = config.get('log.redact')
       expect(redactPaths).toEqual([])
+    })
+  })
+
+  describe(isProductionEnvironment, () => {
+    afterEach(() => {
+      config.reset('cdpEnvironment')
+    })
+
+    it('should return true when cdpEnvironment is prod', () => {
+      config.set('cdpEnvironment', 'prod')
+
+      expect(isProductionEnvironment()).toBe(true)
+    })
+
+    it.each([
+      'local',
+      'infra-dev',
+      'management',
+      'dev',
+      'test',
+      'perf-test',
+      'ext-test'
+    ])('should return false when cdpEnvironment is %s', (env) => {
+      config.set('cdpEnvironment', env)
+
+      expect(isProductionEnvironment()).toBe(false)
     })
   })
 

--- a/src/server/common/helpers/logging/logger-options.js
+++ b/src/server/common/helpers/logging/logger-options.js
@@ -1,7 +1,7 @@
 import { ecsFormat } from '@elastic/ecs-pino-format'
 import { getTraceId } from '@defra/hapi-tracing'
 
-import { config } from '#config/config.js'
+import { config, isProductionEnvironment } from '#config/config.js'
 
 /**
  * @typedef {Error & {isBoom: true, output: {statusCode: number, payload: object}, data?: object}} BoomError
@@ -10,8 +10,6 @@ import { config } from '#config/config.js'
 const logConfig = config.get('log')
 const serviceName = config.get('serviceName')
 const serviceVersion = config.get('serviceVersion')
-const cdpEnvironment = config.get('cdpEnvironment')
-const isProductionEnvironment = cdpEnvironment === 'prod'
 
 const formatters = {
   ecs: {
@@ -47,7 +45,7 @@ export const loggerOptions = {
       }
 
       // @ts-ignore - check for Boom error before casting
-      if (!isProductionEnvironment && err.isBoom && err.output) {
+      if (!isProductionEnvironment() && err.isBoom && err.output) {
         /** @type {BoomError} */
         const boomErr = /** @type {BoomError} */ (err)
         errorObj.statusCode = boomErr.output.statusCode

--- a/src/server/common/helpers/logging/logger-options.test.js
+++ b/src/server/common/helpers/logging/logger-options.test.js
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { config } from '#config/config.js'
+import { loggerOptions } from './logger-options.js'
 
 let mockGetTraceId
 
@@ -7,14 +10,6 @@ vi.mock('@defra/hapi-tracing', () => ({
 }))
 
 describe('#loggerOptions', () => {
-  let loggerOptions
-
-  beforeEach(async () => {
-    vi.resetModules()
-    const loggerOptionsModule = await import('./logger-options.js')
-    loggerOptions = loggerOptionsModule.loggerOptions
-  })
-
   describe('mixin function', () => {
     test('Should include trace ID in mixin when trace ID exists', () => {
       mockGetTraceId = vi.fn().mockReturnValue('test-trace-id-123')
@@ -153,33 +148,13 @@ describe('#loggerOptions', () => {
 })
 
 describe('#loggerOptions in production environment', () => {
-  beforeEach(() => {
-    vi.resetModules()
+  afterEach(() => {
+    config.reset('cdpEnvironment')
   })
 
-  test('Should exclude Boom error details in prod environment', async () => {
-    vi.doMock('#config/config.js', () => ({
-      config: {
-        get: vi.fn((key) => {
-          const values = {
-            log: {
-              enabled: true,
-              level: 'info',
-              format: 'ecs',
-              redact: []
-            },
-            serviceName: 'test-service',
-            serviceVersion: '1.0.0',
-            cdpEnvironment: 'prod'
-          }
-          return values[key]
-        })
-      }
-    }))
-
-    const { loggerOptions: prodLoggerOptions } =
-      await import('./logger-options.js')
-    const { err: errorSerializer } = prodLoggerOptions.serializers
+  test('Should exclude Boom error details in prod environment', () => {
+    config.set('cdpEnvironment', 'prod')
+    const { err: errorSerializer } = loggerOptions.serializers
 
     const boomError = new Error('Validation failed')
     boomError.isBoom = true


### PR DESCRIPTION
Ticket: [PAE-1412](https://eaflood.atlassian.net/browse/PAE-1412)
extract `isProductionEnvironment()` to `src/config/config.js` and replace the inlined const in `logger-options.js`.

[PAE-1412]: https://eaflood.atlassian.net/browse/PAE-1412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ