### PR TITLE
PAE-1339: typecheck tests (advisory)

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -40,6 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: pr-prep
     continue-on-error: true
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -60,7 +63,9 @@ jobs:
 
       - name: Lint types (tests)
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          COMMENT_FILE: ${{ runner.temp }}/lint-types-tests-comment.md
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           # disable setup-node's tsc problem matcher: we summarise via the script
           echo "::remove-matcher owner=tsc::"
@@ -71,6 +76,13 @@ jobs:
           echo "$OUTPUT" \
             | node scripts/lint-types-tests-summary.js \
             >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post PR comment
+        if: always()
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: lint-types-tests
+          path: ${{ runner.temp }}/lint-types-tests-comment.md
 
   test-journey:
     name: Run Journey Tests

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -3,7 +3,7 @@ name: Check Pull Request
 on:
   pull_request:
     branches:
-      - "*"
+      - '*'
     types:
       - opened
       - reopened
@@ -21,8 +21,6 @@ jobs:
       - name: Prepare PR
         uses: DEFRA/epr-re-ex-service/.github/actions/pr-preparation@main
 
-
-
   pr-validator:
     name: Run Pull Request Checks
     runs-on: ubuntu-latest
@@ -36,6 +34,43 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}
+
+  type-check-tests:
+    name: Lint Types - Tests
+    runs-on: ubuntu-latest
+    needs: pr-prep
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Upgrade npm
+        run: npm install -g npm@11.12.1
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Lint types (tests)
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          # disable setup-node's tsc problem matcher: we summarise via the script
+          echo "::remove-matcher owner=tsc::"
+
+          OUTPUT=$(npm run lint:types:tests 2>&1) || true
+          echo "$OUTPUT"
+
+          echo "$OUTPUT" \
+            | node scripts/lint-types-tests-summary.js \
+            >> "$GITHUB_STEP_SUMMARY"
 
   test-journey:
     name: Run Journey Tests

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,5 +1,5 @@
 export default {
-  '*.{js,json,md}': 'prettier --write',
-  'src/**/*.js': ['npm run lint:js:fix'],
+  '**/*.{js,json,md}': 'prettier --write',
+  '{src,scripts}/**/*.js': ['npm run lint:js:fix'],
   '*': () => 'gitleaks protect --staged --no-banner --verbose'
 }

--- a/jsconfig.typecheck.tests.json
+++ b/jsconfig.typecheck.tests.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./jsconfig.typecheck.json",
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  },
+  "include": [
+    "src/**/*.test.js",
+    "src/**/test-helpers/**/*.js",
+    "src/**/test-fixtures.js",
+    "src/**/*.d.ts"
+  ],
+  "exclude": ["node_modules", ".vite"]
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lint:js:fix": "eslint . --fix",
     "lint:scss": "stylelint \"src/**/*.scss\" --cache --cache-location .cache/stylelint --cache-strategy content --color --ignore-path .gitignore",
     "lint:types": "tsc -p jsconfig.typecheck.json",
+    "lint:types:tests": "tsc -p jsconfig.typecheck.tests.json",
     "pretest": "npm run build:frontend",
     "test": "TZ=UTC vitest run --coverage",
     "test:watch": "TZ=UTC vitest",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "epr-re-ex-admin-frontend",
+  "private": true,
   "version": "0.0.0",
   "description": "Admin UI for the Re-Ex packaging Extended Producer Responsibilities service (pEPR)",
   "sideEffects": false,

--- a/scripts/lint-types-tests-summary.js
+++ b/scripts/lint-types-tests-summary.js
@@ -1,0 +1,278 @@
+import { execSync } from 'node:child_process'
+
+import ts from 'typescript'
+
+/**
+ * @typedef {object} BuildSummaryInput
+ * @property {string} tscOutput
+ * @property {string[]} changedFiles
+ * @property {(code: number) => string} tsCodeLookup
+ */
+
+/**
+ * @typedef {object} BuildSummaryResult
+ * @property {string} markdown
+ * @property {number} exitCode
+ */
+
+const TEST_FILE_PATTERNS = [
+  /\.test\.js$/,
+  /\/test-helpers\//,
+  /\/test-fixtures\.js$/,
+  /\.d\.ts$/
+]
+
+/**
+ * @param {string[]} paths
+ * @returns {string[]}
+ */
+export const filterTestFiles = (paths) =>
+  paths.filter((p) => TEST_FILE_PATTERNS.some((re) => re.test(p)))
+
+const errorLineRegex = /^(src\/[^(]+)\(\d+,\d+\): error (TS\d+): (.*)$/
+
+/**
+ * @param {string} tscOutput
+ * @returns {Array<{file: string, code: string, message: string, line: string}>}
+ */
+const parseErrors = (tscOutput) => {
+  const errors = []
+  for (const line of tscOutput.split('\n')) {
+    const match = line.match(errorLineRegex)
+    if (match) {
+      errors.push({ file: match[1], code: match[2], message: match[3], line })
+    }
+  }
+  return errors
+}
+
+/**
+ * @param {Array<{file: string}>} errors
+ * @returns {Map<string, number>}
+ */
+const countByFile = (errors) => {
+  const counts = new Map()
+  for (const { file } of errors) {
+    counts.set(file, (counts.get(file) ?? 0) + 1)
+  }
+  return counts
+}
+
+/**
+ * @param {Array<{code: string, message: string}>} errors
+ * @returns {Array<{code: string, count: number, message: string}>}
+ */
+const topCodes = (errors) => {
+  /** @type {Map<string, {count: number, message: string}>} */
+  const acc = new Map()
+  for (const { code, message } of errors) {
+    const entry = acc.get(code)
+    if (entry) {
+      entry.count += 1
+    } else {
+      acc.set(code, { count: 1, message })
+    }
+  }
+  return [...acc.entries()]
+    .map(([code, { count, message }]) => ({ code, count, message }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 10)
+}
+
+/**
+ * @param {Array<{file: string, line: string}>} errors
+ * @param {string} file
+ * @returns {string[]}
+ */
+const errorLinesFor = (errors, file) =>
+  errors.filter((e) => e.file === file).map((e) => e.line)
+
+/**
+ * @param {string[]} changedFiles
+ * @param {ReturnType<typeof parseErrors>} errors
+ * @returns {{section: string, prErrorTotal: number}}
+ */
+const buildPrSection = (changedFiles, errors) => {
+  if (changedFiles.length === 0) {
+    return { section: '_no test files changed in this PR_', prErrorTotal: 0 }
+  }
+
+  const blocks = []
+  let prErrorTotal = 0
+  for (const file of [...changedFiles].sort()) {
+    const lines = errorLinesFor(errors, file)
+    if (lines.length === 0) {
+      blocks.push(`- :white_check_mark: \`${file}\` (0 errors)`)
+    } else {
+      prErrorTotal += lines.length
+      blocks.push(
+        `<details><summary><code>${file}</code> (${lines.length} errors)</summary>\n\n` +
+          '```\n' +
+          lines.join('\n') +
+          '\n```\n\n</details>'
+      )
+    }
+  }
+  return { section: blocks.join('\n'), prErrorTotal }
+}
+
+/**
+ * @param {number} prErrorTotal
+ * @returns {string}
+ */
+const prHeader = (prErrorTotal) => {
+  if (prErrorTotal === 0) {
+    return ':white_check_mark: no type errors in test files changed in this PR'
+  }
+  return `:warning: **${prErrorTotal} type error(s) in test files changed in this PR**`
+}
+
+/**
+ * @param {ReturnType<typeof parseErrors>} errors
+ * @param {(code: number) => string} tsCodeLookup
+ * @returns {string}
+ */
+const topCodesTable = (errors, tsCodeLookup) => {
+  const rows = ['| Count | Code | Description |', '| ---: | --- | --- |']
+  for (const { code, count, message } of topCodes(errors)) {
+    const numericCode = Number(code.slice(2))
+    const description = (tsCodeLookup(numericCode) || message).replace(
+      /\|/g,
+      '\\|'
+    )
+    const slug = code.toLowerCase()
+    rows.push(
+      `| ${count} | [${code}](https://typescript.tv/errors/${slug}/) | ${description} |`
+    )
+  }
+  return rows.join('\n')
+}
+
+/**
+ * @param {ReturnType<typeof parseErrors>} errors
+ * @returns {string}
+ */
+const errorsByFileBlock = (errors) => {
+  const counts = [...countByFile(errors).entries()].sort(
+    (a, b) => b[1] - a[1] || a[0].localeCompare(b[0])
+  )
+  return counts.map(([file, count]) => `${count} ${file}`).join('\n')
+}
+
+/**
+ * @param {BuildSummaryInput} input
+ * @returns {BuildSummaryResult}
+ */
+export const buildSummary = ({ tscOutput, changedFiles, tsCodeLookup }) => {
+  const errors = parseErrors(tscOutput)
+  const { section: section1, prErrorTotal } = buildPrSection(
+    changedFiles,
+    errors
+  )
+
+  let section2
+  if (errors.length === 0) {
+    section2 = '### All errors\n\n:white_check_mark: Test type check passed'
+  } else {
+    const fullList = errors.map((e) => e.line).join('\n')
+    section2 = [
+      '### All errors',
+      '',
+      `:warning: **${errors.length} type errors found in tests**`,
+      '',
+      '#### Top error codes',
+      '',
+      topCodesTable(errors, tsCodeLookup),
+      '',
+      '<details><summary>Errors by file (count)</summary>',
+      '',
+      '```',
+      errorsByFileBlock(errors),
+      '```',
+      '',
+      '</details>',
+      '',
+      '<details><summary>Full error list</summary>',
+      '',
+      '```',
+      fullList,
+      '```',
+      '',
+      '</details>'
+    ].join('\n')
+  }
+
+  const markdown = [
+    '## Lint Types - Tests',
+    '',
+    '### Errors in this PR',
+    '',
+    prHeader(prErrorTotal),
+    '',
+    section1,
+    '',
+    section2,
+    ''
+  ].join('\n')
+
+  return { markdown, exitCode: prErrorTotal > 0 ? 1 : 0 }
+}
+
+/* v8 ignore start */
+/**
+ * @param {number} code
+ * @returns {string}
+ */
+const tsCodeLookupFromPackage = (() => {
+  /** @type {Map<number, string>} */
+  const map = new Map()
+  const diagnostics =
+    /** @type {Record<string, {code?: number, message?: string}>} */ (
+      /** @type {unknown} */ (ts).Diagnostics ?? {}
+    )
+  for (const key of Object.keys(diagnostics)) {
+    const d = diagnostics[key]
+    if (d?.code && d?.message) {
+      map.set(d.code, d.message)
+    }
+  }
+  return (/** @type {number} */ code) => map.get(code) ?? ''
+})()
+
+/**
+ * @returns {Promise<string>}
+ */
+const readStdin = async () => {
+  const chunks = []
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk)
+  }
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+/**
+ * @returns {string[]}
+ */
+const changedFilesFromGit = () => {
+  const baseSha = process.env.BASE_SHA
+  if (!baseSha) {
+    return []
+  }
+  const out = execSync(
+    `git diff --name-only ${baseSha}...HEAD -- src/`
+  ).toString()
+  return filterTestFiles(out.split('\n').filter(Boolean))
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const tscOutput = await readStdin()
+  const changedFiles = changedFilesFromGit()
+  const { markdown, exitCode } = buildSummary({
+    tscOutput,
+    changedFiles,
+    tsCodeLookup: tsCodeLookupFromPackage
+  })
+  process.stdout.write(markdown)
+  process.exitCode = exitCode
+}
+/* v8 ignore stop */

--- a/scripts/lint-types-tests-summary.js
+++ b/scripts/lint-types-tests-summary.js
@@ -1,4 +1,6 @@
 import { execSync } from 'node:child_process'
+import { writeFileSync } from 'node:fs'
+import { text } from 'node:stream/consumers'
 
 import ts from 'typescript'
 
@@ -32,34 +34,37 @@ export const filterTestFiles = (paths) =>
 const errorLineRegex = /^(src\/[^(]+)\(\d+,\d+\): error (TS\d+): (.*)$/
 
 /**
+ * @typedef {{file: string, code: string, message: string, line: string}} ParsedError
+ */
+
+/**
  * @param {string} tscOutput
- * @returns {Array<{file: string, code: string, message: string, line: string}>}
+ * @returns {{errors: ParsedError[], byFile: Map<string, ParsedError[]>}}
  */
 const parseErrors = (tscOutput) => {
+  /** @type {ParsedError[]} */
   const errors = []
+  /** @type {Map<string, ParsedError[]>} */
+  const byFile = new Map()
   for (const line of tscOutput.split('\n')) {
     const match = line.match(errorLineRegex)
-    if (match) {
-      errors.push({ file: match[1], code: match[2], message: match[3], line })
+    if (!match) {
+      continue
+    }
+    const error = { file: match[1], code: match[2], message: match[3], line }
+    errors.push(error)
+    const list = byFile.get(error.file)
+    if (list) {
+      list.push(error)
+    } else {
+      byFile.set(error.file, [error])
     }
   }
-  return errors
+  return { errors, byFile }
 }
 
 /**
- * @param {Array<{file: string}>} errors
- * @returns {Map<string, number>}
- */
-const countByFile = (errors) => {
-  const counts = new Map()
-  for (const { file } of errors) {
-    counts.set(file, (counts.get(file) ?? 0) + 1)
-  }
-  return counts
-}
-
-/**
- * @param {Array<{code: string, message: string}>} errors
+ * @param {ParsedError[]} errors
  * @returns {Array<{code: string, count: number, message: string}>}
  */
 const topCodes = (errors) => {
@@ -80,19 +85,11 @@ const topCodes = (errors) => {
 }
 
 /**
- * @param {Array<{file: string, line: string}>} errors
- * @param {string} file
- * @returns {string[]}
- */
-const errorLinesFor = (errors, file) =>
-  errors.filter((e) => e.file === file).map((e) => e.line)
-
-/**
  * @param {string[]} changedFiles
- * @param {ReturnType<typeof parseErrors>} errors
+ * @param {Map<string, ParsedError[]>} byFile
  * @returns {{section: string, prErrorTotal: number}}
  */
-const buildPrSection = (changedFiles, errors) => {
+const buildPrSection = (changedFiles, byFile) => {
   if (changedFiles.length === 0) {
     return { section: '_no test files changed in this PR_', prErrorTotal: 0 }
   }
@@ -100,20 +97,26 @@ const buildPrSection = (changedFiles, errors) => {
   const blocks = []
   let prErrorTotal = 0
   for (const file of [...changedFiles].sort()) {
-    const lines = errorLinesFor(errors, file)
-    if (lines.length === 0) {
-      blocks.push(`- :white_check_mark: \`${file}\` (0 errors)`)
-    } else {
-      prErrorTotal += lines.length
-      blocks.push(
-        `<details><summary><code>${file}</code> (${lines.length} errors)</summary>\n\n` +
-          '```\n' +
-          lines.join('\n') +
-          '\n```\n\n</details>'
-      )
+    const fileErrors = byFile.get(file) ?? []
+    if (fileErrors.length === 0) {
+      continue
+    }
+    prErrorTotal += fileErrors.length
+    blocks.push(
+      `<details><summary><code>${file}</code> (${fileErrors.length} errors)</summary>\n\n` +
+        '```\n' +
+        fileErrors.map((e) => e.line).join('\n') +
+        '\n```\n\n</details>'
+    )
+  }
+
+  if (blocks.length === 0) {
+    return {
+      section: '_no type errors in test files changed in this PR_',
+      prErrorTotal: 0
     }
   }
-  return { section: blocks.join('\n'), prErrorTotal }
+  return { section: blocks.join('\n\n'), prErrorTotal }
 }
 
 /**
@@ -128,7 +131,7 @@ const prHeader = (prErrorTotal) => {
 }
 
 /**
- * @param {ReturnType<typeof parseErrors>} errors
+ * @param {ParsedError[]} errors
  * @param {(code: number) => string} tsCodeLookup
  * @returns {string}
  */
@@ -149,14 +152,48 @@ const topCodesTable = (errors, tsCodeLookup) => {
 }
 
 /**
- * @param {ReturnType<typeof parseErrors>} errors
+ * @param {Map<string, ParsedError[]>} byFile
  * @returns {string}
  */
-const errorsByFileBlock = (errors) => {
-  const counts = [...countByFile(errors).entries()].sort(
-    (a, b) => b[1] - a[1] || a[0].localeCompare(b[0])
-  )
+const errorsByFileBlock = (byFile) => {
+  const counts = [...byFile.entries()]
+    .map(
+      ([file, errs]) => /** @type {[string, number]} */ ([file, errs.length])
+    )
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
   return counts.map(([file, count]) => `${count} ${file}`).join('\n')
+}
+
+/**
+ * @typedef {object} BuildPrCommentInput
+ * @property {string} tscOutput
+ * @property {string[]} changedFiles
+ * @property {string} [runUrl]
+ */
+
+/**
+ * @param {BuildPrCommentInput} input
+ * @returns {BuildSummaryResult}
+ */
+export const buildPrComment = ({ tscOutput, changedFiles, runUrl }) => {
+  const { byFile } = parseErrors(tscOutput)
+  const { section, prErrorTotal } = buildPrSection(changedFiles, byFile)
+
+  const lines = [
+    '## Lint Types - Tests',
+    '',
+    '### Errors in this PR',
+    '',
+    prHeader(prErrorTotal),
+    '',
+    section
+  ]
+  if (runUrl) {
+    lines.push('', `[View full summary](${runUrl})`)
+  }
+  lines.push('')
+
+  return { markdown: lines.join('\n'), exitCode: prErrorTotal > 0 ? 1 : 0 }
 }
 
 /**
@@ -164,10 +201,10 @@ const errorsByFileBlock = (errors) => {
  * @returns {BuildSummaryResult}
  */
 export const buildSummary = ({ tscOutput, changedFiles, tsCodeLookup }) => {
-  const errors = parseErrors(tscOutput)
+  const { errors, byFile } = parseErrors(tscOutput)
   const { section: section1, prErrorTotal } = buildPrSection(
     changedFiles,
-    errors
+    byFile
   )
 
   let section2
@@ -187,7 +224,7 @@ export const buildSummary = ({ tscOutput, changedFiles, tsCodeLookup }) => {
       '<details><summary>Errors by file (count)</summary>',
       '',
       '```',
-      errorsByFileBlock(errors),
+      errorsByFileBlock(byFile),
       '```',
       '',
       '</details>',
@@ -240,39 +277,39 @@ const tsCodeLookupFromPackage = (() => {
 })()
 
 /**
- * @returns {Promise<string>}
- */
-const readStdin = async () => {
-  const chunks = []
-  for await (const chunk of process.stdin) {
-    chunks.push(chunk)
-  }
-  return Buffer.concat(chunks).toString('utf8')
-}
-
-/**
  * @returns {string[]}
  */
 const changedFilesFromGit = () => {
-  const baseSha = process.env.BASE_SHA
-  if (!baseSha) {
+  const baseRef = process.env.BASE_REF
+  if (!baseRef) {
     return []
   }
   const out = execSync(
-    `git diff --name-only ${baseSha}...HEAD -- src/`
+    `git diff --name-only origin/${baseRef}...HEAD -- src/`
   ).toString()
   return filterTestFiles(out.split('\n').filter(Boolean))
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  const tscOutput = await readStdin()
+  const tscOutput = await text(process.stdin)
   const changedFiles = changedFilesFromGit()
-  const { markdown, exitCode } = buildSummary({
+
+  const summary = buildSummary({
     tscOutput,
     changedFiles,
     tsCodeLookup: tsCodeLookupFromPackage
   })
-  process.stdout.write(markdown)
-  process.exitCode = exitCode
+  process.stdout.write(summary.markdown)
+
+  if (process.env.COMMENT_FILE) {
+    const comment = buildPrComment({
+      tscOutput,
+      changedFiles,
+      runUrl: process.env.RUN_URL
+    })
+    writeFileSync(process.env.COMMENT_FILE, comment.markdown)
+  }
+
+  process.exitCode = summary.exitCode
 }
 /* v8 ignore stop */

--- a/scripts/lint-types-tests-summary.test.js
+++ b/scripts/lint-types-tests-summary.test.js
@@ -1,0 +1,250 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildSummary, filterTestFiles } from './lint-types-tests-summary.js'
+
+describe('lint-types-tests-summary', () => {
+  describe('filterTestFiles', () => {
+    it('should include .test.js files', () => {
+      const result = filterTestFiles([
+        'src/server/foo/foo.test.js',
+        'src/server/foo/foo.js'
+      ])
+
+      expect(result).toStrictEqual(['src/server/foo/foo.test.js'])
+    })
+
+    it('should include files under any test-helpers directory', () => {
+      const result = filterTestFiles([
+        'src/server/common/test-helpers/auth.js',
+        'src/server/common/helpers/auth.js'
+      ])
+
+      expect(result).toStrictEqual(['src/server/common/test-helpers/auth.js'])
+    })
+
+    it('should include test-fixtures.js files', () => {
+      const result = filterTestFiles([
+        'src/server/foo/test-fixtures.js',
+        'src/server/foo/fixtures.js'
+      ])
+
+      expect(result).toStrictEqual(['src/server/foo/test-fixtures.js'])
+    })
+
+    it('should include .d.ts files', () => {
+      const result = filterTestFiles([
+        'src/server/types/hapi.d.ts',
+        'src/server/types/hapi.js'
+      ])
+
+      expect(result).toStrictEqual(['src/server/types/hapi.d.ts'])
+    })
+  })
+
+  describe('buildSummary', () => {
+    const noopLookup = () => ''
+
+    describe('exit code', () => {
+      it('should be 0 when no test files changed', () => {
+        const result = buildSummary({
+          tscOutput: '',
+          changedFiles: [],
+          tsCodeLookup: noopLookup
+        })
+
+        expect(result.exitCode).toBe(0)
+      })
+
+      it('should be 0 when changed files have no errors', () => {
+        const result = buildSummary({
+          tscOutput:
+            "src/server/x/x.test.js(1,1): error TS2304: Cannot find name 'a'.",
+          changedFiles: ['src/server/foo/foo.test.js'],
+          tsCodeLookup: noopLookup
+        })
+
+        expect(result.exitCode).toBe(0)
+      })
+
+      it('should be 1 when any changed file has errors', () => {
+        const result = buildSummary({
+          tscOutput:
+            "src/server/foo/foo.test.js(1,1): error TS2304: Cannot find name 'a'.",
+          changedFiles: ['src/server/foo/foo.test.js'],
+          tsCodeLookup: noopLookup
+        })
+
+        expect(result.exitCode).toBe(1)
+      })
+    })
+
+    describe('section 1 - errors in this PR', () => {
+      it('should show placeholder when no test files changed', () => {
+        const { markdown } = buildSummary({
+          tscOutput: '',
+          changedFiles: [],
+          tsCodeLookup: noopLookup
+        })
+
+        expect(markdown).toContain('### Errors in this PR')
+        expect(markdown).toContain('_no test files changed in this PR_')
+      })
+
+      it('should list each changed file with a green tick when clean', () => {
+        const { markdown } = buildSummary({
+          tscOutput: '',
+          changedFiles: [
+            'src/server/foo/foo.test.js',
+            'src/server/bar/bar.test.js'
+          ],
+          tsCodeLookup: noopLookup
+        })
+
+        expect(markdown).toContain(
+          ':white_check_mark: `src/server/foo/foo.test.js` (0 errors)'
+        )
+        expect(markdown).toContain(
+          ':white_check_mark: `src/server/bar/bar.test.js` (0 errors)'
+        )
+      })
+
+      it('should emit collapsible details for files with errors', () => {
+        const tscOutput = [
+          "src/server/foo/foo.test.js(10,3): error TS2322: Type 'string' is not assignable to type 'number'.",
+          "src/server/foo/foo.test.js(15,5): error TS2304: Cannot find name 'bar'."
+        ].join('\n')
+
+        const { markdown } = buildSummary({
+          tscOutput,
+          changedFiles: ['src/server/foo/foo.test.js'],
+          tsCodeLookup: noopLookup
+        })
+
+        expect(markdown).toContain(
+          '<details><summary><code>src/server/foo/foo.test.js</code> (2 errors)</summary>'
+        )
+        expect(markdown).toContain(
+          "error TS2322: Type 'string' is not assignable to type 'number'."
+        )
+      })
+
+      it('should include total error count in the pr-scope header', () => {
+        const tscOutput = [
+          'src/server/foo/foo.test.js(10,3): error TS2322: a.',
+          'src/server/foo/foo.test.js(15,5): error TS2304: b.',
+          'src/server/bar/bar.test.js(1,1): error TS2304: c.'
+        ].join('\n')
+
+        const { markdown } = buildSummary({
+          tscOutput,
+          changedFiles: [
+            'src/server/foo/foo.test.js',
+            'src/server/bar/bar.test.js'
+          ],
+          tsCodeLookup: noopLookup
+        })
+
+        expect(markdown).toContain(
+          '**3 type error(s) in test files changed in this PR**'
+        )
+        expect(markdown).not.toContain('advisory')
+      })
+    })
+
+    describe('section 2 - all errors', () => {
+      it('should show passed when tsc had no errors', () => {
+        const { markdown } = buildSummary({
+          tscOutput: '',
+          changedFiles: [],
+          tsCodeLookup: noopLookup
+        })
+
+        expect(markdown).toContain('### All errors')
+        expect(markdown).toContain(':white_check_mark: Test type check passed')
+      })
+
+      it('should report total errors found', () => {
+        const tscOutput = [
+          'src/a.test.js(1,1): error TS2304: foo.',
+          'src/b.test.js(1,1): error TS2304: bar.',
+          'src/c.test.js(1,1): error TS2304: baz.'
+        ].join('\n')
+
+        const { markdown } = buildSummary({
+          tscOutput,
+          changedFiles: [],
+          tsCodeLookup: noopLookup
+        })
+
+        expect(markdown).toContain('**3 type errors found in tests**')
+        expect(markdown).not.toContain('advisory')
+      })
+
+      it('should include top error codes with description and typescript.tv link', () => {
+        const tscOutput =
+          "src/a.test.js(1,1): error TS2304: Cannot find name 'foo'."
+        const tsCodeLookup = (code) =>
+          code === 2304 ? "Cannot find name '{0}'." : ''
+
+        const { markdown } = buildSummary({
+          tscOutput,
+          changedFiles: [],
+          tsCodeLookup
+        })
+
+        expect(markdown).toContain(
+          "| 1 | [TS2304](https://typescript.tv/errors/ts2304/) | Cannot find name '{0}'. |"
+        )
+      })
+
+      it('should fall back to in-output message when lookup yields nothing', () => {
+        const tscOutput =
+          'src/a.test.js(1,1): error TS9999: Some weird internal error.'
+
+        const { markdown } = buildSummary({
+          tscOutput,
+          changedFiles: [],
+          tsCodeLookup: noopLookup
+        })
+
+        expect(markdown).toContain('Some weird internal error.')
+      })
+
+      it('should include errors by file count, sorted descending', () => {
+        const tscOutput = [
+          'src/a.test.js(1,1): error TS2304: x.',
+          'src/a.test.js(2,2): error TS2304: y.',
+          'src/b.test.js(1,1): error TS2304: z.'
+        ].join('\n')
+
+        const { markdown } = buildSummary({
+          tscOutput,
+          changedFiles: [],
+          tsCodeLookup: noopLookup
+        })
+
+        expect(markdown).toContain('Errors by file (count)')
+        expect(markdown).toContain('2 src/a.test.js\n')
+        expect(markdown).toContain('1 src/b.test.js\n')
+        expect(markdown).not.toMatch(/src\/[ab]\.test\.js:/)
+        expect(markdown.indexOf('src/a.test.js')).toBeLessThan(
+          markdown.indexOf('src/b.test.js')
+        )
+      })
+
+      it('should include the full error list verbatim', () => {
+        const tscOutput =
+          "src/a.test.js(1,1): error TS2304: Cannot find name 'foo'."
+
+        const { markdown } = buildSummary({
+          tscOutput,
+          changedFiles: [],
+          tsCodeLookup: noopLookup
+        })
+
+        expect(markdown).toContain('Full error list')
+        expect(markdown).toContain(tscOutput)
+      })
+    })
+  })
+})

--- a/scripts/lint-types-tests-summary.test.js
+++ b/scripts/lint-types-tests-summary.test.js
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildSummary, filterTestFiles } from './lint-types-tests-summary.js'
+import {
+  buildPrComment,
+  buildSummary,
+  filterTestFiles
+} from './lint-types-tests-summary.js'
 
 describe('lint-types-tests-summary', () => {
   describe('filterTestFiles', () => {
@@ -90,22 +94,23 @@ describe('lint-types-tests-summary', () => {
         expect(markdown).toContain('_no test files changed in this PR_')
       })
 
-      it('should list each changed file with a green tick when clean', () => {
+      it('should omit clean files from the section', () => {
+        const tscOutput =
+          "src/server/foo/foo.test.js(1,1): error TS2304: Cannot find name 'a'."
+
         const { markdown } = buildSummary({
-          tscOutput: '',
+          tscOutput,
           changedFiles: [
             'src/server/foo/foo.test.js',
-            'src/server/bar/bar.test.js'
+            'src/server/clean/clean.test.js'
           ],
           tsCodeLookup: noopLookup
         })
 
         expect(markdown).toContain(
-          ':white_check_mark: `src/server/foo/foo.test.js` (0 errors)'
+          '<details><summary><code>src/server/foo/foo.test.js</code>'
         )
-        expect(markdown).toContain(
-          ':white_check_mark: `src/server/bar/bar.test.js` (0 errors)'
-        )
+        expect(markdown).not.toContain('src/server/clean/clean.test.js')
       })
 
       it('should emit collapsible details for files with errors', () => {
@@ -245,6 +250,64 @@ describe('lint-types-tests-summary', () => {
         expect(markdown).toContain('Full error list')
         expect(markdown).toContain(tscOutput)
       })
+    })
+  })
+
+  describe('buildPrComment', () => {
+    it('should include the pr-scope section', () => {
+      const { markdown } = buildPrComment({
+        tscOutput:
+          "src/server/foo/foo.test.js(1,1): error TS2304: Cannot find name 'a'.",
+        changedFiles: ['src/server/foo/foo.test.js']
+      })
+
+      expect(markdown).toContain('Lint Types - Tests')
+      expect(markdown).toContain(
+        '<details><summary><code>src/server/foo/foo.test.js</code> (1 errors)</summary>'
+      )
+    })
+
+    it('should omit the all-errors section', () => {
+      const { markdown } = buildPrComment({
+        tscOutput: 'src/a.test.js(1,1): error TS2304: x.',
+        changedFiles: []
+      })
+
+      expect(markdown).not.toContain('All errors')
+      expect(markdown).not.toContain('Top error codes')
+      expect(markdown).not.toContain('Errors by file (count)')
+      expect(markdown).not.toContain('Full error list')
+    })
+
+    it('should include a link to the run when runUrl is given', () => {
+      const { markdown } = buildPrComment({
+        tscOutput: 'src/a.test.js(1,1): error TS2304: x.',
+        changedFiles: [],
+        runUrl: 'https://github.com/o/r/actions/runs/123'
+      })
+
+      expect(markdown).toContain(
+        '[View full summary](https://github.com/o/r/actions/runs/123)'
+      )
+    })
+
+    it('should not include a run-url link when runUrl is omitted', () => {
+      const { markdown } = buildPrComment({
+        tscOutput: 'src/a.test.js(1,1): error TS2304: x.',
+        changedFiles: []
+      })
+
+      expect(markdown).not.toContain('View full summary')
+    })
+
+    it('should propagate exit code when changed files have errors', () => {
+      const result = buildPrComment({
+        tscOutput:
+          "src/server/foo/foo.test.js(1,1): error TS2304: Cannot find name 'a'.",
+        changedFiles: ['src/server/foo/foo.test.js']
+      })
+
+      expect(result.exitCode).toBe(1)
     })
   })
 })


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)

type-checks test files and emits an advisory ci summary (top error codes with descriptions, errors-by-file, full list).

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ