### PR TITLE
PAE-1478: Show waste balance on registration overview for accredited registrations

### DIFF
--- a/src/server/routes/registration-overview/controller.get.js
+++ b/src/server/routes/registration-overview/controller.get.js
@@ -33,6 +33,20 @@ const toSummaryLogTableRow =
     ]
   }
 
+const fetchWasteBalance = async (request, organisationId, accreditationId) => {
+  try {
+    const balanceMap = await fetchJsonFromBackend(
+      request,
+      `/v1/organisations/${organisationId}/waste-balances?accreditationIds=${accreditationId}`,
+      {}
+    )
+    return balanceMap[accreditationId] ?? null
+  } catch (err) {
+    request.logger.warn({ message: 'Failed to fetch waste balance', err })
+    return null
+  }
+}
+
 export const registrationOverviewGETController = {
   async handler(request, h) {
     const { organisationId, registrationId } = request.params
@@ -56,6 +70,14 @@ export const registrationOverviewGETController = {
       organisationId,
       registrationId
     )
+
+    const wasteBalance = registration.accreditation
+      ? await fetchWasteBalance(
+          request,
+          organisationId,
+          registration.accreditation.id
+        )
+      : null
 
     const pageTitle = request.route.settings.app.pageTitle
 
@@ -83,7 +105,8 @@ export const registrationOverviewGETController = {
         ...rp,
         formattedPeriod: formatPeriod(rp.period, calendar.cadence)
       })),
-      summaryLogRows
+      summaryLogRows,
+      wasteBalance
     })
   }
 }

--- a/src/server/routes/registration-overview/get.integration.test.js
+++ b/src/server/routes/registration-overview/get.integration.test.js
@@ -36,6 +36,8 @@ describe('#registrationOverviewController', () => {
     vi.clearAllMocks()
   })
 
+  const accreditationId = '69c3b4f0abda9efa68dd6698'
+
   /**
    * @type {{
    *   id: string,
@@ -55,10 +57,15 @@ describe('#registrationOverviewController', () => {
     material: 'glass',
     site: 'Site A',
     accreditation: {
-      id: '69c3b4f0abda9efa68dd6698',
+      id: accreditationId,
       accreditationNumber: 'ACC-50030-001',
       status: 'approved'
     }
+  }
+
+  const mockWasteBalance = {
+    amount: 1500,
+    availableAmount: 1200
   }
 
   const mockOverview = {
@@ -133,7 +140,8 @@ describe('#registrationOverviewController', () => {
     calendarResponse = mockCalendar,
     summaryLogsResponse = {
       summaryLogs: /** @type {Array<typeof mockSubmittedSummaryLog>} */ ([])
-    }
+    },
+    wasteBalanceResponse = { [accreditationId]: mockWasteBalance }
   ) => {
     mswServer.use(
       http.get(
@@ -147,6 +155,10 @@ describe('#registrationOverviewController', () => {
       http.get(
         `${backendUrl}/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs`,
         () => HttpResponse.json(summaryLogsResponse)
+      ),
+      http.get(
+        `${backendUrl}/v1/organisations/${organisationId}/waste-balances`,
+        () => HttpResponse.json(wasteBalanceResponse)
       )
     )
   }
@@ -504,6 +516,94 @@ describe('#registrationOverviewController', () => {
       expect(result).toEqual(
         expect.stringContaining('Sorry, there is a problem with the service')
       )
+    })
+
+    describe('Waste balance section', () => {
+      const findWasteBalanceSection = ($) => $('#waste-balance')
+
+      test('Should render the waste balance table with amount and available amount when accredited', async () => {
+        useMockBackend()
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        const $ = cheerio.load(result)
+        const section = findWasteBalanceSection($)
+        expect(section).toHaveLength(1)
+
+        const headers = section.find('thead tr th')
+        expect($(headers[0]).text().trim()).toEqual('Amount (tonnes)')
+        expect($(headers[1]).text().trim()).toEqual('Available amount (tonnes)')
+
+        const cells = section.find('tbody tr td')
+        expect($(cells[0]).text().trim()).toEqual('1500')
+        expect($(cells[1]).text().trim()).toEqual('1200')
+      })
+
+      test('Should not render the waste balance section when the registration has no accreditation', async () => {
+        useMockBackend({
+          ...mockOverview,
+          registrations: [{ ...mockRegistration, accreditation: null }]
+        })
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        const $ = cheerio.load(result)
+        expect(findWasteBalanceSection($)).toHaveLength(0)
+      })
+
+      test('Should not render the waste balance section when the backend returns no balance', async () => {
+        useMockBackend(mockOverview, mockCalendar, { summaryLogs: [] }, {})
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        const $ = cheerio.load(result)
+        expect(findWasteBalanceSection($)).toHaveLength(0)
+      })
+
+      test('Should still render the page when the waste balance endpoint errors', async () => {
+        mswServer.use(
+          http.get(
+            `${backendUrl}/v1/organisations/${organisationId}/overview`,
+            () => HttpResponse.json(mockOverview)
+          ),
+          http.get(
+            `${backendUrl}/v1/organisations/${organisationId}/registrations/${registrationId}/reports/calendar`,
+            () => HttpResponse.json(mockCalendar)
+          ),
+          http.get(
+            `${backendUrl}/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs`,
+            () => HttpResponse.json({ summaryLogs: [] })
+          ),
+          http.get(
+            `${backendUrl}/v1/organisations/${organisationId}/waste-balances`,
+            () => {
+              throw HttpResponse.text('', { status: 500 })
+            }
+          )
+        )
+
+        const { statusCode, result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        expect(statusCode).toBe(statusCodes.ok)
+        const $ = cheerio.load(result)
+        expect(findWasteBalanceSection($)).toHaveLength(0)
+      })
     })
 
     describe('Unsubmit link visibility', () => {

--- a/src/server/routes/registration-overview/get.integration.test.js
+++ b/src/server/routes/registration-overview/get.integration.test.js
@@ -559,7 +559,7 @@ describe('#registrationOverviewController', () => {
         expect(findWasteBalanceSection($)).toHaveLength(0)
       })
 
-      test('Should not render the waste balance section when the backend returns no balance', async () => {
+      test('Should render "No waste balance data" when the backend returns no balance for the accreditation', async () => {
         useMockBackend(mockOverview, mockCalendar, { summaryLogs: [] }, {})
 
         const { result } = await server.inject({
@@ -569,10 +569,13 @@ describe('#registrationOverviewController', () => {
         })
 
         const $ = cheerio.load(result)
-        expect(findWasteBalanceSection($)).toHaveLength(0)
+        const section = findWasteBalanceSection($)
+        expect(section).toHaveLength(1)
+        expect(section.find('table')).toHaveLength(0)
+        expect(result).toContain('No waste balance data')
       })
 
-      test('Should still render the page when the waste balance endpoint errors', async () => {
+      test('Should still render the page with "No waste balance data" when the waste balance endpoint errors', async () => {
         mswServer.use(
           http.get(
             `${backendUrl}/v1/organisations/${organisationId}/overview`,
@@ -602,7 +605,10 @@ describe('#registrationOverviewController', () => {
 
         expect(statusCode).toBe(statusCodes.ok)
         const $ = cheerio.load(result)
-        expect(findWasteBalanceSection($)).toHaveLength(0)
+        const section = findWasteBalanceSection($)
+        expect(section).toHaveLength(1)
+        expect(section.find('table')).toHaveLength(0)
+        expect(result).toContain('No waste balance data')
       })
     })
 

--- a/src/server/routes/registration-overview/get.integration.test.js
+++ b/src/server/routes/registration-overview/get.integration.test.js
@@ -141,7 +141,9 @@ describe('#registrationOverviewController', () => {
     summaryLogsResponse = {
       summaryLogs: /** @type {Array<typeof mockSubmittedSummaryLog>} */ ([])
     },
-    wasteBalanceResponse = { [accreditationId]: mockWasteBalance }
+    wasteBalanceResponse = /** @type {Record<string, typeof mockWasteBalance>} */ ({
+      [accreditationId]: mockWasteBalance
+    })
   ) => {
     mswServer.use(
       http.get(

--- a/src/server/routes/registration-overview/index.njk
+++ b/src/server/routes/registration-overview/index.njk
@@ -84,5 +84,23 @@
         {% endif %}
       </div>
     </div>
+    {% if registration.accreditation and wasteBalance %}
+      <div class="govuk-grid-row">
+        <div id="waste-balance" class="govuk-grid-column-two-thirds">
+          {{ govukTable({
+            caption: "Waste balance",
+            captionClasses: "govuk-table__caption--m",
+            head: [
+              { text: "Amount (tonnes)" },
+              { text: "Available amount (tonnes)" }
+            ],
+            rows: [[
+              { text: wasteBalance.amount },
+              { text: wasteBalance.availableAmount }
+            ]]
+          }) }}
+        </div>
+      </div>
+    {% endif %}
   </div>
 {% endblock %}

--- a/src/server/routes/registration-overview/index.njk
+++ b/src/server/routes/registration-overview/index.njk
@@ -84,21 +84,26 @@
         {% endif %}
       </div>
     </div>
-    {% if registration.accreditation and wasteBalance %}
+    {% if registration.accreditation %}
       <div class="govuk-grid-row">
         <div id="waste-balance" class="govuk-grid-column-two-thirds">
-          {{ govukTable({
-            caption: "Waste balance",
-            captionClasses: "govuk-table__caption--m",
-            head: [
-              { text: "Amount (tonnes)" },
-              { text: "Available amount (tonnes)" }
-            ],
-            rows: [[
-              { text: wasteBalance.amount },
-              { text: wasteBalance.availableAmount }
-            ]]
-          }) }}
+          {% if wasteBalance %}
+            {{ govukTable({
+              caption: "Waste balance",
+              captionClasses: "govuk-table__caption--m",
+              head: [
+                { text: "Amount (tonnes)" },
+                { text: "Available amount (tonnes)" }
+              ],
+              rows: [[
+                { text: wasteBalance.amount },
+                { text: wasteBalance.availableAmount }
+              ]]
+            }) }}
+          {% else %}
+            <h2 class="govuk-heading-m">Waste balance</h2>
+            <p class="govuk-body">No waste balance data</p>
+          {% endif %}
         </div>
       </div>
     {% endif %}


### PR DESCRIPTION
Ticket: [PAE-1478](https://eaflood.atlassian.net/browse/PAE-1478)
## Summary

- Add a "Waste balance" section to the registration overview page, visible only for accredited registrations
- Display current `amount` and `availableAmount` fetched from the existing waste-balances endpoint

<img width="2176" height="1086" alt="image" src="https://github.com/user-attachments/assets/0ca7df07-0d46-4222-8ec0-cfc830fb6103" />


## Linked issue

PAE-1478 - Discrepancies in waste balance

[PAE-1478]: https://eaflood.atlassian.net/browse/PAE-1478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ