### PR TITLE
PAE-250: Remove stale @babel/plugin-transform-modules-systemjs and fast-uri overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,8 +119,6 @@
     "webpack-cli": "7.0.2"
   },
   "overrides": {
-    "@babel/plugin-transform-modules-systemjs": "7.29.4",
-    "fast-uri": "3.1.2",
     "jsoneditor": {
       "ajv": "6.14.0"
     },


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
Both overrides were originally added to silence transitive vulnerabilities. Their parent packages have since updated their dependency ranges, so neither override changes the resolved tree any more.

Verified by removing each override individually, re-resolving the lockfile, and confirming both `npm audit` and `snyk test` report no new findings.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ