### PR TITLE
PAE-1412: local x-cdp-request-id fallback for trace.id

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -106,6 +106,17 @@ export const config = convict({
       format: ['ecs', 'pino-pretty'],
       default: isProduction ? 'ecs' : 'pino-pretty',
       env: 'LOG_FORMAT'
+    },
+    redact: {
+      doc: 'Log paths to redact',
+      format: Array,
+      default: isProduction
+        ? [
+            'http.request.headers.authorization',
+            'http.request.headers.cookie',
+            'http.response.headers'
+          ]
+        : []
     }
   },
   httpProxy: {

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -106,17 +106,6 @@ export const config = convict({
       format: ['ecs', 'pino-pretty'],
       default: isProduction ? 'ecs' : 'pino-pretty',
       env: 'LOG_FORMAT'
-    },
-    redact: {
-      doc: 'Log paths to redact',
-      format: Array,
-      default: isProduction
-        ? [
-            'http.request.headers.authorization',
-            'http.request.headers.cookie',
-            'http.response.headers'
-          ]
-        : []
     }
   },
   httpProxy: {

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -111,7 +111,11 @@ export const config = convict({
       doc: 'Log paths to redact',
       format: Array,
       default: isProduction
-        ? ['req.headers.authorization', 'req.headers.cookie', 'res.headers']
+        ? [
+            'http.request.headers.authorization',
+            'http.request.headers.cookie',
+            'http.response.headers'
+          ]
         : []
     }
   },

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -298,3 +298,5 @@ config.validate({ allowed: 'strict' })
 
 export const isProductionEnvironment = () =>
   config.get('cdpEnvironment') === 'prod'
+
+export const isLocalEnvironment = () => config.get('cdpEnvironment') === 'local'

--- a/src/config/config.test.js
+++ b/src/config/config.test.js
@@ -19,9 +19,9 @@ describe('#config', () => {
 
       const redactPaths = config.get('log.redact')
       expect(redactPaths).toEqual([
-        'req.headers.authorization',
-        'req.headers.cookie',
-        'res.headers'
+        'http.request.headers.authorization',
+        'http.request.headers.cookie',
+        'http.response.headers'
       ])
     })
 

--- a/src/config/config.test.js
+++ b/src/config/config.test.js
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
 
-import { config, isProductionEnvironment } from './config.js'
+import {
+  config,
+  isLocalEnvironment,
+  isProductionEnvironment
+} from './config.js'
 
 describe('#config', () => {
   beforeEach(() => {
@@ -54,6 +58,32 @@ describe('#config', () => {
       config.set('cdpEnvironment', env)
 
       expect(isProductionEnvironment()).toBe(false)
+    })
+  })
+
+  describe(isLocalEnvironment, () => {
+    afterEach(() => {
+      config.reset('cdpEnvironment')
+    })
+
+    it('should return true when cdpEnvironment is local', () => {
+      config.set('cdpEnvironment', 'local')
+
+      expect(isLocalEnvironment()).toBe(true)
+    })
+
+    it.each([
+      'infra-dev',
+      'management',
+      'dev',
+      'test',
+      'perf-test',
+      'ext-test',
+      'prod'
+    ])('should return false when cdpEnvironment is %s', (env) => {
+      config.set('cdpEnvironment', env)
+
+      expect(isLocalEnvironment()).toBe(false)
     })
   })
 

--- a/src/config/config.test.js
+++ b/src/config/config.test.js
@@ -11,30 +11,6 @@ describe('#config', () => {
     vi.resetModules()
   })
 
-  describe('Log redact configuration', () => {
-    test('Should set log redact paths for production environment', async () => {
-      vi.stubEnv('NODE_ENV', 'production')
-      const configModule = await import('./config.js')
-      const config = configModule.config
-
-      const redactPaths = config.get('log.redact')
-      expect(redactPaths).toEqual([
-        'http.request.headers.authorization',
-        'http.request.headers.cookie',
-        'http.response.headers'
-      ])
-    })
-
-    test('Should set log redact paths to empty array for non-production environments', async () => {
-      vi.stubEnv('NODE_ENV', 'test')
-      const configModule = await import('./config.js')
-      const config = configModule.config
-
-      const redactPaths = config.get('log.redact')
-      expect(redactPaths).toEqual([])
-    })
-  })
-
   describe(isProductionEnvironment, () => {
     afterEach(() => {
       config.reset('cdpEnvironment')
@@ -84,6 +60,15 @@ describe('#config', () => {
       config.set('cdpEnvironment', env)
 
       expect(isLocalEnvironment()).toBe(false)
+    })
+  })
+
+  describe('production defaults', () => {
+    it('should default log.format to ecs when NODE_ENV is production', async () => {
+      vi.stubEnv('NODE_ENV', 'production')
+      const configModule = await import('./config.js')
+
+      expect(configModule.config.get('log.format')).toBe('ecs')
     })
   })
 

--- a/src/server/common/helpers/logging/logger-options.js
+++ b/src/server/common/helpers/logging/logger-options.js
@@ -57,9 +57,17 @@ export const loggerOptions = {
       ...(traceId ? { trace: { id: traceId } } : {})
     }
   },
-  redact: {
-    paths: logConfig.redact,
-    remove: true
+  get redact() {
+    return {
+      paths: isProductionEnvironment()
+        ? [
+            'http.request.headers.authorization',
+            'http.request.headers.cookie',
+            'http.response.headers'
+          ]
+        : [],
+      remove: true
+    }
   },
   level: logConfig.level,
   ...formatters[logConfig.format],

--- a/src/server/common/helpers/logging/logger-options.js
+++ b/src/server/common/helpers/logging/logger-options.js
@@ -37,9 +37,13 @@ const formatters = {
   'pino-pretty': { transport: { target: 'pino-pretty' } }
 }
 
+const isAccessLogIgnored = (/** @type {string} */ path) =>
+  path === '/health' || path.startsWith('/public/')
+
 export const loggerOptions = {
   enabled: logConfig.enabled,
-  ignorePaths: ['/health'],
+  ignoreFunc: (_options, /** @type {{ path: string }} */ request) =>
+    isAccessLogIgnored(request.path),
   getChildBindings: (request) => {
     const traceId = request.headers[tracingHeader]
     return {

--- a/src/server/common/helpers/logging/logger-options.js
+++ b/src/server/common/helpers/logging/logger-options.js
@@ -7,7 +7,11 @@ const logConfig = config.get('log')
 const serviceName = config.get('serviceName')
 const serviceVersion = config.get('serviceVersion')
 
-const ecsOptions = ecsFormat({ serviceVersion, serviceName })
+const ecsOptions = ecsFormat({
+  serviceVersion,
+  serviceName,
+  convertReqRes: true
+})
 const ecsLog =
   /** @type {(obj: object) => { error?: { stack_trace?: string } }} */ (
     ecsOptions.formatters?.log
@@ -35,6 +39,15 @@ const formatters = {
 export const loggerOptions = {
   enabled: logConfig.enabled,
   ignorePaths: ['/health'],
+  getChildBindings: (request) => ({
+    http: {
+      request: {
+        id: request.info.id,
+        method: request.method.toUpperCase()
+      }
+    },
+    url: { path: request.path }
+  }),
   redact: {
     paths: logConfig.redact,
     remove: true

--- a/src/server/common/helpers/logging/logger-options.js
+++ b/src/server/common/helpers/logging/logger-options.js
@@ -6,6 +6,7 @@ import { config, isProductionEnvironment } from '#config/config.js'
 const logConfig = config.get('log')
 const serviceName = config.get('serviceName')
 const serviceVersion = config.get('serviceVersion')
+const tracingHeader = config.get('tracing.header')
 
 const ecsOptions = ecsFormat({
   serviceVersion,
@@ -39,15 +40,19 @@ const formatters = {
 export const loggerOptions = {
   enabled: logConfig.enabled,
   ignorePaths: ['/health'],
-  getChildBindings: (request) => ({
-    http: {
-      request: {
-        id: request.info.id,
-        method: request.method.toUpperCase()
-      }
-    },
-    url: { path: request.path }
-  }),
+  getChildBindings: (request) => {
+    const traceId = request.headers[tracingHeader]
+    return {
+      http: {
+        request: {
+          id: request.info.id,
+          method: request.method.toUpperCase()
+        }
+      },
+      url: { path: request.path },
+      ...(traceId ? { trace: { id: traceId } } : {})
+    }
+  },
   redact: {
     paths: logConfig.redact,
     remove: true

--- a/src/server/common/helpers/logging/logger-options.js
+++ b/src/server/common/helpers/logging/logger-options.js
@@ -57,17 +57,9 @@ export const loggerOptions = {
       ...(traceId ? { trace: { id: traceId } } : {})
     }
   },
-  get redact() {
-    return {
-      paths: isProductionEnvironment()
-        ? [
-            'http.request.headers.authorization',
-            'http.request.headers.cookie',
-            'http.response.headers'
-          ]
-        : [],
-      remove: true
-    }
+  redact: {
+    paths: logConfig.redact,
+    remove: true
   },
   level: logConfig.level,
   ...formatters[logConfig.format],

--- a/src/server/common/helpers/logging/request-logger.integration.test.js
+++ b/src/server/common/helpers/logging/request-logger.integration.test.js
@@ -54,6 +54,52 @@ describe('request-logger integration (hapi-pino + pino + ecs format)', () => {
     })
   })
 
+  it('should bind ECS http.* and url.* on the per-request child logger (no flat req)', async () => {
+    config.set('cdpEnvironment', 'dev')
+    const { server, lines } = await newServer()
+    server.route({
+      method: 'GET',
+      path: '/test',
+      handler: (request) => {
+        request.logger.info({ message: 'handler entered' })
+        return 'ok'
+      }
+    })
+
+    await server.inject('/test')
+    const out = findLine(lines, (l) => l.message === 'handler entered')
+
+    expect(out).toMatchObject({
+      http: { request: { method: 'GET' } },
+      url: { path: '/test' }
+    })
+    expect(out.http.request.id).toStrictEqual(expect.any(String))
+    expect(out).not.toHaveProperty('req')
+  })
+
+  it('should emit ECS http.response.* and url.path on the hapi-pino response auto-log', async () => {
+    config.set('cdpEnvironment', 'dev')
+    const { server, lines } = await newServer()
+    server.route({
+      method: 'GET',
+      path: '/test',
+      handler: () => 'ok'
+    })
+
+    await server.inject('/test')
+    const out = findLine(
+      lines,
+      (l) => l.url?.path === '/test' && l.http?.response
+    )
+
+    expect(out).toMatchObject({
+      http: { response: { status_code: 200 } },
+      url: { path: '/test' }
+    })
+    expect(out).not.toHaveProperty('req')
+    expect(out).not.toHaveProperty('res')
+  })
+
   it('should map a logged err to ECS error.* when cdpEnvironment is non-prod', async () => {
     config.set('cdpEnvironment', 'dev')
     const { server, lines } = await newServer()

--- a/src/server/common/helpers/logging/request-logger.integration.test.js
+++ b/src/server/common/helpers/logging/request-logger.integration.test.js
@@ -1,5 +1,5 @@
 import pino from 'pino'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { createLogger } from './logger.js'
 import { loggerOptions } from './logger-options.js'
@@ -168,10 +168,13 @@ describe('request-logger integration (hapi-pino + pino + ecs format)', () => {
     expect(out).toBeUndefined()
   })
 
-  it('should redact authorization, cookie, and response headers in production', async () => {
-    config.set('cdpEnvironment', 'prod')
+  it('should redact authorization, cookie, and response headers when NODE_ENV is production', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.resetModules()
 
-    const { server, lines } = await createLogCaptureServer()
+    const { createLogCaptureServer: createServer } =
+      await import('#server/common/test-helpers/log-capture-server.js')
+    const { server, lines } = await createServer()
     server.route({
       method: 'GET',
       path: '/test',
@@ -192,6 +195,8 @@ describe('request-logger integration (hapi-pino + pino + ecs format)', () => {
     expect(emitted).not.toContain('LEAKED_JWT_TOKEN')
     expect(emitted).not.toContain('LEAKED_SESSION_VALUE')
     expect(emitted).not.toContain('LEAKED_RESPONSE_HEADER')
+
+    vi.unstubAllEnvs()
   })
 
   it('should still emit an access log for non-/public requests', async () => {

--- a/src/server/common/helpers/logging/request-logger.integration.test.js
+++ b/src/server/common/helpers/logging/request-logger.integration.test.js
@@ -168,6 +168,32 @@ describe('request-logger integration (hapi-pino + pino + ecs format)', () => {
     expect(out).toBeUndefined()
   })
 
+  it('should redact authorization, cookie, and response headers in production', async () => {
+    config.set('cdpEnvironment', 'prod')
+
+    const { server, lines } = await createLogCaptureServer()
+    server.route({
+      method: 'GET',
+      path: '/test',
+      handler: (_, h) =>
+        h.response('ok').header('x-redact-test', 'LEAKED_RESPONSE_HEADER')
+    })
+
+    await server.inject({
+      url: '/test',
+      headers: {
+        authorization: 'Bearer LEAKED_JWT_TOKEN',
+        cookie: 'session=LEAKED_SESSION_VALUE'
+      }
+    })
+
+    const emitted = lines.join('\n')
+
+    expect(emitted).not.toContain('LEAKED_JWT_TOKEN')
+    expect(emitted).not.toContain('LEAKED_SESSION_VALUE')
+    expect(emitted).not.toContain('LEAKED_RESPONSE_HEADER')
+  })
+
   it('should still emit an access log for non-/public requests', async () => {
     const { server, findLine } = await createLogCaptureServer()
     server.route({

--- a/src/server/common/helpers/logging/request-logger.integration.test.js
+++ b/src/server/common/helpers/logging/request-logger.integration.test.js
@@ -1,28 +1,10 @@
-import hapi from '@hapi/hapi'
-import hapiPino from 'hapi-pino'
 import pino from 'pino'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { createLogger } from './logger.js'
 import { loggerOptions } from './logger-options.js'
 import { config } from '#config/config.js'
-
-const newServer = async () => {
-  const lines = []
-  const stream = { write: (s) => lines.push(s) }
-  const { transport: _transport, ...rest } = loggerOptions
-
-  const server = hapi.server({ port: 0 })
-  await server.register({
-    plugin: hapiPino,
-    options: { ...rest, enabled: true, level: 'trace', stream }
-  })
-
-  return { server, lines }
-}
-
-const findLine = (lines, predicate) =>
-  lines.map((s) => JSON.parse(s)).find(predicate)
+import { createLogCaptureServer } from '#server/common/test-helpers/log-capture-server.js'
 
 describe('request-logger integration (hapi-pino + pino + ecs format)', () => {
   afterEach(() => {
@@ -31,7 +13,7 @@ describe('request-logger integration (hapi-pino + pino + ecs format)', () => {
 
   it('should emit a canonical IndexedLogProperties payload through hapi-pino unchanged', async () => {
     config.set('cdpEnvironment', 'dev')
-    const { server, lines } = await newServer()
+    const { server, findLine } = await createLogCaptureServer()
     server.route({
       method: 'GET',
       path: '/test',
@@ -45,7 +27,7 @@ describe('request-logger integration (hapi-pino + pino + ecs format)', () => {
     })
 
     await server.inject('/test')
-    const out = findLine(lines, (l) => l.message === 'test event')
+    const out = findLine((l) => l.message === 'test event')
 
     expect(out).toMatchObject({
       message: 'test event',
@@ -56,7 +38,7 @@ describe('request-logger integration (hapi-pino + pino + ecs format)', () => {
 
   it('should bind ECS http.* and url.* on the per-request child logger (no flat req)', async () => {
     config.set('cdpEnvironment', 'dev')
-    const { server, lines } = await newServer()
+    const { server, findLine } = await createLogCaptureServer()
     server.route({
       method: 'GET',
       path: '/test',
@@ -67,7 +49,7 @@ describe('request-logger integration (hapi-pino + pino + ecs format)', () => {
     })
 
     await server.inject('/test')
-    const out = findLine(lines, (l) => l.message === 'handler entered')
+    const out = findLine((l) => l.message === 'handler entered')
 
     expect(out).toMatchObject({
       http: { request: { method: 'GET' } },
@@ -79,7 +61,7 @@ describe('request-logger integration (hapi-pino + pino + ecs format)', () => {
 
   it('should emit ECS http.response.* and url.path on the hapi-pino response auto-log', async () => {
     config.set('cdpEnvironment', 'dev')
-    const { server, lines } = await newServer()
+    const { server, findLine } = await createLogCaptureServer()
     server.route({
       method: 'GET',
       path: '/test',
@@ -87,10 +69,7 @@ describe('request-logger integration (hapi-pino + pino + ecs format)', () => {
     })
 
     await server.inject('/test')
-    const out = findLine(
-      lines,
-      (l) => l.url?.path === '/test' && l.http?.response
-    )
+    const out = findLine((l) => l.url?.path === '/test' && l.http?.response)
 
     expect(out).toMatchObject({
       http: { response: { status_code: 200 } },
@@ -102,7 +81,7 @@ describe('request-logger integration (hapi-pino + pino + ecs format)', () => {
 
   it('should map a logged err to ECS error.* when cdpEnvironment is non-prod', async () => {
     config.set('cdpEnvironment', 'dev')
-    const { server, lines } = await newServer()
+    const { server, findLine } = await createLogCaptureServer()
     server.route({
       method: 'GET',
       path: '/test',
@@ -113,7 +92,7 @@ describe('request-logger integration (hapi-pino + pino + ecs format)', () => {
     })
 
     await server.inject('/test')
-    const out = findLine(lines, (l) => l.message === 'boom path')
+    const out = findLine((l) => l.message === 'boom path')
 
     expect(out?.error).toStrictEqual(
       expect.objectContaining({
@@ -126,7 +105,7 @@ describe('request-logger integration (hapi-pino + pino + ecs format)', () => {
 
   it('should strip error.stack_trace when cdpEnvironment is prod', async () => {
     config.set('cdpEnvironment', 'prod')
-    const { server, lines } = await newServer()
+    const { server, findLine } = await createLogCaptureServer()
     server.route({
       method: 'GET',
       path: '/test',
@@ -137,7 +116,7 @@ describe('request-logger integration (hapi-pino + pino + ecs format)', () => {
     })
 
     await server.inject('/test')
-    const out = findLine(lines, (l) => l.message === 'boom path')
+    const out = findLine((l) => l.message === 'boom path')
 
     expect(out?.error).toBeDefined()
     expect(out?.error).not.toHaveProperty('stack_trace')

--- a/src/server/common/helpers/logging/request-logger.integration.test.js
+++ b/src/server/common/helpers/logging/request-logger.integration.test.js
@@ -149,4 +149,36 @@ describe('request-logger integration (hapi-pino + pino + ecs format)', () => {
       expect(log[method]).toBeTypeOf('function')
     }
   )
+
+  it('should not emit an access log for /public/* requests', async () => {
+    const { server, findLine } = await createLogCaptureServer()
+    server.route({
+      method: 'GET',
+      path: '/public/{path*}',
+      handler: () => 'ok'
+    })
+
+    await server.inject('/public/stylesheets/application.css')
+    const out = findLine(
+      (l) =>
+        l.url?.path === '/public/stylesheets/application.css' &&
+        l.http?.response
+    )
+
+    expect(out).toBeUndefined()
+  })
+
+  it('should still emit an access log for non-/public requests', async () => {
+    const { server, findLine } = await createLogCaptureServer()
+    server.route({
+      method: 'GET',
+      path: '/visible',
+      handler: () => 'ok'
+    })
+
+    await server.inject('/visible')
+    const out = findLine((l) => l.url?.path === '/visible' && l.http?.response)
+
+    expect(out?.http?.response?.status_code).toBe(200)
+  })
 })

--- a/src/server/common/helpers/request-tracing.integration.test.js
+++ b/src/server/common/helpers/request-tracing.integration.test.js
@@ -1,26 +1,16 @@
-import hapi from '@hapi/hapi'
-import hapiPino from 'hapi-pino'
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { loggerOptions } from './logging/logger-options.js'
 import { requestTracing } from './request-tracing.js'
 import { config } from '#config/config.js'
+import { createLogCaptureServer } from '#server/common/test-helpers/log-capture-server.js'
 
 const UUID_V4 =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 const newServer = async () => {
-  const lines = []
-  const stream = { write: (s) => lines.push(s) }
-  const { transport: _transport, ...rest } = loggerOptions
-
-  const server = hapi.server({ port: 0 })
-  await server.register({
-    plugin: hapiPino,
-    options: { ...rest, enabled: true, level: 'trace', stream }
-  })
-  await server.register(requestTracing)
-  server.route({
+  const captured = await createLogCaptureServer()
+  await captured.server.register(requestTracing)
+  captured.server.route({
     method: 'GET',
     path: '/test',
     handler: (request) => {
@@ -28,12 +18,8 @@ const newServer = async () => {
       return 'ok'
     }
   })
-
-  return { server, lines }
+  return captured
 }
-
-const findHandlerLine = (lines) =>
-  lines.map((s) => JSON.parse(s)).find((l) => l.message === 'inside handler')
 
 describe('#request-tracing', () => {
   describe('local trace.id fallback', () => {
@@ -43,48 +29,48 @@ describe('#request-tracing', () => {
 
     it('should mint a uuid trace.id when local and no x-cdp-request-id header is supplied', async () => {
       config.set('cdpEnvironment', 'local')
-      const { server, lines } = await newServer()
+      const { server, findLine } = await newServer()
 
       await server.inject('/test')
-      const out = findHandlerLine(lines)
+      const out = findLine((l) => l.message === 'inside handler')
 
       expect(out?.trace?.id).toMatch(UUID_V4)
     })
 
     it('should not mint a trace.id when not local and no x-cdp-request-id header is supplied', async () => {
       config.set('cdpEnvironment', 'dev')
-      const { server, lines } = await newServer()
+      const { server, findLine } = await newServer()
 
       await server.inject('/test')
-      const out = findHandlerLine(lines)
+      const out = findLine((l) => l.message === 'inside handler')
 
       expect(out).not.toHaveProperty('trace')
     })
 
     it('should pass through an incoming x-cdp-request-id header as trace.id regardless of environment', async () => {
       config.set('cdpEnvironment', 'prod')
-      const { server, lines } = await newServer()
+      const { server, findLine } = await newServer()
 
       await server.inject({
         method: 'GET',
         url: '/test',
         headers: { 'x-cdp-request-id': 'incoming-trace-abc' }
       })
-      const out = findHandlerLine(lines)
+      const out = findLine((l) => l.message === 'inside handler')
 
       expect(out?.trace?.id).toBe('incoming-trace-abc')
     })
 
     it('should not overwrite an incoming x-cdp-request-id header when local', async () => {
       config.set('cdpEnvironment', 'local')
-      const { server, lines } = await newServer()
+      const { server, findLine } = await newServer()
 
       await server.inject({
         method: 'GET',
         url: '/test',
         headers: { 'x-cdp-request-id': 'incoming-trace-xyz' }
       })
-      const out = findHandlerLine(lines)
+      const out = findLine((l) => l.message === 'inside handler')
 
       expect(out?.trace?.id).toBe('incoming-trace-xyz')
     })

--- a/src/server/common/helpers/request-tracing.integration.test.js
+++ b/src/server/common/helpers/request-tracing.integration.test.js
@@ -1,0 +1,92 @@
+import hapi from '@hapi/hapi'
+import hapiPino from 'hapi-pino'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { loggerOptions } from './logging/logger-options.js'
+import { requestTracing } from './request-tracing.js'
+import { config } from '#config/config.js'
+
+const UUID_V4 =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+const newServer = async () => {
+  const lines = []
+  const stream = { write: (s) => lines.push(s) }
+  const { transport: _transport, ...rest } = loggerOptions
+
+  const server = hapi.server({ port: 0 })
+  await server.register({
+    plugin: hapiPino,
+    options: { ...rest, enabled: true, level: 'trace', stream }
+  })
+  await server.register(requestTracing)
+  server.route({
+    method: 'GET',
+    path: '/test',
+    handler: (request) => {
+      request.logger.info({ message: 'inside handler' })
+      return 'ok'
+    }
+  })
+
+  return { server, lines }
+}
+
+const findHandlerLine = (lines) =>
+  lines.map((s) => JSON.parse(s)).find((l) => l.message === 'inside handler')
+
+describe('#request-tracing', () => {
+  describe('local trace.id fallback', () => {
+    afterEach(() => {
+      config.reset('cdpEnvironment')
+    })
+
+    it('should mint a uuid trace.id when local and no x-cdp-request-id header is supplied', async () => {
+      config.set('cdpEnvironment', 'local')
+      const { server, lines } = await newServer()
+
+      await server.inject('/test')
+      const out = findHandlerLine(lines)
+
+      expect(out?.trace?.id).toMatch(UUID_V4)
+    })
+
+    it('should not mint a trace.id when not local and no x-cdp-request-id header is supplied', async () => {
+      config.set('cdpEnvironment', 'dev')
+      const { server, lines } = await newServer()
+
+      await server.inject('/test')
+      const out = findHandlerLine(lines)
+
+      expect(out).not.toHaveProperty('trace')
+    })
+
+    it('should pass through an incoming x-cdp-request-id header as trace.id regardless of environment', async () => {
+      config.set('cdpEnvironment', 'prod')
+      const { server, lines } = await newServer()
+
+      await server.inject({
+        method: 'GET',
+        url: '/test',
+        headers: { 'x-cdp-request-id': 'incoming-trace-abc' }
+      })
+      const out = findHandlerLine(lines)
+
+      expect(out?.trace?.id).toBe('incoming-trace-abc')
+    })
+
+    it('should not overwrite an incoming x-cdp-request-id header when local', async () => {
+      config.set('cdpEnvironment', 'local')
+      const { server, lines } = await newServer()
+
+      await server.inject({
+        method: 'GET',
+        url: '/test',
+        headers: { 'x-cdp-request-id': 'incoming-trace-xyz' }
+      })
+      const out = findHandlerLine(lines)
+
+      expect(out?.trace?.id).toBe('incoming-trace-xyz')
+    })
+  })
+})

--- a/src/server/common/helpers/request-tracing.integration.test.js
+++ b/src/server/common/helpers/request-tracing.integration.test.js
@@ -75,4 +75,38 @@ describe('#request-tracing', () => {
       expect(out?.trace?.id).toBe('incoming-trace-xyz')
     })
   })
+
+  describe('trace.id on auto-emit access logs', () => {
+    afterEach(() => {
+      config.reset('cdpEnvironment')
+    })
+
+    it('should land trace.id on the response auto-log when an incoming header is present', async () => {
+      config.set('cdpEnvironment', 'prod')
+      const { server, findLine } = await newServer()
+
+      await server.inject({
+        method: 'GET',
+        url: '/test',
+        headers: { 'x-cdp-request-id': 'incoming-trace-resp' }
+      })
+      const out = findLine((l) => l.url?.path === '/test' && l.http?.response)
+
+      expect(out?.trace?.id).toBe('incoming-trace-resp')
+    })
+
+    it('should share the same trace.id across handler and response logs', async () => {
+      config.set('cdpEnvironment', 'local')
+      const { server, findLine } = await newServer()
+
+      await server.inject('/test')
+      const handler = findLine((l) => l.message === 'inside handler')
+      const response = findLine(
+        (l) => l.url?.path === '/test' && l.http?.response
+      )
+
+      expect(handler?.trace?.id).toMatch(UUID_V4)
+      expect(response?.trace?.id).toBe(handler?.trace?.id)
+    })
+  })
 })

--- a/src/server/common/helpers/request-tracing.js
+++ b/src/server/common/helpers/request-tracing.js
@@ -21,12 +21,16 @@ const localTraceIdFallback = {
    * @param {TracingOptions} options
    */
   register: (server, { tracingHeader }) => {
-    server.ext('onRequest', (request, h) => {
-      if (!request.headers[tracingHeader]) {
-        request.headers[tracingHeader] = randomUUID()
-      }
-      return h.continue
-    })
+    server.ext(
+      'onRequest',
+      (request, h) => {
+        if (!request.headers[tracingHeader]) {
+          request.headers[tracingHeader] = randomUUID()
+        }
+        return h.continue
+      },
+      { before: 'hapi-pino' }
+    )
   }
 }
 

--- a/src/server/common/helpers/request-tracing.js
+++ b/src/server/common/helpers/request-tracing.js
@@ -1,10 +1,48 @@
+import { randomUUID } from 'node:crypto'
+
 import { tracing } from '@defra/hapi-tracing'
 
-import { config } from '#config/config.js'
+import { config, isLocalEnvironment } from '#config/config.js'
+
+/**
+ * @import { Server } from '@hapi/hapi'
+ */
+
+/**
+ * @typedef {{ tracingHeader: string }} TracingOptions
+ */
 
 export const getTracingHeaderName = () => config.get('tracing.header')
 
+const localTraceIdFallback = {
+  name: 'local-trace-id-fallback',
+  /**
+   * @param {Server} server
+   * @param {TracingOptions} options
+   */
+  register: (server, { tracingHeader }) => {
+    server.ext('onRequest', (request, h) => {
+      if (!request.headers[tracingHeader]) {
+        request.headers[tracingHeader] = randomUUID()
+      }
+      return h.continue
+    })
+  }
+}
+
 export const requestTracing = {
-  plugin: tracing.plugin,
+  plugin: {
+    name: 'request-tracing',
+    /**
+     * @param {Server} server
+     * @param {TracingOptions} options
+     */
+    register: async (server, options) => {
+      if (isLocalEnvironment()) {
+        await server.register({ plugin: localTraceIdFallback, options })
+      }
+      await server.register({ plugin: tracing.plugin, options })
+    }
+  },
   options: { tracingHeader: getTracingHeaderName() }
 }

--- a/src/server/common/helpers/useragent-protection.integration.test.js
+++ b/src/server/common/helpers/useragent-protection.integration.test.js
@@ -1,0 +1,68 @@
+import hapi from '@hapi/hapi'
+import hapiPino from 'hapi-pino'
+import { describe, expect, it } from 'vitest'
+
+import { loggerOptions } from './logging/logger-options.js'
+import { userAgentProtection } from './useragent-protection.js'
+
+const newServer = async () => {
+  const lines = []
+  const stream = { write: (s) => lines.push(s) }
+  const { transport: _transport, ...rest } = loggerOptions
+
+  const server = hapi.server({ port: 0 })
+  await server.register({
+    plugin: hapiPino,
+    options: { ...rest, enabled: true, level: 'trace', stream }
+  })
+  await server.register(userAgentProtection)
+  server.route({
+    method: 'GET',
+    path: '/test',
+    options: { auth: false },
+    handler: () => 'ok'
+  })
+
+  return { server, lines }
+}
+
+const findLine = (lines, predicate) =>
+  lines.map((s) => JSON.parse(s)).find(predicate)
+
+describe('userAgentProtection logging', () => {
+  it('should emit an ECS-shaped warn line when User-Agent is truncated', async () => {
+    const { server, lines } = await newServer()
+
+    await server.inject({
+      method: 'GET',
+      url: '/test',
+      headers: { 'user-agent': `Mozilla/5.0 ${'X'.repeat(2000)}` }
+    })
+    const out = findLine(lines, (l) => l.message === 'Truncated User-Agent')
+
+    expect(out).toMatchObject({
+      'log.level': 'warn',
+      message: 'Truncated User-Agent',
+      event: {
+        action: 'user_agent_truncated',
+        category: 'security',
+        reason: 'from=2012 to=150'
+      }
+    })
+  })
+
+  it('should not emit a truncation warning when User-Agent is within limit', async () => {
+    const { server, lines } = await newServer()
+
+    await server.inject({
+      method: 'GET',
+      url: '/test',
+      headers: { 'user-agent': 'Mozilla/5.0' }
+    })
+    const out = findLine(lines, (l) =>
+      l.message?.startsWith('Truncated User-Agent')
+    )
+
+    expect(out).toBeUndefined()
+  })
+})

--- a/src/server/common/helpers/useragent-protection.js
+++ b/src/server/common/helpers/useragent-protection.js
@@ -14,15 +14,18 @@ export const userAgentProtection = {
       const userAgent = request.headers['user-agent']
 
       if (userAgent && userAgent.length > MAX_USER_AGENT_LENGTH) {
-        // Truncate the User-Agent header to prevent ReDoS attacks
         request.headers['user-agent'] = userAgent.substring(
           0,
           MAX_USER_AGENT_LENGTH
         )
-        server.log(
-          ['security', 'user-agent'],
-          `Truncated User-Agent from ${userAgent.length} to ${MAX_USER_AGENT_LENGTH} chars`
-        )
+        server.logger.warn({
+          message: 'Truncated User-Agent',
+          event: {
+            action: 'user_agent_truncated',
+            category: 'security',
+            reason: `from=${userAgent.length} to=${MAX_USER_AGENT_LENGTH}`
+          }
+        })
       }
 
       return h.continue

--- a/src/server/common/helpers/useragent-protection.test.js
+++ b/src/server/common/helpers/useragent-protection.test.js
@@ -34,66 +34,6 @@ describe('user-agent protection', () => {
     expect(response.statusCode).toBe(httpConstants.HTTP_STATUS_OK)
   })
 
-  test('should truncate oversized User-Agent strings', async () => {
-    const longUserAgent = `Mozilla/5.0 ${'X'.repeat(2000)}`
-    const expectedTruncated = longUserAgent.substring(0, MAX_USER_AGENT_LENGTH)
-
-    const response = await server.inject({
-      method: 'GET',
-      url: '/',
-      headers: {
-        'user-agent': longUserAgent
-      }
-    })
-
-    expect(response.statusCode).toBe(httpConstants.HTTP_STATUS_OK)
-    expect(longUserAgent.length).toBeGreaterThan(MAX_USER_AGENT_LENGTH)
-    expect(expectedTruncated).toHaveLength(MAX_USER_AGENT_LENGTH)
-    expect(expectedTruncated).toBe(`Mozilla/5.0 ${'X'.repeat(138)}`)
-  })
-
-  test('should truncate User-Agent strings with suspicious patterns (ReDoS PoC)', async () => {
-    const maliciousUserAgent = `Mozilla/5.0 (${'X'.repeat(200)}) Gecko/20100101 Firefox/77.0`
-    const expectedTruncated = maliciousUserAgent.substring(
-      0,
-      MAX_USER_AGENT_LENGTH
-    )
-
-    const response = await server.inject({
-      method: 'GET',
-      url: '/',
-      headers: {
-        'user-agent': maliciousUserAgent
-      }
-    })
-
-    expect(response.statusCode).toBe(httpConstants.HTTP_STATUS_OK)
-    expect(maliciousUserAgent.length).toBeGreaterThan(MAX_USER_AGENT_LENGTH)
-    expect(expectedTruncated).toHaveLength(MAX_USER_AGENT_LENGTH)
-    expect(expectedTruncated.startsWith('Mozilla/5.0 (')).toBe(true)
-  })
-
-  test('should truncate User-Agent strings with repeated characters', async () => {
-    const maliciousUserAgent = `Mozilla/5.0 ${'A'.repeat(1500)} Safari`
-    const expectedTruncated = maliciousUserAgent.substring(
-      0,
-      MAX_USER_AGENT_LENGTH
-    )
-
-    const response = await server.inject({
-      method: 'GET',
-      url: '/',
-      headers: {
-        'user-agent': maliciousUserAgent
-      }
-    })
-
-    expect(response.statusCode).toBe(httpConstants.HTTP_STATUS_OK)
-    expect(maliciousUserAgent.length).toBeGreaterThan(MAX_USER_AGENT_LENGTH)
-    expect(expectedTruncated).toHaveLength(MAX_USER_AGENT_LENGTH)
-    expect(expectedTruncated).toBe(`Mozilla/5.0 ${'A'.repeat(138)}`)
-  })
-
   test('should handle requests without User-Agent header', async () => {
     const response = await server.inject({
       method: 'GET',

--- a/src/server/common/test-helpers/log-capture-server.js
+++ b/src/server/common/test-helpers/log-capture-server.js
@@ -1,0 +1,38 @@
+import hapi from '@hapi/hapi'
+import hapiPino from 'hapi-pino'
+
+import { loggerOptions } from '#server/common/helpers/logging/logger-options.js'
+
+/**
+ * @import { Server } from '@hapi/hapi'
+ */
+
+/**
+ * @typedef {Record<string, any>} LogLine
+ *
+ * @typedef {object} LogCaptureServer
+ * @property {Server} server - Hapi server with a capture stream attached to hapi-pino
+ * @property {string[]} lines - Raw JSON log lines emitted by hapi-pino
+ * @property {(predicate: (line: LogLine) => boolean) => LogLine | undefined} findLine - Locate a parsed log line by predicate
+ */
+
+/**
+ * @returns {Promise<LogCaptureServer>}
+ */
+export const createLogCaptureServer = async () => {
+  const lines = []
+  const stream = { write: (s) => lines.push(s) }
+  const { transport: _transport, ...rest } = loggerOptions
+
+  const server = hapi.server({ port: 0 })
+  await server.register({
+    plugin: hapiPino,
+    options: { ...rest, enabled: true, level: 'trace', stream }
+  })
+
+  return {
+    server,
+    lines,
+    findLine: (predicate) => lines.map((s) => JSON.parse(s)).find(predicate)
+  }
+}

--- a/src/server/common/test-helpers/log-capture-server.js
+++ b/src/server/common/test-helpers/log-capture-server.js
@@ -8,8 +8,20 @@ import { loggerOptions } from '#server/common/helpers/logging/logger-options.js'
  */
 
 /**
- * @typedef {Record<string, any>} LogLine
- *
+ * @typedef {{
+ *   message?: string,
+ *   ['log.level']?: string,
+ *   ['service.name']?: string,
+ *   ['@timestamp']?: string,
+ *   trace?: { id?: string },
+ *   url?: { path?: string, full?: string },
+ *   http?: {
+ *     request?: { id?: string, method?: string },
+ *     response?: { status_code?: number, body?: { bytes?: number } }
+ *   },
+ *   error?: { type?: string, message?: string, stack_trace?: string, code?: string },
+ *   event?: { category?: string, action?: string, kind?: string, outcome?: string }
+ * }} LogLine
  * @typedef {object} LogCaptureServer
  * @property {Server} server - Hapi server with a capture stream attached to hapi-pino
  * @property {string[]} lines - Raw JSON log lines emitted by hapi-pino
@@ -20,8 +32,9 @@ import { loggerOptions } from '#server/common/helpers/logging/logger-options.js'
  * @returns {Promise<LogCaptureServer>}
  */
 export const createLogCaptureServer = async () => {
+  /** @type {string[]} */
   const lines = []
-  const stream = { write: (s) => lines.push(s) }
+  const stream = { write: (/** @type {string} */ s) => lines.push(s) }
   const { transport: _transport, ...rest } = loggerOptions
 
   const server = hapi.server({ port: 0 })


### PR DESCRIPTION
Ticket: [PAE-1412](https://eaflood.atlassian.net/browse/PAE-1412)
## Summary
- mints a uuid v4 `x-cdp-request-id` header at the front of the request lifecycle when `cdpEnvironment === 'local'` and the inbound request lacks the header
- gated at register time so the extension is not registered at all in non-local environments (no per-request env check)
- existing `withTraceId` propagation now carries the minted id through fe -> be (verified locally; same `trace.id` lands on logs across services)
- adds `isLocalEnvironment()` helper alongside the existing `isProductionEnvironment()` in config

## Test plan
- [x] integration tests cover: local mints uuid; non-local does not mint; incoming header passes through in any env; local does not overwrite an incoming header
- [x] unit tests added for `isLocalEnvironment`
- [x] verified end-to-end via journey-test sanity slice on the followups stack: 244 unique trace.ids minted, 29 propagate fe -> be in handler logs

[PAE-1412]: https://eaflood.atlassian.net/browse/PAE-1412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ