### PR TITLE
PAE-1421: Add Regulator as first column of report submissions CSV

### DIFF
--- a/src/server/routes/report-submissions/controller.post.js
+++ b/src/server/routes/report-submissions/controller.post.js
@@ -18,6 +18,7 @@ function generateCsv(reportSubmissions, generatedAt) {
     ['Generated at', formatDateTime(generatedAt)],
     [],
     [
+      'Regulator',
       'Organisation name',
       'Organisation registered approver contact number',
       'Organisation registered approver person email address',
@@ -52,6 +53,7 @@ function generateCsv(reportSubmissions, generatedAt) {
 
   for (const row of reportSubmissions) {
     rows.push([
+      row.regulator,
       sanitizeFormulaInjection(row.organisationName),
       row.approvedPersonsPhone,
       row.approvedPersonsEmail,

--- a/src/server/routes/report-submissions/controller.post.test.js
+++ b/src/server/routes/report-submissions/controller.post.test.js
@@ -11,6 +11,7 @@ vi.mock('#server/common/helpers/logging/logger.js', () => ({
 }))
 
 const buildRow = (overrides = {}) => ({
+  regulator: 'EA',
   organisationName: 'Acme Ltd',
   submitterPhone: '01234567890',
   approvedPersonsPhone: '09876543210',
@@ -109,7 +110,7 @@ describe('reportSubmissionsPostController', () => {
     expect(firstLine).toContain('Report submissions')
   })
 
-  test('CSV includes the 12 column headers', async () => {
+  test('CSV includes the non-tonnage column headers', async () => {
     fetchJsonFromBackend.mockResolvedValue({
       reportSubmissions: [],
       generatedAt: '2026-04-17T10:00:00.000Z'
@@ -118,6 +119,7 @@ describe('reportSubmissionsPostController', () => {
     await reportSubmissionsPostController.handler(mockRequest, mockH)
 
     const csv = mockH.response.mock.calls[0][0]
+    expect(csv).toContain('Regulator')
     expect(csv).toContain('Organisation name')
     expect(csv).toContain('Organisation registered approver contact number')
     expect(csv).toContain(
@@ -133,6 +135,51 @@ describe('reportSubmissionsPostController', () => {
     expect(csv).toContain('Due Date')
     expect(csv).toContain('Submitted Date')
     expect(csv).toContain('Submitted By')
+  })
+
+  test('Regulator is the first column header', async () => {
+    fetchJsonFromBackend.mockResolvedValue({
+      reportSubmissions: [],
+      generatedAt: '2026-04-17T10:00:00.000Z'
+    })
+
+    await reportSubmissionsPostController.handler(mockRequest, mockH)
+
+    const csv = mockH.response.mock.calls[0][0]
+    const headerLine = csv
+      .split(/\r?\n/)
+      .find((line) => line.startsWith('"Regulator"'))
+    expect(headerLine).toMatch(/^"Regulator","Organisation name"/)
+  })
+
+  test('regulator value appears as the first cell of a data row', async () => {
+    fetchJsonFromBackend.mockResolvedValue({
+      reportSubmissions: [buildRow({ regulator: 'NIEA' })],
+      generatedAt: '2026-04-17T10:00:00.000Z'
+    })
+
+    await reportSubmissionsPostController.handler(mockRequest, mockH)
+
+    const csv = mockH.response.mock.calls[0][0]
+    const dataLine = csv
+      .split(/\r?\n/)
+      .find((line) => line.startsWith('"NIEA"'))
+    expect(dataLine).toMatch(/^"NIEA","Acme Ltd"/)
+  })
+
+  test('empty regulator renders as an empty first cell', async () => {
+    fetchJsonFromBackend.mockResolvedValue({
+      reportSubmissions: [buildRow({ regulator: '' })],
+      generatedAt: '2026-04-17T10:00:00.000Z'
+    })
+
+    await reportSubmissionsPostController.handler(mockRequest, mockH)
+
+    const csv = mockH.response.mock.calls[0][0]
+    const dataLine = csv
+      .split(/\r?\n/)
+      .find((line) => line.startsWith('"","Acme Ltd"'))
+    expect(dataLine).toBeDefined()
   })
 
   test('CSV includes data rows', async () => {

--- a/src/server/routes/report-submissions/controller.post.test.js
+++ b/src/server/routes/report-submissions/controller.post.test.js
@@ -167,21 +167,6 @@ describe('reportSubmissionsPostController', () => {
     expect(dataLine).toMatch(/^"NIEA","Acme Ltd"/)
   })
 
-  test('empty regulator renders as an empty first cell', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
-      reportSubmissions: [buildRow({ regulator: '' })],
-      generatedAt: '2026-04-17T10:00:00.000Z'
-    })
-
-    await reportSubmissionsPostController.handler(mockRequest, mockH)
-
-    const csv = mockH.response.mock.calls[0][0]
-    const dataLine = csv
-      .split(/\r?\n/)
-      .find((line) => line.startsWith('"","Acme Ltd"'))
-    expect(dataLine).toBeDefined()
-  })
-
   test('CSV includes data rows', async () => {
     fetchJsonFromBackend.mockResolvedValue({
       reportSubmissions: [buildRow()],


### PR DESCRIPTION
## Summary

- Adds "Regulator" as the first column of the report submissions CSV
- Reads from the new `regulator` field on the backend's `/v1/organisations/reports/submissions` response (always one of `EA` / `NIEA` / `SEPA` / `NRW`, enforced by the backend Joi schema)
- Existing 29 columns retain their relative ordering; CSV is now 30 columns wide

## Changes

- `src/server/routes/report-submissions/controller.post.js` — prepends `'Regulator'` to header array and `row.regulator` to the per-row push (no formula-injection sanitisation needed — values are constrained to four uppercase tokens)
- `src/server/routes/report-submissions/controller.post.test.js` — adds two focused tests (Regulator is the first column header, regulator value appears as the first cell); updates `buildRow` default to include `regulator: 'EA'`; renames `'CSV includes the 12 column headers'` to `'CSV includes the non-tonnage column headers'` and adds Regulator to the assertion list

## Deployment ordering

Depends on [DEFRA/epr-backend#1145](https://github.com/DEFRA/epr-backend/pull/1145) being merged and deployed first.
