### PR TITLE
PAE-250: Fix @hapi/content and @hapi/wreck vulnerabilities

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,8 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.25.1
-ignore: {}
+ignore:
+  'SNYK-JS-POSTCSSSELECTORPARSER-16873882':
+    - '*':
+        reason: 'No upstream fix available. postcss-selector-parser is pulled in transitively by cssnano during the webpack CSS build only and is never reached at application runtime, so the uncontrolled-recursion DoS is not exploitable here. Revisit when a patched version is published.'
+        expires: '2026-11-27T00:00:00.000Z'
 patch: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2473,9 +2473,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/content": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.1.tgz",
-      "integrity": "sha512-lQ2vOoFMNYxwKVnKf+3Pi3PfoviM4EJYlT9JbrBPfEc0xKMiVDqqXF8UTE1S1oKhHQliWSP5t6zTKNlmaXBGcQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.2.tgz",
+      "integrity": "sha512-OKyCOTjNR1hftwSjk9ueyAQTw8AwapvzBrPIWMGn39vhR5PmqLdYFmLc35bsSBye7gSMnlkXfc679bUdMIcRyQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/boom": "^10.0.0"
@@ -2870,9 +2870,9 @@
       }
     },
     "node_modules/@hapi/wreck": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.1.0.tgz",
-      "integrity": "sha512-0z6ZRCmFEfV/MQqkQomJ7sl/hyxvcZM7LtuVqN3vdAO4vM9eBbowl0kaqQj9EJJQab+3Uuh1GxbGIBFy4NfJ4w==",
+      "version": "18.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.1.1.tgz",
+      "integrity": "sha512-UwTeGBfAnB/1mkw4gD6IQGI/bgMu7iGmqgT8K+xxye3z4ZHhCZlmS2wuHBJmENhBJSKqvoYzJ71ds3Xfq4gofQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/boom": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,8 @@
     "webpack-cli": "7.0.2"
   },
   "overrides": {
+    "@hapi/content": "6.0.2",
+    "@hapi/wreck": "18.1.1",
     "jsoneditor": {
       "ajv": "6.14.0"
     },


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## What changed

Pins two transitively-pulled hapi dependencies to their patched versions via npm `overrides`, and documents one advisory with no upstream fix. There are no application code changes.

- `@hapi/content` → 6.0.2 — fixes a header-parser parameter-smuggling issue where duplicate parameters could bypass upload filters (high, GHSA-36hh-x5p5-jgc8). Reaches us transitively through `@hapi/hapi` → `@hapi/subtext`.
- `@hapi/wreck` → 18.1.1 — fixes a leak of the `Proxy-Authorization` header to a different host on a cross-hostname redirect (moderate, GHSA-vhjm-w67q-g75c). Reaches us through `@hapi/bell`.

## postcss-selector-parser (no upstream fix)

Snyk flags an uncontrolled-recursion DoS in `postcss-selector-parser` 7.1.1 (moderate, SNYK-JS-POSTCSSSELECTORPARSER-16873882) for which no patched version exists. It is pulled in transitively by `cssnano` during the webpack CSS build and is never reached at application runtime, so the issue is not exploitable here. It is recorded in `.snyk` with a six-month expiry so it resurfaces for review once a fix is available.


[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ