### PR TITLE
PAE-1339: fix type errors

### DIFF
--- a/.github/actions/test-and-scan/action.yml
+++ b/.github/actions/test-and-scan/action.yml
@@ -34,6 +34,10 @@ runs:
       shell: bash
       run: npm run lint
 
+    - name: Lint types
+      shell: bash
+      run: npm run lint:types
+
     - name: Build
       shell: bash
       run: npm run build:frontend

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -37,52 +37,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}
 
-  type-check:
-    name: Lint Types (advisory)
-    runs-on: ubuntu-latest
-    needs: pr-prep
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-          cache: npm
-
-      - name: Upgrade npm
-        run: npm install -g npm@11.12.1
-
-      - name: Install dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Lint types
-        run: |
-          OUTPUT=$(npm run lint:types 2>&1) && STATUS=0 || STATUS=$?
-          echo "$OUTPUT"
-
-          ERRORS=$(echo "$OUTPUT" | grep -c "^src/" || true)
-
-          {
-            if [ "$STATUS" -eq 0 ]; then
-              echo "## Lint Types"
-              echo ""
-              echo ":white_check_mark: Type check passed"
-            else
-              echo "## Lint Types"
-              echo ""
-              echo ":warning: **${ERRORS} type errors found** (advisory — not blocking)"
-              echo ""
-              echo "<details><summary>Errors by file</summary>"
-              echo ""
-              echo '```'
-              echo "$OUTPUT" | grep "^src/" | sed 's/(.*/:/' | sort | uniq -c | sort -rn
-              echo '```'
-              echo "</details>"
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
-
   test-journey:
     name: Run Journey Tests
     runs-on: ubuntu-latest

--- a/src/client/javascripts/jsoneditor.helpers.js
+++ b/src/client/javascripts/jsoneditor.helpers.js
@@ -5,6 +5,10 @@ import { schemaTypeIncludes } from './jsoneditor.schema-utils.js'
 import { inflateNullObjects, buildNullTemplate } from './jsoneditor.inflate.js'
 
 /**
+ * @import { ValidateFunction } from 'ajv'
+ */
+
+/**
  * Finds a schema node by following a JSONEditor path
  * @param {Object} schema - The root JSON schema
  * @param {Array} path - Array of path segments
@@ -323,7 +327,7 @@ export function getAutocompleteOptions(schema, path) {
  * @param {*} json - The JSON data to validate
  * @param {*} originalData - The original data to compare against for read-only checks
  * @param {Object} schema - The JSON schema to validate against
- * @param {Function} validate - The AJV validation function
+ * @param {ValidateFunction} validate - The AJV validation function
  * @returns {Array} Array of validation errors
  */
 export function validateJSON(json, originalData, schema, validate) {
@@ -387,7 +391,9 @@ export function validateJSON(json, originalData, schema, validate) {
  * @param {*} data - The data to sync
  */
 function syncHiddenInput(hiddenInputId, data) {
-  const hiddenInput = document.getElementById(hiddenInputId)
+  const hiddenInput = /** @type {HTMLInputElement | null} */ (
+    document.getElementById(hiddenInputId)
+  )
   if (hiddenInput) {
     hiddenInput.value = JSON.stringify(data)
   }
@@ -424,7 +430,9 @@ function clearStorageIfSuccessful(successMessageId, storageManager) {
  * @param {Array} errors - Array of validation errors
  */
 function updateSaveButtonState(saveButtonId, errors) {
-  const saveButton = document.getElementById(saveButtonId)
+  const saveButton = /** @type {HTMLButtonElement | null} */ (
+    document.getElementById(saveButtonId)
+  )
   if (saveButton) {
     saveButton.disabled = errors.length > 0
   }
@@ -438,6 +446,9 @@ function isDraftValid(draftData, backendData) {
 
 function injectDraftStaleWarning(staleWarningPlaceholderId) {
   const container = document.getElementById(staleWarningPlaceholderId)
+  if (!container) {
+    return
+  }
   container.innerHTML = `
   <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" tabindex="-1">
     <div class="govuk-notification-banner__header">
@@ -477,7 +488,7 @@ function clearDraftIfStale(
  * Creates JSONEditor configuration options
  * @param {Object} options - Configuration options
  * @param {Object} options.schema - JSON schema
- * @param {Function} options.validate - AJV validation function
+ * @param {ValidateFunction} options.validate - AJV validation function
  * @param {Object} options.originalData - Original data for comparison
  * @param {string} options.hiddenInputId - The ID of the hidden input element
  * @param {string} options.saveButtonId - The ID of the save button
@@ -561,6 +572,9 @@ function setupResetButton(
   hiddenInputId
 ) {
   const resetButton = document.getElementById(resetButtonId)
+  if (!resetButton) {
+    return
+  }
   resetButton.addEventListener('click', () => {
     if (globalThis.confirm('Are you sure you want to reset all changes?')) {
       storageManager.clear()
@@ -700,14 +714,15 @@ function loadEditorData(
  * Initialise the JSONEditor for organisation data
  * @param {Object} options - Configuration options
  * @param {Object} options.schema - The JSON schema for validation
- * @param {Function} options.validate - The AJV validation function
+ * @param {ValidateFunction} options.validate - The AJV validation function
  * @param {string} options.storageKey - The localStorage key for draft storage
- * @param {string} options.containerId - The ID of the container element
- * @param {string} options.payloadElementId - The ID of the element containing original JSON data
- * @param {string} options.hiddenInputId - The ID of the hidden input for form submission
- * @param {string} options.successMessageId - The ID of the success message element
- * @param {string} options.resetButtonId - The ID of the reset button
- * @param {string} options.saveButtonId - The ID of the save button
+ * @param {string} [options.containerId] - The ID of the container element
+ * @param {string} [options.payloadElementId] - The ID of the element containing original JSON data
+ * @param {string} [options.hiddenInputId] - The ID of the hidden input for form submission
+ * @param {string} [options.successMessageId] - The ID of the success message element
+ * @param {string} [options.resetButtonId] - The ID of the reset button
+ * @param {string} [options.saveButtonId] - The ID of the save button
+ * @param {string} [options.staleDraftWarningPlaceholderId] - The ID of the stale draft warning placeholder
  */
 export function initJSONEditor({
   schema,

--- a/src/client/javascripts/jsoneditor.helpers.js
+++ b/src/client/javascripts/jsoneditor.helpers.js
@@ -1,8 +1,9 @@
-import isEqual from 'lodash/isEqual.js'
 import JSONEditor from 'jsoneditor'
 import 'jsoneditor/dist/jsoneditor.css'
+import isEqual from 'lodash/isEqual.js'
+import { buildNullTemplate, inflateNullObjects } from './jsoneditor.inflate.js'
 import { schemaTypeIncludes } from './jsoneditor.schema-utils.js'
-import { inflateNullObjects, buildNullTemplate } from './jsoneditor.inflate.js'
+import { validateJSON } from './jsoneditor.validation.js'
 
 /**
  * @import { ValidateFunction } from 'ajv'
@@ -33,19 +34,6 @@ export function findSchemaNode(schema, path) {
 }
 
 /**
- * Gets a value at a specific path in an object
- * @param {Object} obj - The object to traverse
- * @param {Array} path - Array of path segments
- * @returns {*} The value at the path, or undefined if not found
- */
-export function getValueAtPath(obj, path) {
-  if (!obj || !Array.isArray(path)) {
-    return undefined
-  }
-  return path.reduce((acc, key) => acc?.[key], obj)
-}
-
-/**
  * Checks if a node represents an object field (should have locked key names)
  * @param {Object} node - The JSONEditor node to check
  * @returns {boolean} True if node is an object field
@@ -67,91 +55,6 @@ export function isNodeEditable(node) {
 
   // Everything else is editable normally
   return true
-}
-
-/**
- * Adds a read-only change error if the field has changed
- * @param {*} data - Current data
- * @param {*} original - Original data to compare against
- * @param {Object} schema - JSON schema for validation
- * @param {Array} path - Current path in the data structure
- * @param {Array} errors - Array to accumulate errors
- */
-function addReadOnlyErrorIfChanged(data, original, schema, path, errors) {
-  if (schema.readOnly && !isEqual(data, original)) {
-    errors.push({
-      path,
-      message: 'This read-only field cannot be changed.'
-    })
-  }
-}
-
-/**
- * Recursively checks read-only changes in object properties
- * @param {Object} data - Current object data
- * @param {Object} original - Original object data
- * @param {Object} schema - JSON schema with object properties
- * @param {Array} path - Current path in the data structure
- * @param {Array} errors - Array to accumulate errors
- */
-function checkObjectPropertiesReadOnly(data, original, schema, path, errors) {
-  for (const [key, subschema] of Object.entries(schema.properties)) {
-    const newVal = data ? data[key] : undefined
-    const oldVal = original ? original[key] : undefined
-    checkReadOnlyChanges(newVal, oldVal, subschema, [...path, key], errors)
-  }
-}
-
-/**
- * Recursively checks read-only changes in array items
- * @param {Array} data - Current array data
- * @param {*} original - Original data (may or may not be an array)
- * @param {Object} schema - JSON schema with array items definition
- * @param {Array} path - Current path in the data structure
- * @param {Array} errors - Array to accumulate errors
- */
-function checkArrayItemsReadOnly(data, original, schema, path, errors) {
-  for (const [i, item] of data.entries()) {
-    const oldItem = Array.isArray(original) ? original[i] : undefined
-    checkReadOnlyChanges(item, oldItem, schema.items, [...path, i], errors)
-  }
-}
-
-/**
- * Recursively checks for changes to read-only fields and adds validation errors
- * @param {*} data - Current data
- * @param {*} original - Original data to compare against
- * @param {Object} schema - JSON schema for validation
- * @param {Array} path - Current path in the data structure
- * @param {Array} errors - Array to accumulate errors
- * @returns {Array} Array of validation errors
- */
-export function checkReadOnlyChanges(
-  data,
-  original,
-  schema,
-  path = [],
-  errors = []
-) {
-  if (!schema || typeof schema !== 'object') {
-    return errors
-  }
-
-  addReadOnlyErrorIfChanged(data, original, schema, path, errors)
-
-  if (schemaTypeIncludes(schema, 'object') && schema.properties) {
-    checkObjectPropertiesReadOnly(data, original, schema, path, errors)
-  }
-
-  if (
-    schemaTypeIncludes(schema, 'array') &&
-    Array.isArray(data) &&
-    schema.items
-  ) {
-    checkArrayItemsReadOnly(data, original, schema, path, errors)
-  }
-
-  return errors
 }
 
 /**
@@ -320,69 +223,6 @@ export function getAutocompleteOptions(schema, path) {
     return subschema.enum.map((v) => v.toString())
   }
   return []
-}
-
-/**
- * Validates JSON data against a schema using AJV and checks for read-only field changes
- * @param {*} json - The JSON data to validate
- * @param {*} originalData - The original data to compare against for read-only checks
- * @param {Object} schema - The JSON schema to validate against
- * @param {ValidateFunction} validate - The AJV validation function
- * @returns {Array} Array of validation errors
- */
-export function validateJSON(json, originalData, schema, validate) {
-  let errors = []
-
-  // 1️⃣ Run normal AJV validation
-  const valid = validate(json)
-  if (!valid && validate.errors) {
-    errors.push(
-      ...validate.errors.map((err) => {
-        let message = err.message || 'Validation error'
-
-        // 🧩 Customise enum messages
-        if (err.keyword === 'enum' && err.params?.allowedValues) {
-          const allowed = err.params.allowedValues
-            .map((v) => JSON.stringify(v))
-            .join(', ')
-          message = `must be one of: ${allowed}`
-        }
-
-        // Parse the base path
-        let path = err.instancePath
-          ? err.instancePath
-              .replace(/^\//, '')
-              .split('/')
-              .map(decodeURIComponent)
-          : []
-
-        // Handle additionalProperties errors - append the property name to the path
-        if (
-          err.keyword === 'additionalProperties' &&
-          err.params?.additionalProperty
-        ) {
-          path = [...path, err.params.additionalProperty]
-        }
-
-        return {
-          path,
-          message
-        }
-      })
-    )
-  }
-
-  // 2️⃣ Add readOnly checks *only if changed*
-  checkReadOnlyChanges(json, originalData, schema, [], errors)
-
-  // 3️⃣ 🔍 Filter: only show errors for changed fields
-  errors = errors.filter((err) => {
-    const newValue = getValueAtPath(json, err.path)
-    const oldValue = getValueAtPath(originalData, err.path)
-    return !isEqual(newValue, oldValue)
-  })
-
-  return errors
 }
 
 /**

--- a/src/client/javascripts/jsoneditor.helpers.test.js
+++ b/src/client/javascripts/jsoneditor.helpers.test.js
@@ -1420,6 +1420,63 @@ describe('JSONEditor Helpers', () => {
       document.getElementById = originalGetById
     })
 
+    it('should not throw when the stale draft warning placeholder is missing', () => {
+      payloadEl.textContent = JSON.stringify({
+        id: 1,
+        name: 'Original',
+        version: '2'
+      })
+
+      const draftData = { id: 1, name: 'Draft', version: 1 }
+
+      const originalGetById = document.getElementById
+      document.getElementById = vi.fn((id) => {
+        if (id === 'jsoneditor') return container
+        if (id === 'organisation-json') return payloadEl
+        if (id === 'jsoneditor-organisation-object') return hiddenInput
+        if (id === 'jsoneditor-reset-button') return resetButton
+        if (id === 'jsoneditor-save-button') return saveButton
+        if (id === 'organisation-success-message') return messageEl
+        return null
+      })
+
+      localStorageMock.getItem
+        .mockReturnValueOnce(JSON.stringify(draftData))
+        .mockReturnValueOnce(null)
+
+      expect(() =>
+        initJSONEditor({
+          schema: testSchema,
+          validate: mockValidate,
+          storageKey: 'test-storage-key'
+        })
+      ).not.toThrow()
+
+      document.getElementById = originalGetById
+    })
+
+    it('should not throw when the reset button is missing', () => {
+      const originalGetById = document.getElementById
+      document.getElementById = vi.fn((id) => {
+        if (id === 'jsoneditor') return container
+        if (id === 'organisation-json') return payloadEl
+        if (id === 'jsoneditor-organisation-object') return hiddenInput
+        if (id === 'jsoneditor-save-button') return saveButton
+        if (id === 'organisation-success-message') return messageEl
+        return null
+      })
+
+      expect(() =>
+        initJSONEditor({
+          schema: testSchema,
+          validate: mockValidate,
+          storageKey: 'test-storage-key'
+        })
+      ).not.toThrow()
+
+      document.getElementById = originalGetById
+    })
+
     it('should reset editor when confirmed', () => {
       initJSONEditor({
         schema: testSchema,

--- a/src/client/javascripts/jsoneditor.helpers.test.js
+++ b/src/client/javascripts/jsoneditor.helpers.test.js
@@ -1,15 +1,17 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   findSchemaNode,
-  getValueAtPath,
-  isNodeEditable,
-  checkReadOnlyChanges,
-  highlightChanges,
-  LocalStorageManager,
   getAutocompleteOptions,
-  validateJSON,
-  initJSONEditor
+  highlightChanges,
+  initJSONEditor,
+  isNodeEditable,
+  LocalStorageManager
 } from './jsoneditor.helpers.js'
+import {
+  checkReadOnlyChanges,
+  getValueAtPath,
+  validateJSON
+} from './jsoneditor.validation.js'
 
 // Use vi.hoisted to ensure these are available when mocks are set up
 const { mockSet, mockGet, MockJSONEditorConstructor } = vi.hoisted(() => {

--- a/src/client/javascripts/jsoneditor.js
+++ b/src/client/javascripts/jsoneditor.js
@@ -1,6 +1,7 @@
 import { initJSONEditor } from './jsoneditor.helpers.js'
 // @ts-expect-error -- generated ajv file is @ts-nocheck; types come from the ValidateFunction cast below
 import rawValidate from '#server/common/schemas/organisation.ajv.js'
+// @ts-expect-error
 import schema from '#server/common/schemas/organisation.json'
 
 /** @type {import('ajv').ValidateFunction} */

--- a/src/client/javascripts/jsoneditor.js
+++ b/src/client/javascripts/jsoneditor.js
@@ -1,7 +1,7 @@
 import { initJSONEditor } from './jsoneditor.helpers.js'
 // @ts-expect-error -- generated ajv file is @ts-nocheck; types come from the ValidateFunction cast below
 import rawValidate from '#server/common/schemas/organisation.ajv.js'
-// @ts-expect-error
+// @ts-expect-error -- JSON import; eslint parser doesn't support import attributes yet
 import schema from '#server/common/schemas/organisation.json'
 
 /** @type {import('ajv').ValidateFunction} */

--- a/src/client/javascripts/jsoneditor.validation.js
+++ b/src/client/javascripts/jsoneditor.validation.js
@@ -1,0 +1,167 @@
+import isEqual from 'lodash/isEqual.js'
+import { schemaTypeIncludes } from './jsoneditor.schema-utils.js'
+
+/**
+ * @import { ValidateFunction } from 'ajv'
+ */
+
+/**
+ * Gets a value at a specific path in an object
+ * @param {Object} obj - The object to traverse
+ * @param {Array} path - Array of path segments
+ * @returns {*} The value at the path, or undefined if not found
+ */
+export function getValueAtPath(obj, path) {
+  if (!obj || !Array.isArray(path)) {
+    return undefined
+  }
+  return path.reduce((acc, key) => acc?.[key], obj)
+}
+
+/**
+ * Adds a read-only change error if the field has changed
+ * @param {*} data - Current data
+ * @param {*} original - Original data to compare against
+ * @param {Object} schema - JSON schema for validation
+ * @param {Array} path - Current path in the data structure
+ * @param {Array} errors - Array to accumulate errors
+ */
+function addReadOnlyErrorIfChanged(data, original, schema, path, errors) {
+  if (schema.readOnly && !isEqual(data, original)) {
+    errors.push({
+      path,
+      message: 'This read-only field cannot be changed.'
+    })
+  }
+}
+
+/**
+ * Recursively checks read-only changes in object properties
+ * @param {Object} data - Current object data
+ * @param {Object} original - Original object data
+ * @param {Object} schema - JSON schema with object properties
+ * @param {Array} path - Current path in the data structure
+ * @param {Array} errors - Array to accumulate errors
+ */
+function checkObjectPropertiesReadOnly(data, original, schema, path, errors) {
+  for (const [key, subschema] of Object.entries(schema.properties)) {
+    const newVal = data ? data[key] : undefined
+    const oldVal = original ? original[key] : undefined
+    checkReadOnlyChanges(newVal, oldVal, subschema, [...path, key], errors)
+  }
+}
+
+/**
+ * Recursively checks read-only changes in array items
+ * @param {Array} data - Current array data
+ * @param {*} original - Original data (may or may not be an array)
+ * @param {Object} schema - JSON schema with array items definition
+ * @param {Array} path - Current path in the data structure
+ * @param {Array} errors - Array to accumulate errors
+ */
+function checkArrayItemsReadOnly(data, original, schema, path, errors) {
+  for (const [i, item] of data.entries()) {
+    const oldItem = Array.isArray(original) ? original[i] : undefined
+    checkReadOnlyChanges(item, oldItem, schema.items, [...path, i], errors)
+  }
+}
+
+/**
+ * Recursively checks for changes to read-only fields and adds validation errors
+ * @param {*} data - Current data
+ * @param {*} original - Original data to compare against
+ * @param {Object} schema - JSON schema for validation
+ * @param {Array} path - Current path in the data structure
+ * @param {Array} errors - Array to accumulate errors
+ * @returns {Array} Array of validation errors
+ */
+export function checkReadOnlyChanges(
+  data,
+  original,
+  schema,
+  path = [],
+  errors = []
+) {
+  if (!schema || typeof schema !== 'object') {
+    return errors
+  }
+
+  addReadOnlyErrorIfChanged(data, original, schema, path, errors)
+
+  if (schemaTypeIncludes(schema, 'object') && schema.properties) {
+    checkObjectPropertiesReadOnly(data, original, schema, path, errors)
+  }
+
+  if (
+    schemaTypeIncludes(schema, 'array') &&
+    Array.isArray(data) &&
+    schema.items
+  ) {
+    checkArrayItemsReadOnly(data, original, schema, path, errors)
+  }
+
+  return errors
+}
+
+/**
+ * Validates JSON data against a schema using AJV and checks for read-only field changes
+ * @param {*} json - The JSON data to validate
+ * @param {*} originalData - The original data to compare against for read-only checks
+ * @param {Object} schema - The JSON schema to validate against
+ * @param {ValidateFunction} validate - The AJV validation function
+ * @returns {Array} Array of validation errors
+ */
+export function validateJSON(json, originalData, schema, validate) {
+  let errors = []
+
+  // 1️⃣ Run normal AJV validation
+  const valid = validate(json)
+  if (!valid && validate.errors) {
+    errors.push(
+      ...validate.errors.map((err) => {
+        let message = err.message || 'Validation error'
+
+        // 🧩 Customise enum messages
+        if (err.keyword === 'enum' && err.params?.allowedValues) {
+          const allowed = err.params.allowedValues
+            .map((v) => JSON.stringify(v))
+            .join(', ')
+          message = `must be one of: ${allowed}`
+        }
+
+        // Parse the base path
+        let path = err.instancePath
+          ? err.instancePath
+              .replace(/^\//, '')
+              .split('/')
+              .map(decodeURIComponent)
+          : []
+
+        // Handle additionalProperties errors - append the property name to the path
+        if (
+          err.keyword === 'additionalProperties' &&
+          err.params?.additionalProperty
+        ) {
+          path = [...path, err.params.additionalProperty]
+        }
+
+        return {
+          path,
+          message
+        }
+      })
+    )
+  }
+
+  // 2️⃣ Add readOnly checks *only if changed*
+  checkReadOnlyChanges(json, originalData, schema, [], errors)
+
+  // 3️⃣ 🔍 Filter: only show errors for changed fields
+  errors = errors.filter((err) => {
+    const newValue = getValueAtPath(json, err.path)
+    const oldValue = getValueAtPath(originalData, err.path)
+    return !isEqual(newValue, oldValue)
+  })
+
+  return errors
+}

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,9 @@ import { createLogger } from './server/common/helpers/logging/logger.js'
 
 await startServer()
 
-process.on('unhandledRejection', (error) => {
+process.on('unhandledRejection', (reason) => {
   const logger = createLogger()
-  logger.error({ err: error, message: 'Unhandled rejection' })
+  const err = reason instanceof Error ? reason : new Error(String(reason))
+  logger.error({ err, message: 'Unhandled rejection' })
   process.exitCode = 1
 })

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -70,4 +70,27 @@ describe('#index', () => {
       expect(process.exitCode).toBe(1)
     })
   })
+
+  describe('When unhandledRejection occurs with a non-Error reason', () => {
+    beforeEach(async () => {
+      await import('./index.js')
+
+      process.emit('unhandledRejection', 'plain string rejection')
+    })
+
+    test('Should wrap the reason in an Error before logging', () => {
+      expect(mockLoggerError).toHaveBeenCalledWith({
+        err: expect.any(Error),
+        message: 'Unhandled rejection'
+      })
+
+      const [{ err }] = mockLoggerError.mock.calls[0]
+
+      expect(err.message).toBe('plain string rejection')
+    })
+
+    test('Should set process exitCode to 1', () => {
+      expect(process.exitCode).toBe(1)
+    })
+  })
 })

--- a/src/server/common/helpers/auth/types.js
+++ b/src/server/common/helpers/auth/types.js
@@ -1,0 +1,19 @@
+/**
+ * Subset of the Entra ID JWT payload claims the app reads. Mirrors the
+ * `DefraIdJwtPayload` typedef pattern used in epr-frontend and epr-backend.
+ *
+ * Authoritative claim list: Microsoft's id_token reference for v2.0 tokens
+ * https://learn.microsoft.com/en-us/entra/identity-platform/id-tokens
+ *
+ * `login_hint` is optional — only present after a prior successful sign-in
+ * when re-prompting the user.
+ * @typedef {{
+ *   oid: string
+ *   name: string
+ *   preferred_username: string
+ *   login_hint?: string
+ *   exp: number
+ * }} EntraIdTokenPayload
+ */
+
+export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/server/common/helpers/auth/verify-token.js
+++ b/src/server/common/helpers/auth/verify-token.js
@@ -2,6 +2,14 @@ import * as jose from 'jose'
 import { getOidcConfig } from './get-oidc-config.js'
 import { config } from '#config/config.js'
 
+/**
+ * @import { EntraIdTokenPayload } from './types.js'
+ */
+
+/**
+ * @param {string} token
+ * @returns {Promise<EntraIdTokenPayload>}
+ */
 async function verifyToken(token) {
   const { jwks_uri: uri } = await getOidcConfig()
   const clientId = config.get('entraId.clientId')
@@ -15,7 +23,7 @@ async function verifyToken(token) {
     issuer: `https://login.microsoftonline.com/${tenantId}/v2.0`
   })
 
-  return payload
+  return /** @type {EntraIdTokenPayload} */ (payload)
 }
 
 export { verifyToken }

--- a/src/server/common/helpers/content-security-policy.js
+++ b/src/server/common/helpers/content-security-policy.js
@@ -1,6 +1,28 @@
 import Blankie from 'blankie'
 import { config } from '#config/config.js'
 
+/**
+ * @import { ServerRegisterPluginObject } from '@hapi/hapi'
+ */
+
+/**
+ * @typedef {{
+ *   defaultSrc?: string[]
+ *   fontSrc?: string[]
+ *   connectSrc?: string[]
+ *   mediaSrc?: string[]
+ *   styleSrc?: string[]
+ *   scriptSrc?: string[]
+ *   imgSrc?: string[]
+ *   frameSrc?: string[]
+ *   objectSrc?: string[]
+ *   frameAncestors?: string[]
+ *   formAction?: string[]
+ *   manifestSrc?: string[]
+ *   generateNonces?: boolean
+ * }} BlankieOptions
+ */
+
 export function cspFormAction({ isProduction, cdpUploaderUrl }) {
   if (isProduction) {
     return ['self']
@@ -14,7 +36,7 @@ export function cspFormAction({ isProduction, cdpUploaderUrl }) {
 
 /**
  * Manage content security policies.
- * @satisfies {import('@hapi/hapi').Plugin}
+ * @satisfies {ServerRegisterPluginObject<BlankieOptions>}
  */
 const contentSecurityPolicy = {
   plugin: Blankie,

--- a/src/server/common/helpers/errors.js
+++ b/src/server/common/helpers/errors.js
@@ -49,7 +49,7 @@ export function catchAll(request, h) {
   const pageTitle = request.route?.settings?.app?.pageTitle
   const viewResponse = h.view(template, { pageTitle }).code(statusCode)
 
-  const originalHeaders = response.headers || response.output?.headers || {}
+  const originalHeaders = response.output?.headers ?? {}
   for (const [key, value] of Object.entries(originalHeaders)) {
     if (key.toLowerCase() === 'content-type') {
       continue

--- a/src/server/common/helpers/errors.test.js
+++ b/src/server/common/helpers/errors.test.js
@@ -39,8 +39,7 @@ describe('#catchAll unit tests', () => {
       isBoom: true,
       message: mockMessage,
       data: { stack: mockStack },
-      output: { statusCode, headers },
-      headers
+      output: { statusCode, headers }
     }
     return {
       response,
@@ -168,28 +167,6 @@ describe('#catchAll unit tests', () => {
     expect(mockToolkitHeader).not.toHaveBeenCalledWith(
       'content-type',
       'application/json'
-    )
-  })
-
-  test('Should handle headers from response.output.headers when response.headers is not available', () => {
-    const request = {
-      response: {
-        isBoom: true,
-        message: mockMessage,
-        data: { stack: mockStack },
-        output: {
-          statusCode: statusCodes.notFound,
-          headers: { 'x-output-header': 'output-value' }
-        }
-      },
-      logger: { error: mockLoggerError }
-    }
-
-    catchAll(request, mockToolkit)
-
-    expect(mockToolkitHeader).toHaveBeenCalledWith(
-      'x-output-header',
-      'output-value'
     )
   })
 

--- a/src/server/common/helpers/fetch-organisation-overview.js
+++ b/src/server/common/helpers/fetch-organisation-overview.js
@@ -1,4 +1,6 @@
+import { errorCodes } from '#server/common/enums/error-codes.js'
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
+import { notFound } from '#server/common/helpers/logging/cdp-boom.js'
 
 /**
  * @typedef {{
@@ -35,3 +37,28 @@ export const fetchOrganisationOverview = (request, organisationId) =>
     `/v1/organisations/${organisationId}/overview`,
     {}
   )
+
+/**
+ * Find a registration on the overview by id, throwing an enriched 404
+ * if it's missing.
+ * @param {OrganisationOverview} overview
+ * @param {string} organisationId
+ * @param {string} registrationId
+ * @returns {Registration}
+ */
+export const findRegistration = (overview, organisationId, registrationId) => {
+  const registration = overview.registrations.find(
+    (r) => r.id === registrationId
+  )
+
+  if (!registration) {
+    throw notFound('Registration not found', errorCodes.registrationNotFound, {
+      event: {
+        action: 'fetch_registration',
+        reason: `organisationId=${organisationId} registrationId=${registrationId}`
+      }
+    })
+  }
+
+  return registration
+}

--- a/src/server/common/helpers/fetch-organisation-overview.test.js
+++ b/src/server/common/helpers/fetch-organisation-overview.test.js
@@ -1,5 +1,8 @@
 import { vi } from 'vitest'
-import { fetchOrganisationOverview } from './fetch-organisation-overview.js'
+import {
+  fetchOrganisationOverview,
+  findRegistration
+} from './fetch-organisation-overview.js'
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
 
 vi.mock('#server/common/helpers/fetch-json-from-backend.js', () => ({
@@ -49,5 +52,37 @@ describe('fetchOrganisationOverview', () => {
     await expect(
       fetchOrganisationOverview(mockRequest, '69c3b4f0abda9efa68dd6697')
     ).rejects.toThrow('backend unavailable')
+  })
+})
+
+describe(findRegistration, () => {
+  const organisationId = 'aaa111bbb222ccc333ddd4444'
+  const registrationId = 'bbb222ccc333ddd444eee5555'
+
+  test('returns the matching registration when present', () => {
+    const registration = { id: registrationId, registrationNumber: 'REG-001' }
+    const overview = { registrations: [registration] }
+
+    expect(findRegistration(overview, organisationId, registrationId)).toBe(
+      registration
+    )
+  })
+
+  test('throws notFound enriched with code and event when missing', () => {
+    const overview = { registrations: [] }
+
+    expect(() =>
+      findRegistration(overview, organisationId, registrationId)
+    ).toThrow(
+      expect.objectContaining({
+        isBoom: true,
+        message: 'Registration not found',
+        code: 'registration_not_found',
+        event: {
+          action: 'fetch_registration',
+          reason: `organisationId=${organisationId} registrationId=${registrationId}`
+        }
+      })
+    )
   })
 })

--- a/src/server/routes/registration-overview/controller.get.js
+++ b/src/server/routes/registration-overview/controller.get.js
@@ -1,7 +1,8 @@
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
-import { fetchOrganisationOverview } from '#server/common/helpers/fetch-organisation-overview.js'
-import { errorCodes } from '#server/common/enums/error-codes.js'
-import { notFound } from '#server/common/helpers/logging/cdp-boom.js'
+import {
+  fetchOrganisationOverview,
+  findRegistration
+} from '#server/common/helpers/fetch-organisation-overview.js'
 import { formatPeriod } from '#server/common/helpers/format-reporting-period.js'
 
 const GREEN_TAG = 'govuk-tag--green'
@@ -50,22 +51,11 @@ export const registrationOverviewGETController = {
       )
     ])
 
-    const registration = overview.registrations.find(
-      (r) => r.id === registrationId
+    const registration = findRegistration(
+      overview,
+      organisationId,
+      registrationId
     )
-
-    if (!registration) {
-      throw notFound(
-        'Registration not found',
-        errorCodes.registrationNotFound,
-        {
-          event: {
-            action: 'fetch_registration',
-            reason: `organisationId=${organisationId} registrationId=${registrationId}`
-          }
-        }
-      )
-    }
 
     const pageTitle = request.route.settings.app.pageTitle
 

--- a/src/server/routes/report-submissions/types.js
+++ b/src/server/routes/report-submissions/types.js
@@ -1,0 +1,38 @@
+/**
+ * Row in the report-submissions CSV download. Mirrors the shape returned
+ * by `GET /v1/organisations/reports/submissions` on epr-backend.
+ * @typedef {{
+ *   accreditationNumber: string
+ *   approvedPersonsEmail: string
+ *   approvedPersonsPhone: string
+ *   averagePrnPernPricePerTonne: string
+ *   dueDate: string
+ *   material: string
+ *   noteToRegulator: string
+ *   organisationName: string
+ *   registrationNumber: string
+ *   regulator: string
+ *   reportType: string
+ *   reportingPeriod: string
+ *   submittedBy: string
+ *   submittedDate: string
+ *   submitterEmail: string
+ *   submitterPhone: string
+ *   tonnageExportedForRecycling: string
+ *   tonnageExportedThatWasRefused: string
+ *   tonnageExportedThatWasStopped: string
+ *   tonnagePrnsPernsIssued: string
+ *   tonnageReceivedButNotExported: string
+ *   tonnageReceivedButNotRecycled: string
+ *   tonnageReceivedForRecycling: string
+ *   tonnageRecycled: string
+ *   tonnageRepatriated: string
+ *   tonnageSentOnToExporter: string
+ *   tonnageSentOnToOtherFacilities: string
+ *   tonnageSentOnToReprocessor: string
+ *   tonnageSentOnTotal: string
+ *   totalRevenuePrnsPerns: string
+ * }} ReportSubmissionsRow
+ */
+
+export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/server/routes/report-unsubmit/controller.get-confirm.js
+++ b/src/server/routes/report-unsubmit/controller.get-confirm.js
@@ -1,5 +1,8 @@
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
-import { fetchOrganisationOverview } from '#server/common/helpers/fetch-organisation-overview.js'
+import {
+  fetchOrganisationOverview,
+  findRegistration
+} from '#server/common/helpers/fetch-organisation-overview.js'
 import { PAGE_TITLE } from './constants.js'
 import { formatPeriod } from '#server/common/helpers/format-reporting-period.js'
 
@@ -21,8 +24,10 @@ export const reportUnsubmitConfirmGetController = {
     }
 
     const overview = await fetchOrganisationOverview(request, organisationId)
-    const registration = overview.registrations.find(
-      (r) => r.id === registrationId
+    const registration = findRegistration(
+      overview,
+      organisationId,
+      registrationId
     )
 
     return h.view('routes/report-unsubmit/confirm', {

--- a/src/server/routes/report-unsubmit/controller.get-result.js
+++ b/src/server/routes/report-unsubmit/controller.get-result.js
@@ -1,5 +1,8 @@
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
-import { fetchOrganisationOverview } from '#server/common/helpers/fetch-organisation-overview.js'
+import {
+  fetchOrganisationOverview,
+  findRegistration
+} from '#server/common/helpers/fetch-organisation-overview.js'
 import { formatPeriod } from '#server/common/helpers/format-reporting-period.js'
 
 export const reportUnsubmitResultGetController = {
@@ -24,8 +27,10 @@ export const reportUnsubmitResultGetController = {
     }
 
     const overview = await fetchOrganisationOverview(request, organisationId)
-    const registration = overview.registrations.find(
-      (r) => r.id === registrationId
+    const registration = findRegistration(
+      overview,
+      organisationId,
+      registrationId
     )
 
     return h.view('routes/report-unsubmit/result', {

--- a/src/server/routes/report-unsubmit/controller.post.js
+++ b/src/server/routes/report-unsubmit/controller.post.js
@@ -1,5 +1,8 @@
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
-import { fetchOrganisationOverview } from '#server/common/helpers/fetch-organisation-overview.js'
+import {
+  fetchOrganisationOverview,
+  findRegistration
+} from '#server/common/helpers/fetch-organisation-overview.js'
 import { formatPeriod } from '#server/common/helpers/format-reporting-period.js'
 
 export const reportUnsubmitPostController = {
@@ -22,8 +25,10 @@ export const reportUnsubmitPostController = {
     }
 
     const overview = await fetchOrganisationOverview(request, organisationId)
-    const registration = overview.registrations.find(
-      (r) => r.id === registrationId
+    const registration = findRegistration(
+      overview,
+      organisationId,
+      registrationId
     )
 
     return h.view('routes/report-unsubmit/result', {

--- a/src/server/routes/report-unsubmit/index.integration.test.js
+++ b/src/server/routes/report-unsubmit/index.integration.test.js
@@ -147,6 +147,25 @@ describe('report-unsubmit', () => {
     expect($('a:contains("Cancel")').attr('href')).toBe(overviewUrl)
   })
 
+  test('confirm page returns 404 when the registration is missing from the overview', async () => {
+    getUserSession.mockReturnValue(mockUserSession)
+    mswServer.use(
+      http.get(
+        `${backendUrl}/v1/organisations/${organisationId}/overview`,
+        () => HttpResponse.json({ ...mockOverview, registrations: [] })
+      )
+    )
+    stubReport({ currentStatus: 'submitted', unsubmittedAt: null })
+
+    const { statusCode } = await server.inject({
+      method: 'GET',
+      url: confirmUrl,
+      auth: authOptions
+    })
+
+    expect(statusCode).toBe(statusCodes.notFound)
+  })
+
   test('confirm page redirects to overview for a non-submitted report', async () => {
     getUserSession.mockReturnValue(mockUserSession)
     stubOverview()

--- a/src/server/routes/tonnage-monitoring/helper.js
+++ b/src/server/routes/tonnage-monitoring/helper.js
@@ -1,3 +1,16 @@
+/**
+ * A row in the materialised tonnage-monitoring table. Three semantic variants
+ * share one structural shape: material rows have `material` and `type`, type
+ * total rows have `type`, year total rows have neither.
+ * @typedef {{
+ *   material?: string
+ *   type?: string
+ *   year: number
+ *   monthValues: Record<string, number | undefined>
+ *   total: number
+ * }} TonnageRow
+ */
+
 const masterOrder = [
   'Jan',
   'Feb',
@@ -69,7 +82,11 @@ export function buildMaterialRowData(data) {
     rows.push(typeTotal, yearTotal)
   }
 
-  return { hasMultipleYears, monthNames, rows }
+  return {
+    hasMultipleYears,
+    monthNames,
+    rows: /** @type {TonnageRow[]} */ (rows)
+  }
 }
 
 function initTypeTotal(item, monthNames) {


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)
clears all 27 source-side type errors reported by `lint:types` on main.

- non-error rejection wrap in `src/index.js`
- csp plugin typed as `ServerRegisterPluginObject<BlankieOptions>`
- dropped dead `response.headers` branch in `catchAll`; tests updated to drop the corresponding fabricated mock field
- new `EntraIdTokenPayload` typedef + typed `verifyToken` return (matches FE/BE `DefraIdJwtPayload` pattern)
- new `ReportSubmissionsRow` typedef for the report-submissions CSV download
- new `findRegistration` helper on `fetch-organisation-overview.js` — throws enriched `notFound` when registration not in overview, replaces inline duplicates in 3 report-unsubmit controllers + the existing one in registration-overview
- `TonnageRow` typedef + cast-at-return in tonnage-monitoring helper; controllers and formatters now type-check cleanly
- jsoneditor cluster: typed `validate` as ajv's `ValidateFunction`, `HTMLInputElement`/`HTMLButtonElement` casts on `getElementById` returns, null guards on the `injectDraftStaleWarning`/`setupResetButton` lookups (with new tests covering the null branches), JSDoc options optionality + missing `staleDraftWarningPlaceholderId` field, JSON schema import suppressed with `@ts-expect-error` until eslint parser supports import attributes

follow-up bead raised:
- admin observability gap — no boom-error-logger plugin to surface enriched event/code from thrown cdp-boom errors (FE/BE both have one)

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ