### PR TITLE
PAE-250: Prune stale postcss override

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
     },
     "stylelint-config-gds": {
       "stylelint": "$stylelint"
-    },
-    "postcss": "8.5.10"
+    }
   }
 }


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## Summary

Removes the `postcss` entry from `package.json` `overrides` because it is no longer changing anything — `autoprefixer@10.4.27`, `css-loader@7.1.4` and the rest of the postcss-using packages already pull in `postcss@8.5.10`, the same version the override was pinning.

The override was tested in isolation by removing it from `package.json`, regenerating the lockfile, and running both `npm audit` and `snyk test`. Both reported zero issues with the override gone.

The remaining nested overrides (`jsoneditor.ajv`, `ajv-cli.fast-json-patch`, `stylelint-config-gds.stylelint`) are compatibility shims rather than vulnerability mitigations and were not part of this sweep.

## Why prune it

The shared CI `Preparation` step rejects unpinned ranges in `overrides`, which means each entry is a permanent forced version that won't update with the rest of the tree until someone removes it. Stale overrides that no longer affect resolution add maintenance noise — they're easily mistaken for active mitigations during future audits and force the reviewer to verify why each one is still there. Pruning them keeps the override list a meaningful list of active mitigations.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ