### PR TITLE
PAE-1443/1444: Waste records export — admin tab and download page

### DIFF
--- a/src/config/nunjucks/context/build-navigation.js
+++ b/src/config/nunjucks/context/build-navigation.js
@@ -10,6 +10,7 @@ const navItems = [
   { text: 'PRN activity', href: '/prn-activity' },
   { text: 'PRN tonnage', href: '/prn-tonnage' },
   { text: 'Report submissions', href: '/report-submissions' },
+  { text: 'Waste records export', href: '/waste-records-export' },
   { text: 'System logs', href: '/system-logs' },
   { text: 'Queue management', href: '/queue-management', matchSubPaths: true }
 ]

--- a/src/config/nunjucks/context/build-navigation.test.js
+++ b/src/config/nunjucks/context/build-navigation.test.js
@@ -66,6 +66,11 @@ describe('#buildNavigation', () => {
       },
       {
         current: false,
+        text: 'Waste records export',
+        href: '/waste-records-export'
+      },
+      {
+        current: false,
         text: 'System logs',
         href: '/system-logs'
       },
@@ -136,6 +141,11 @@ describe('#buildNavigation', () => {
       },
       {
         current: false,
+        text: 'Waste records export',
+        href: '/waste-records-export'
+      },
+      {
+        current: false,
         text: 'System logs',
         href: '/system-logs'
       },
@@ -163,18 +173,22 @@ describe('#buildNavigation', () => {
     )
   })
 
-  test('Should place report submissions before system logs', () => {
+  test('Should place report submissions before waste records export before system logs', () => {
     const navigation = buildNavigation(
       mockRequest({ path: '/non-existent-path' })
     )
     const reportSubmissionsIndex = navigation.findIndex(
       (item) => item.text === 'Report submissions'
     )
+    const wasteRecordsExportIndex = navigation.findIndex(
+      (item) => item.text === 'Waste records export'
+    )
     const systemLogsIndex = navigation.findIndex(
       (item) => item.text === 'System logs'
     )
 
-    expect(reportSubmissionsIndex).toBe(systemLogsIndex - 1)
+    expect(wasteRecordsExportIndex).toBe(reportSubmissionsIndex + 1)
+    expect(systemLogsIndex).toBe(wasteRecordsExportIndex + 1)
   })
 
   test('Should place overseas sites after summary log uploads', () => {

--- a/src/config/nunjucks/context/context.test.js
+++ b/src/config/nunjucks/context/context.test.js
@@ -115,6 +115,11 @@ describe('context and cache', () => {
             },
             {
               current: false,
+              text: 'Waste records export',
+              href: '/waste-records-export'
+            },
+            {
+              current: false,
               text: 'System logs',
               href: '/system-logs'
             },
@@ -303,6 +308,11 @@ describe('context and cache', () => {
               current: false,
               text: 'Report submissions',
               href: '/report-submissions'
+            },
+            {
+              current: false,
+              text: 'Waste records export',
+              href: '/waste-records-export'
             },
             {
               current: false,

--- a/src/server/common/helpers/fetch-json-from-backend.js
+++ b/src/server/common/helpers/fetch-json-from-backend.js
@@ -66,7 +66,8 @@ export const fetchJsonFromBackend = async (request, path, options) => {
         event: {
           action: 'external_fetch',
           reason: classifierTail(error)
-        }
+        },
+        cause: error
       }
     )
   }

--- a/src/server/common/helpers/fetch-redirect-from-backend.js
+++ b/src/server/common/helpers/fetch-redirect-from-backend.js
@@ -54,7 +54,8 @@ export const fetchRedirectFromBackend = async (request, path) => {
         event: {
           action: 'external_fetch',
           reason: classifierTail(error)
-        }
+        },
+        cause: error
       }
     )
   }

--- a/src/server/common/helpers/logging/cdp-boom.js
+++ b/src/server/common/helpers/logging/cdp-boom.js
@@ -6,26 +6,30 @@ import Boom from '@hapi/boom'
  *
  * @typedef {Pick<NonNullable<CdpIndexedLog['event']>, 'action' | 'reason' | 'reference'>} CdpBoomEvent
  * @typedef {BoomError & { code?: string, event?: CdpBoomEvent }} CdpBoom
- * @typedef {{ event: CdpBoomEvent, payload?: Record<string, unknown> }} CdpBoomEnrichment
+ * @typedef {{ event: CdpBoomEvent, payload?: Record<string, unknown>, cause?: unknown }} CdpBoomEnrichment
  */
 
 /**
  * Attaches CDP-indexed log enrichment fields (`code` + `event`) to a Boom
- * error and optionally merges `payload` into the response body. Mutates and
- * returns the boom so call sites read as
- * `throw badRequest('msg', 'code', { event, payload })`.
+ * error, optionally merges `payload` into the response body, and optionally
+ * chains the underlying error via the standard `Error.cause` so Pino's
+ * `err` serializer surfaces it in CDP logs. Mutates and returns the boom so
+ * call sites read as `throw badRequest('msg', 'code', { event, payload, cause })`.
  *
  * @param {BoomError} boom
  * @param {string} code
  * @param {CdpBoomEnrichment} enrichment
  * @returns {CdpBoom}
  */
-const enrich = (boom, code, { event, payload }) => {
+const enrich = (boom, code, { event, payload, cause }) => {
   const enriched = /** @type {CdpBoom} */ (boom)
   enriched.code = code
   enriched.event = event
   if (payload) {
     enriched.output.payload = { ...enriched.output.payload, ...payload }
+  }
+  if (cause !== undefined) {
+    enriched.cause = cause
   }
   return enriched
 }

--- a/src/server/common/helpers/logging/cdp-boom.test.js
+++ b/src/server/common/helpers/logging/cdp-boom.test.js
@@ -56,5 +56,28 @@ describe('cdp-boom', () => {
 
       expect(boom.output.payload).toMatchObject({ detail: { id: 'x' } })
     })
+
+    it('attaches the underlying error to .cause when provided so it surfaces in pino err logs', () => {
+      const underlying = Object.assign(new TypeError('network down'), {
+        code: 'UND_ERR_SOCKET'
+      })
+      const boom = internal('wrapper message', 'a_code', {
+        event: {
+          action: 'external_fetch',
+          reason: 'type=TypeError code=UND_ERR_SOCKET'
+        },
+        cause: underlying
+      })
+
+      expect(boom.cause).toBe(underlying)
+    })
+
+    it('omits the cause property when not provided so existing call sites are unaffected', () => {
+      const boom = internal('msg', 'a_code', {
+        event: { action: 'an_action', reason: 'a_reason' }
+      })
+
+      expect('cause' in boom).toBe(false)
+    })
   })
 })

--- a/src/server/common/helpers/stream-from-backend.js
+++ b/src/server/common/helpers/stream-from-backend.js
@@ -57,7 +57,8 @@ export const streamFromBackend = async (request, path, options) => {
       `Failed to stream from backend at url: ${url}`,
       errorCodes.externalFetchFailed,
       {
-        event: { action: 'external_fetch', reason: classifierTail(error) }
+        event: { action: 'external_fetch', reason: classifierTail(error) },
+        cause: error
       }
     )
   }

--- a/src/server/common/helpers/stream-from-backend.js
+++ b/src/server/common/helpers/stream-from-backend.js
@@ -1,0 +1,62 @@
+import Boom from '@hapi/boom'
+import { config } from '#config/config.js'
+import { errorCodes } from '#server/common/enums/error-codes.js'
+import { classifierTail, internal } from './logging/cdp-boom.js'
+import { getUserSession } from './auth/get-user-session.js'
+import { withTraceId } from '@defra/hapi-tracing'
+import { getTracingHeaderName } from './request-tracing.js'
+
+/**
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ */
+
+/**
+ * Streaming counterpart to fetchJsonFromBackend — returns the raw fetch
+ * Response so the caller can pass `response.body` straight through to
+ * `h.response(body)` for chunked download proxying.
+ *
+ * @param {HapiRequest} request
+ * @param {string} path
+ * @param {RequestInit} [options]
+ * @returns {Promise<Response>}
+ */
+export const streamFromBackend = async (request, path, options) => {
+  const eprBackendUrl = config.get('eprBackendUrl')
+  const userSession = await getUserSession(request)
+
+  const completeOptions = {
+    ...options,
+    headers: withTraceId(getTracingHeaderName(), {
+      ...options?.headers,
+      Authorization: `Bearer ${userSession?.token}`,
+      Accept: 'text/csv'
+    })
+  }
+
+  const url = `${eprBackendUrl}${path}`
+
+  try {
+    const response = await fetch(url, completeOptions)
+
+    if (!response.ok) {
+      throw Boom.boomify(
+        new Error(
+          `Failed to stream from backend at url: ${url}: ${response.status} ${response.statusText}`
+        ),
+        { statusCode: response.status }
+      )
+    }
+
+    return response
+  } catch (error) {
+    if (error.isBoom) throw error
+
+    throw internal(
+      `Failed to stream from backend at url: ${url}`,
+      errorCodes.externalFetchFailed,
+      {
+        event: { action: 'external_fetch', reason: classifierTail(error) }
+      }
+    )
+  }
+}

--- a/src/server/common/helpers/stream-from-backend.js
+++ b/src/server/common/helpers/stream-from-backend.js
@@ -49,7 +49,9 @@ export const streamFromBackend = async (request, path, options) => {
 
     return response
   } catch (error) {
-    if (error.isBoom) throw error
+    if (error.isBoom) {
+      throw error
+    }
 
     throw internal(
       `Failed to stream from backend at url: ${url}`,

--- a/src/server/common/helpers/stream-from-backend.test.js
+++ b/src/server/common/helpers/stream-from-backend.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { streamFromBackend } from './stream-from-backend.js'
+
+const { mockUserSession, mockConfigGet } = vi.hoisted(() => ({
+  mockUserSession: vi.fn(),
+  mockConfigGet: vi.fn()
+}))
+
+vi.mock('./auth/get-user-session.js', () => ({
+  getUserSession: (req) => mockUserSession(req)
+}))
+
+vi.mock('#config/config.js', () => ({
+  config: { get: (k) => mockConfigGet(k) }
+}))
+
+const fetchSpy = vi.fn()
+beforeEach(() => {
+  globalThis.fetch = fetchSpy
+  mockConfigGet.mockImplementation((k) =>
+    k === 'eprBackendUrl' ? 'http://backend' : ''
+  )
+  mockUserSession.mockResolvedValue({ token: 'abc' })
+})
+afterEach(() => {
+  fetchSpy.mockReset()
+})
+
+describe('streamFromBackend', () => {
+  it('returns the response body and headers when status is 2xx', async () => {
+    const body = new ReadableStream({
+      start(c) {
+        c.enqueue(new Uint8Array([0x68, 0x69]))
+        c.close()
+      }
+    })
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({
+        'content-type': 'text/csv',
+        'content-disposition': 'attachment; filename="x.csv"'
+      }),
+      body
+    })
+
+    const result = await streamFromBackend({ yar: {} }, '/x')
+    expect(result.status).toBe(200)
+    expect(result.headers.get('content-type')).toBe('text/csv')
+    expect(result.body).toBe(body)
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://backend/x',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer abc' })
+      })
+    )
+  })
+
+  it('throws a Boom error when the response is not ok', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+      headers: new Headers({}),
+      body: null
+    })
+
+    await expect(streamFromBackend({ yar: {} }, '/x')).rejects.toMatchObject({
+      isBoom: true,
+      output: { statusCode: 503 }
+    })
+  })
+
+  it('throws an internal error if fetch itself rejects', async () => {
+    fetchSpy.mockRejectedValue(new Error('network down'))
+    await expect(streamFromBackend({ yar: {} }, '/x')).rejects.toMatchObject({
+      isBoom: true
+    })
+  })
+})

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -19,6 +19,7 @@ import { prnActivity } from './routes/prn-activity/index.js'
 import { summaryLogUploadsReport } from './routes/summary-log/index.js'
 import { orsUpload } from './routes/ors-upload/index.js'
 import { reportSubmissions } from './routes/report-submissions/index.js'
+import { wasteRecordsExport } from './routes/waste-records-export/index.js'
 import { queueManagement } from './routes/queue-management/index.js'
 import { reportUnsubmit } from './routes/report-unsubmit/index.js'
 
@@ -53,6 +54,7 @@ export const router = {
         summaryLogUploadsReport,
         orsUpload,
         reportSubmissions,
+        wasteRecordsExport,
         queueManagement,
         reportUnsubmit
       ])

--- a/src/server/routes/waste-records-export/controller.get.js
+++ b/src/server/routes/waste-records-export/controller.get.js
@@ -1,0 +1,11 @@
+export const wasteRecordsExportGetController = {
+  async handler(request, h) {
+    const error = request.yar.get('error')
+    await request.yar.clear('error')
+
+    return h.view('routes/waste-records-export/index', {
+      pageTitle: 'Waste records export',
+      error
+    })
+  }
+}

--- a/src/server/routes/waste-records-export/controller.get.test.js
+++ b/src/server/routes/waste-records-export/controller.get.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { wasteRecordsExportGetController } from './controller.get.js'
+
+describe('wasteRecordsExportGetController', () => {
+  it('renders the index view with pageTitle and any flash error', async () => {
+    const view = vi.fn()
+    const yarGet = vi.fn().mockReturnValue('Something failed')
+    const yarClear = vi.fn()
+    const request = { yar: { get: yarGet, clear: yarClear } }
+    const h = { view }
+
+    await wasteRecordsExportGetController.handler(request, h)
+
+    expect(yarGet).toHaveBeenCalledWith('error')
+    expect(yarClear).toHaveBeenCalledWith('error')
+    expect(view).toHaveBeenCalledWith('routes/waste-records-export/index', {
+      pageTitle: 'Waste records export',
+      error: 'Something failed'
+    })
+  })
+
+  it('renders without error when none was flashed', async () => {
+    const view = vi.fn()
+    const request = {
+      yar: { get: vi.fn().mockReturnValue(undefined), clear: vi.fn() }
+    }
+    const h = { view }
+
+    await wasteRecordsExportGetController.handler(request, h)
+
+    expect(view).toHaveBeenCalledWith('routes/waste-records-export/index', {
+      pageTitle: 'Waste records export',
+      error: undefined
+    })
+  })
+})

--- a/src/server/routes/waste-records-export/controller.post.js
+++ b/src/server/routes/waste-records-export/controller.post.js
@@ -1,3 +1,5 @@
+import { Readable } from 'node:stream'
+
 import { streamFromBackend } from '#server/common/helpers/stream-from-backend.js'
 import { createLogger } from '#server/common/helpers/logging/logger.js'
 
@@ -11,8 +13,12 @@ export const wasteRecordsExportPostController = {
         '/v1/admin/waste-records/export.csv'
       )
 
+      // `response.body` from the Fetch API is a Web ReadableStream. Hapi only
+      // understands strings, Buffers, and Node Readable streams — given a Web
+      // stream it serialises the object, which produces `{}` instead of the
+      // CSV payload. Adapt to a Node Readable so Hapi proxies the chunks.
       return h
-        .response(response.body)
+        .response(Readable.fromWeb(response.body))
         .type(response.headers.get('content-type') ?? 'text/csv; charset=utf-8')
         .header(
           'Content-Disposition',

--- a/src/server/routes/waste-records-export/controller.post.js
+++ b/src/server/routes/waste-records-export/controller.post.js
@@ -1,0 +1,36 @@
+import { streamFromBackend } from '#server/common/helpers/stream-from-backend.js'
+import { createLogger } from '#server/common/helpers/logging/logger.js'
+
+const logger = createLogger()
+
+export const wasteRecordsExportPostController = {
+  async handler(request, h) {
+    try {
+      const response = await streamFromBackend(
+        request,
+        '/v1/admin/waste-records/export.csv'
+      )
+
+      return h
+        .response(response.body)
+        .type(response.headers.get('content-type') ?? 'text/csv; charset=utf-8')
+        .header(
+          'Content-Disposition',
+          response.headers.get('content-disposition') ??
+            'attachment; filename="waste-records.csv"'
+        )
+    } catch (error) {
+      logger.error({
+        message: 'Failed to stream waste records export',
+        err: error
+      })
+
+      const errorMessage =
+        error.output?.payload?.message ||
+        'There was a problem downloading the waste records export. Please try again.'
+
+      request.yar.set('error', errorMessage)
+      return h.redirect('/waste-records-export')
+    }
+  }
+}

--- a/src/server/routes/waste-records-export/controller.post.js
+++ b/src/server/routes/waste-records-export/controller.post.js
@@ -3,6 +3,8 @@ import { Readable } from 'node:stream'
 import { streamFromBackend } from '#server/common/helpers/stream-from-backend.js'
 import { createLogger } from '#server/common/helpers/logging/logger.js'
 
+/** @import { ReadableStream as WebReadableStream } from 'node:stream/web' */
+
 const logger = createLogger()
 
 export const wasteRecordsExportPostController = {
@@ -13,12 +15,24 @@ export const wasteRecordsExportPostController = {
         '/v1/admin/waste-records/export.csv'
       )
 
+      if (!response.body) {
+        throw new Error(
+          'Backend returned a successful response with no body for waste-records export'
+        )
+      }
+
       // `response.body` from the Fetch API is a Web ReadableStream. Hapi only
       // understands strings, Buffers, and Node Readable streams — given a Web
       // stream it serialises the object, which produces `{}` instead of the
       // CSV payload. Adapt to a Node Readable so Hapi proxies the chunks.
+      // The cast works around an upstream `@types/node` mismatch between the
+      // Web `ReadableStream<Uint8Array<ArrayBuffer>>` and the older signature
+      // `Readable.fromWeb` expects.
+      const body = /** @type {WebReadableStream} */ (
+        /** @type {unknown} */ (response.body)
+      )
       return h
-        .response(Readable.fromWeb(response.body))
+        .response(Readable.fromWeb(body))
         .type(response.headers.get('content-type') ?? 'text/csv; charset=utf-8')
         .header(
           'Content-Disposition',

--- a/src/server/routes/waste-records-export/controller.post.test.js
+++ b/src/server/routes/waste-records-export/controller.post.test.js
@@ -1,3 +1,5 @@
+import { Readable } from 'node:stream'
+
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 
 import { wasteRecordsExportPostController } from './controller.post.js'
@@ -6,6 +8,24 @@ import { streamFromBackend } from '#server/common/helpers/stream-from-backend.js
 vi.mock('#server/common/helpers/stream-from-backend.js', () => ({
   streamFromBackend: vi.fn()
 }))
+
+const buildWebStream = (chunks) =>
+  new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(new TextEncoder().encode(chunk))
+      }
+      controller.close()
+    }
+  })
+
+const collectNodeStream = (stream) =>
+  new Promise((resolve, reject) => {
+    const parts = []
+    stream.on('data', (c) => parts.push(c))
+    stream.on('end', () => resolve(Buffer.concat(parts).toString('utf-8')))
+    stream.on('error', reject)
+  })
 
 const { mockLoggerError } = vi.hoisted(() => ({ mockLoggerError: vi.fn() }))
 vi.mock('#server/common/helpers/logging/logger.js', () => ({
@@ -34,10 +54,9 @@ describe('wasteRecordsExportPostController', () => {
     return { h, responseBuilder, calls }
   }
 
-  it('proxies the backend response body and copies content-type/disposition headers', async () => {
-    const fakeBody = {}
+  it('converts the backend Web ReadableStream to a Node Readable and preserves the CSV chunks', async () => {
     streamFromBackend.mockResolvedValue({
-      body: fakeBody,
+      body: buildWebStream(['header1,header2\n', 'a,b\n', 'c,d\n']),
       headers: new Headers({
         'content-type': 'text/csv; charset=utf-8',
         'content-disposition':
@@ -54,7 +73,13 @@ describe('wasteRecordsExportPostController', () => {
       request,
       '/v1/admin/waste-records/export.csv'
     )
-    expect(h.response).toHaveBeenCalledWith(fakeBody)
+
+    const passedBody = h.response.mock.calls[0][0]
+    expect(passedBody).toBeInstanceOf(Readable)
+    expect(await collectNodeStream(passedBody)).toBe(
+      'header1,header2\na,b\nc,d\n'
+    )
+
     expect(calls.type).toEqual([['text/csv; charset=utf-8']])
     expect(calls.header).toEqual([
       [
@@ -66,7 +91,7 @@ describe('wasteRecordsExportPostController', () => {
 
   it('falls back to default content-type and disposition when backend headers are missing', async () => {
     streamFromBackend.mockResolvedValue({
-      body: {},
+      body: buildWebStream([]),
       headers: new Headers({})
     })
 

--- a/src/server/routes/waste-records-export/controller.post.test.js
+++ b/src/server/routes/waste-records-export/controller.post.test.js
@@ -138,4 +138,23 @@ describe('wasteRecordsExportPostController', () => {
 
     expect(yarSet).toHaveBeenCalledWith('error', 'Backend exploded')
   })
+
+  it('logs and redirects with a flash error when the backend response has no body', async () => {
+    streamFromBackend.mockResolvedValue({ body: null, headers: new Headers() })
+
+    const { h } = buildHapiH()
+    const yarSet = vi.fn()
+    const request = { yar: { set: yarSet } }
+
+    const result = await wasteRecordsExportPostController.handler(request, h)
+
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Failed to stream waste records export'
+      })
+    )
+    expect(yarSet).toHaveBeenCalledWith('error', expect.any(String))
+    expect(h.redirect).toHaveBeenCalledWith('/waste-records-export')
+    expect(result).toBe('redirect-response')
+  })
 })

--- a/src/server/routes/waste-records-export/controller.post.test.js
+++ b/src/server/routes/waste-records-export/controller.post.test.js
@@ -1,0 +1,116 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+import { wasteRecordsExportPostController } from './controller.post.js'
+import { streamFromBackend } from '#server/common/helpers/stream-from-backend.js'
+
+vi.mock('#server/common/helpers/stream-from-backend.js', () => ({
+  streamFromBackend: vi.fn()
+}))
+
+const { mockLoggerError } = vi.hoisted(() => ({ mockLoggerError: vi.fn() }))
+vi.mock('#server/common/helpers/logging/logger.js', () => ({
+  createLogger: () => ({ error: mockLoggerError })
+}))
+
+describe('wasteRecordsExportPostController', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  const buildHapiH = () => {
+    const calls = { type: [], header: [] }
+    const responseBuilder = {
+      type: vi.fn(function (...args) {
+        calls.type.push(args)
+        return this
+      }),
+      header: vi.fn(function (...args) {
+        calls.header.push(args)
+        return this
+      })
+    }
+    const h = {
+      response: vi.fn(() => responseBuilder),
+      redirect: vi.fn().mockReturnValue('redirect-response')
+    }
+    return { h, responseBuilder, calls }
+  }
+
+  it('proxies the backend response body and copies content-type/disposition headers', async () => {
+    const fakeBody = {}
+    streamFromBackend.mockResolvedValue({
+      body: fakeBody,
+      headers: new Headers({
+        'content-type': 'text/csv; charset=utf-8',
+        'content-disposition':
+          'attachment; filename="waste-records-2026-05-08T10-00-00Z.csv"'
+      })
+    })
+
+    const { h, calls } = buildHapiH()
+    const request = { yar: { set: vi.fn() } }
+
+    await wasteRecordsExportPostController.handler(request, h)
+
+    expect(streamFromBackend).toHaveBeenCalledWith(
+      request,
+      '/v1/admin/waste-records/export.csv'
+    )
+    expect(h.response).toHaveBeenCalledWith(fakeBody)
+    expect(calls.type).toEqual([['text/csv; charset=utf-8']])
+    expect(calls.header).toEqual([
+      [
+        'Content-Disposition',
+        'attachment; filename="waste-records-2026-05-08T10-00-00Z.csv"'
+      ]
+    ])
+  })
+
+  it('falls back to default content-type and disposition when backend headers are missing', async () => {
+    streamFromBackend.mockResolvedValue({
+      body: {},
+      headers: new Headers({})
+    })
+
+    const { h, calls } = buildHapiH()
+    const request = { yar: { set: vi.fn() } }
+
+    await wasteRecordsExportPostController.handler(request, h)
+
+    expect(calls.type).toEqual([['text/csv; charset=utf-8']])
+    expect(calls.header).toEqual([
+      ['Content-Disposition', 'attachment; filename="waste-records.csv"']
+    ])
+  })
+
+  it('redirects with a flash error when the backend call fails', async () => {
+    const error = new Error('boom')
+    streamFromBackend.mockRejectedValue(error)
+
+    const { h } = buildHapiH()
+    const yarSet = vi.fn()
+    const request = { yar: { set: yarSet } }
+
+    const result = await wasteRecordsExportPostController.handler(request, h)
+
+    expect(mockLoggerError).toHaveBeenCalledWith({
+      message: 'Failed to stream waste records export',
+      err: error
+    })
+    expect(yarSet).toHaveBeenCalledWith('error', expect.any(String))
+    expect(h.redirect).toHaveBeenCalledWith('/waste-records-export')
+    expect(result).toBe('redirect-response')
+  })
+
+  it('uses the Boom payload message when available', async () => {
+    const error = new Error('upstream')
+    error.output = { payload: { message: 'Backend exploded' } }
+    streamFromBackend.mockRejectedValue(error)
+
+    const { h } = buildHapiH()
+    const yarSet = vi.fn()
+    const request = { yar: { set: yarSet } }
+
+    await wasteRecordsExportPostController.handler(request, h)
+
+    expect(yarSet).toHaveBeenCalledWith('error', 'Backend exploded')
+  })
+})

--- a/src/server/routes/waste-records-export/index.js
+++ b/src/server/routes/waste-records-export/index.js
@@ -1,0 +1,22 @@
+import { wasteRecordsExportGetController } from './controller.get.js'
+import { wasteRecordsExportPostController } from './controller.post.js'
+
+export const wasteRecordsExport = {
+  plugin: {
+    name: 'waste-records-export',
+    register(server) {
+      server.route([
+        {
+          method: 'GET',
+          path: '/waste-records-export',
+          ...wasteRecordsExportGetController
+        },
+        {
+          method: 'POST',
+          path: '/waste-records-export',
+          ...wasteRecordsExportPostController
+        }
+      ])
+    }
+  }
+}

--- a/src/server/routes/waste-records-export/index.njk
+++ b/src/server/routes/waste-records-export/index.njk
@@ -1,0 +1,36 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% if error %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: [
+            {
+              text: error
+            }
+          ]
+        }) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
+
+      <p class="govuk-body">
+        Download every waste record currently held, with all summary-log fields. The CSV is
+        streamed and may be very large.
+      </p>
+
+      <form method="POST" action="/waste-records-export">
+        <input type="hidden" name="crumb" value="{{ crumb }}" />
+        {{ govukButton({
+          text: "Download CSV"
+        }) }}
+      </form>
+
+    </div>
+  </div>
+{% endblock %}

--- a/src/server/routes/waste-records-export/index.njk
+++ b/src/server/routes/waste-records-export/index.njk
@@ -20,8 +20,7 @@
       <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
 
       <p class="govuk-body">
-        Download every waste record currently held, with all summary-log fields. The CSV is
-        streamed and may be very large.
+        Download every waste record currently held, with all summary-log fields. The CSV may be very large.
       </p>
 
       <form method="POST" action="/waste-records-export">

--- a/src/server/routes/waste-records-export/index.test.js
+++ b/src/server/routes/waste-records-export/index.test.js
@@ -1,0 +1,50 @@
+import { vi, describe, test, expect, beforeEach } from 'vitest'
+
+import { wasteRecordsExport } from './index.js'
+
+describe('#waste-records-export routes plugin', () => {
+  const mockServer = {
+    route: vi.fn()
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('has correct plugin name', () => {
+    expect(wasteRecordsExport.plugin.name).toBe('waste-records-export')
+  })
+
+  test('has a register function', () => {
+    expect(typeof wasteRecordsExport.plugin.register).toBe('function')
+  })
+
+  test('registers two routes', () => {
+    wasteRecordsExport.plugin.register(mockServer)
+
+    const routes = mockServer.route.mock.calls[0][0]
+    expect(routes).toHaveLength(2)
+  })
+
+  test('registers GET /waste-records-export', () => {
+    wasteRecordsExport.plugin.register(mockServer)
+
+    const routes = mockServer.route.mock.calls[0][0]
+    expect(routes[0]).toMatchObject({
+      method: 'GET',
+      path: '/waste-records-export'
+    })
+    expect(routes[0]).toHaveProperty('handler')
+  })
+
+  test('registers POST /waste-records-export', () => {
+    wasteRecordsExport.plugin.register(mockServer)
+
+    const routes = mockServer.route.mock.calls[0][0]
+    expect(routes[1]).toMatchObject({
+      method: 'POST',
+      path: '/waste-records-export'
+    })
+    expect(routes[1]).toHaveProperty('handler')
+  })
+})


### PR DESCRIPTION
Ticket: [PAE-1443](https://eaflood.atlassian.net/browse/PAE-1443)
## Summary

Admin UI half of the new "Waste records export" feature. Adds a new tab between "Report submissions" and "System logs" with a single "Download CSV" button that streams the export from the backend through to the browser.

- New route folder `src/server/routes/waste-records-export/` with GET (renders the page) and POST (streams the download).
- New helper `src/server/common/helpers/stream-from-backend.js` — streaming counterpart to `fetchJsonFromBackend`. Returns the raw `Response` so the body can be piped straight to the Hapi response.
- POST controller proxies `Content-Type` and `Content-Disposition` headers from the backend through to the browser, so the file lands with the timestamped name the backend provides.
- Tab added to `build-navigation.js`; existing nav tests updated.
- All new files have unit tests; tests follow the existing `report-submissions` mocking pattern (`vi.mock` + direct mocked-import + `vi.hoisted` for the logger spy).

## Depends on

Backend PR: https://github.com/DEFRA/epr-backend/pull/1163 — this UI calls `/v1/admin/waste-records/export.csv` which is added there. Must be deployed alongside (or before) this PR for the download to work.

## Manual verification

Local test plan:

- Sign in to the admin UI as a service maintainer
- Confirm "Waste records export" appears in the sidebar between "Report submissions" and "System logs"
- Click the link → page loads with the description and the "Download CSV" button
- Click the button → CSV downloads with filename `waste-records-<timestamp>.csv`
- Open the CSV: header row matches the union of every summary-log field plus the metadata prefix; data rows populate as expected


[PAE-1443]: https://eaflood.atlassian.net/browse/PAE-1443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ