### PR TITLE
PAE-1436 Allow system logs to be retrieved by event type

### DIFF
--- a/src/server/routes/system-logs/controller.post.js
+++ b/src/server/routes/system-logs/controller.post.js
@@ -7,7 +7,7 @@ export const systemLogPostController = {
     const email = request.payload?.email?.trim() || ''
     const subCategory = request.payload?.subCategory || ''
 
-    const hasAnyFilter = referenceNumber || email
+    const hasAnyFilter = referenceNumber || email || subCategory
 
     if (!hasAnyFilter) {
       return h.view('routes/system-logs/index', {
@@ -15,7 +15,7 @@ export const systemLogPostController = {
         systemLogs: [],
         searchTerms: { referenceNumber, email, subCategory },
         error: {
-          text: 'Enter an organisation reference number or email address',
+          text: 'Enter an organisation reference number, email address or event type',
           href: '#referenceNumber'
         }
       })

--- a/src/server/routes/system-logs/index.njk
+++ b/src/server/routes/system-logs/index.njk
@@ -70,6 +70,7 @@
                 text: "Event type",
                 classes: "govuk-label--s"
               },
+              errorMessage: error if error,
               items: [
                 { value: "", text: "All event types", selected: not searchTerms.subCategory },
                 { value: "defra-id-reconciliation", text: "Defra ID reconciliation", selected: searchTerms.subCategory == "defra-id-reconciliation" },

--- a/src/server/routes/system-logs/post.integration.test.js
+++ b/src/server/routes/system-logs/post.integration.test.js
@@ -171,7 +171,7 @@ describe('POST /system-logs', () => {
     })
 
     describe('validation', () => {
-      test('shows error on both fields when no filters are provided', async () => {
+      test('shows error on all fields when no filters are provided', async () => {
         const { $, statusCode } = await submitSearch({
           referenceNumber: '',
           email: '',
@@ -179,28 +179,19 @@ describe('POST /system-logs', () => {
         })
 
         expect(statusCode).toBe(statusCodes.ok)
-        expect($.text()).toContain('There is a problem')
-        expect($.text()).toContain(
-          'Enter an organisation reference number or email address'
+        expect($('.govuk-error-summary').text()).toContain('There is a problem')
+        expect($('.govuk-error-summary').text()).toContain(
+          'Enter an organisation reference number, email address or event type'
         )
+
         expect($('#referenceNumber-error').text()).toContain(
-          'Enter an organisation reference number or email address'
+          'Enter an organisation reference number, email address or event type'
         )
         expect($('#email-error').text()).toContain(
-          'Enter an organisation reference number or email address'
+          'Enter an organisation reference number, email address or event type'
         )
-      })
-
-      test('shows error when only subCategory is provided', async () => {
-        const { $, statusCode } = await submitSearch({
-          referenceNumber: '',
-          email: '',
-          subCategory: 'summary-log'
-        })
-
-        expect(statusCode).toBe(statusCodes.ok)
-        expect($.text()).toContain(
-          'Enter an organisation reference number or email address'
+        expect($('#subCategory-error').text()).toContain(
+          'Enter an organisation reference number, email address or event type'
         )
       })
 
@@ -218,7 +209,7 @@ describe('POST /system-logs', () => {
         expect(backendCalls).toHaveLength(0)
       })
 
-      test('does not call backend when only subCategory is provided', async () => {
+      test('calls backend when only subCategory is provided', async () => {
         const backendCalls = stubBackendResponse(
           HttpResponse.json({ systemLogs: [] })
         )
@@ -229,7 +220,8 @@ describe('POST /system-logs', () => {
           subCategory: 'summary-log'
         })
 
-        expect(backendCalls).toHaveLength(0)
+        expect(backendCalls).toHaveLength(1)
+        expect(backendCalls[0].body).toEqual({ subCategory: 'summary-log' })
       })
     })
 

--- a/src/server/routes/system-logs/post.integration.test.js
+++ b/src/server/routes/system-logs/post.integration.test.js
@@ -208,21 +208,6 @@ describe('POST /system-logs', () => {
 
         expect(backendCalls).toHaveLength(0)
       })
-
-      test('calls backend when only subCategory is provided', async () => {
-        const backendCalls = stubBackendResponse(
-          HttpResponse.json({ systemLogs: [] })
-        )
-
-        await submitSearch({
-          referenceNumber: '',
-          email: '',
-          subCategory: 'summary-log'
-        })
-
-        expect(backendCalls).toHaveLength(1)
-        expect(backendCalls[0].body).toEqual({ subCategory: 'summary-log' })
-      })
     })
 
     describe('form rendering', () => {


### PR DESCRIPTION
Ticket: [PAE-1436](https://eaflood.atlassian.net/browse/PAE-1436)
## Description

Relax system log filtering restriction
- from: one of "org ID, email" must be supplied
- to: one of "org ID, email, event type" must be supplied

Pairs with https://github.com/DEFRA/epr-backend/pull/1150

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1436]: https://eaflood.atlassian.net/browse/PAE-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ