### PR TITLE
PAE-250: Prune stale @hapi/content and @hapi/wreck overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,8 +124,6 @@
     "webpack-cli": "7.0.2"
   },
   "overrides": {
-    "@hapi/content": "6.0.2",
-    "@hapi/wreck": "18.1.1",
     "jsoneditor": {
       "ajv": "6.14.0"
     },


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## What

The `@hapi/content` and `@hapi/wreck` `overrides` entries were added to force patched transitive dependencies. The tree has since moved on: removing both and re-resolving leaves them at safe versions, with `npm audit`, `snyk test` and the full test suite all clean, so the entries are removed.

The nested compatibility overrides (`jsoneditor` → `ajv`, `ajv-cli` → `fast-json-patch`, `stylelint-config-gds` → `stylelint`) are left untouched — they shim version compatibility rather than patch a vulnerability. The existing `postcss-selector-parser` Snyk ignore was re-tested and still suppresses a live build-time finding, so it stays.


[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ