### PR TITLE
PAE-1382: Add waste balance events page for accreditation

### DIFF
--- a/src/server/common/enums/error-codes.js
+++ b/src/server/common/enums/error-codes.js
@@ -5,5 +5,6 @@
 export const errorCodes = {
   externalFetchFailed: 'external_fetch_failed',
   externalRedirectInvalid: 'external_redirect_invalid',
-  registrationNotFound: 'registration_not_found'
+  registrationNotFound: 'registration_not_found',
+  accreditationNotFound: 'accreditation_not_found'
 }

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -22,6 +22,7 @@ import { reportSubmissions } from './routes/report-submissions/index.js'
 import { wasteRecordsExport } from './routes/waste-records-export/index.js'
 import { queueManagement } from './routes/queue-management/index.js'
 import { reportUnsubmit } from './routes/report-unsubmit/index.js'
+import { wasteBalanceEvents } from './routes/waste-balance-events/index.js'
 
 import { serveStaticFiles } from './common/helpers/serve-static-files.js'
 
@@ -56,7 +57,8 @@ export const router = {
         reportSubmissions,
         wasteRecordsExport,
         queueManagement,
-        reportUnsubmit
+        reportUnsubmit,
+        wasteBalanceEvents
       ])
 
       await server.register([serveStaticFiles])

--- a/src/server/routes/registration-overview/controller.get.js
+++ b/src/server/routes/registration-overview/controller.get.js
@@ -106,7 +106,10 @@ export const registrationOverviewGETController = {
         formattedPeriod: formatPeriod(rp.period, calendar.cadence)
       })),
       summaryLogRows,
-      wasteBalance
+      wasteBalance,
+      wasteBalanceEventsUrl: registration.accreditation
+        ? `/organisations/${organisationId}/accreditations/${registration.accreditation.id}/waste-balance-events`
+        : null
     })
   }
 }

--- a/src/server/routes/registration-overview/get.integration.test.js
+++ b/src/server/routes/registration-overview/get.integration.test.js
@@ -322,6 +322,27 @@ describe('#registrationOverviewController', () => {
       ).toHaveClass('govuk-tag')
     })
 
+    test('Should render a waste balance events link when accreditation exists', async () => {
+      useMockBackend()
+
+      const { result } = await server.inject({
+        method: 'GET',
+        url,
+        auth: { strategy: 'session', credentials: mockUserSession }
+      })
+
+      const body = renderPage(result)
+      const eventsValue = getSummaryRowValue(body, 'Waste balance events')
+      const link = within(eventsValue).getByRole('link', {
+        name: 'View'
+      })
+
+      expect(link).toHaveAttribute(
+        'href',
+        `/organisations/${organisationId}/accreditations/${accreditationId}/waste-balance-events`
+      )
+    })
+
     test('Should not render accreditation rows in summary list when accreditation is absent', async () => {
       useMockBackend({
         ...mockOverview,

--- a/src/server/routes/registration-overview/get.integration.test.js
+++ b/src/server/routes/registration-overview/get.integration.test.js
@@ -363,6 +363,9 @@ describe('#registrationOverviewController', () => {
       expect(
         queryByText(body, 'Accreditation status', { selector: 'dt' })
       ).toBeNull()
+      expect(
+        queryByText(body, 'Waste balance events', { selector: 'dt' })
+      ).toBeNull()
     })
 
     test('Should render the reporting periods table', async () => {

--- a/src/server/routes/registration-overview/index.njk
+++ b/src/server/routes/registration-overview/index.njk
@@ -14,11 +14,13 @@
       { key: { text: "Site" }, value: { text: registration.site } }
     ] %}
     {% if registration.accreditation %}
+      {% set wasteBalanceEventsUrl = '/organisations/' ~ organisationId ~ '/accreditations/' ~ registration.accreditation.id ~ '/waste-balance-events' %}
       {% set summaryRows = summaryRows.concat([
         { key: { text: "Accreditation number" }, value: { text: registration.accreditation.accreditationNumber } },
         { key: { text: "Accreditation status" }, value: { html: govukTag({ text: registration.accreditation.status }) } },
         { key: { text: "Waste balance (tonnes)" }, value: { text: wasteBalance.amount if wasteBalance else "No data" } },
-        { key: { text: "Waste balance available (tonnes)" }, value: { text: wasteBalance.availableAmount if wasteBalance else "No data" } }
+        { key: { text: "Waste balance available (tonnes)" }, value: { text: wasteBalance.availableAmount if wasteBalance else "No data" } },
+        { key: { text: "Waste balance events" }, value: { html: '<a class="govuk-link govuk-link--no-visited-state" href="' ~ wasteBalanceEventsUrl ~ '">View</a>' } }
       ]) %}
     {% endif %}
 

--- a/src/server/routes/registration-overview/index.njk
+++ b/src/server/routes/registration-overview/index.njk
@@ -14,7 +14,6 @@
       { key: { text: "Site" }, value: { text: registration.site } }
     ] %}
     {% if registration.accreditation %}
-      {% set wasteBalanceEventsUrl = '/organisations/' ~ organisationId ~ '/accreditations/' ~ registration.accreditation.id ~ '/waste-balance-events' %}
       {% set summaryRows = summaryRows.concat([
         { key: { text: "Accreditation number" }, value: { text: registration.accreditation.accreditationNumber } },
         { key: { text: "Accreditation status" }, value: { html: govukTag({ text: registration.accreditation.status }) } },

--- a/src/server/routes/waste-balance-events/controller.get.js
+++ b/src/server/routes/waste-balance-events/controller.get.js
@@ -15,14 +15,7 @@ export const wasteBalanceEventsGETController = {
   async handler(request, h) {
     const { organisationId, accreditationId } = request.params
 
-    const [overview, events] = await Promise.all([
-      fetchOrganisationOverview(request, organisationId),
-      fetchJsonFromBackend(
-        request,
-        `/v1/admin/organisations/${organisationId}/accreditations/${accreditationId}/waste-balance-events`,
-        {}
-      )
-    ])
+    const overview = await fetchOrganisationOverview(request, organisationId)
 
     const registration = findRegistrationByAccreditation(
       overview,
@@ -41,6 +34,12 @@ export const wasteBalanceEventsGETController = {
         }
       )
     }
+
+    const events = await fetchJsonFromBackend(
+      request,
+      `/v1/admin/registrations/${registration.id}/accreditations/${accreditationId}/waste-balance-events`,
+      {}
+    )
 
     const heading = `${overview.companyName} - ${registration.accreditation.accreditationNumber}`
 

--- a/src/server/routes/waste-balance-events/controller.get.js
+++ b/src/server/routes/waste-balance-events/controller.get.js
@@ -22,7 +22,7 @@ export const wasteBalanceEventsGETController = {
       accreditationId
     )
 
-    if (!registration) {
+    if (!registration?.accreditation) {
       throw notFound(
         'Accreditation not found',
         errorCodes.accreditationNotFound,

--- a/src/server/routes/waste-balance-events/controller.get.js
+++ b/src/server/routes/waste-balance-events/controller.get.js
@@ -17,7 +17,7 @@ export const wasteBalanceEventsGETController = {
       fetchOrganisationOverview(request, organisationId),
       fetchJsonFromBackend(
         request,
-        `/v1/admin/organisations/${organisationId}/accreditations/${accreditationId}/stream-events`,
+        `/v1/admin/organisations/${organisationId}/accreditations/${accreditationId}/waste-balance-events`,
         {}
       )
     ])

--- a/src/server/routes/waste-balance-events/controller.get.js
+++ b/src/server/routes/waste-balance-events/controller.get.js
@@ -1,0 +1,65 @@
+import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
+import { fetchOrganisationOverview } from '#server/common/helpers/fetch-organisation-overview.js'
+
+/**
+ * Find the registration linked to the given accreditation.
+ * @param {import('#server/common/helpers/fetch-organisation-overview.js').OrganisationOverview} overview
+ * @param {string} accreditationId
+ */
+const findRegistrationByAccreditation = (overview, accreditationId) =>
+  overview.registrations.find((r) => r.accreditation?.id === accreditationId)
+
+export const wasteBalanceEventsGETController = {
+  async handler(request, h) {
+    const { organisationId, accreditationId } = request.params
+
+    const [overview, events] = await Promise.all([
+      fetchOrganisationOverview(request, organisationId),
+      fetchJsonFromBackend(
+        request,
+        `/v1/admin/organisations/${organisationId}/accreditations/${accreditationId}/stream-events`,
+        {}
+      )
+    ])
+
+    const registration = findRegistrationByAccreditation(
+      overview,
+      accreditationId
+    )
+
+    const accreditationLabel =
+      registration?.accreditation?.accreditationNumber ?? accreditationId
+
+    const heading = `${overview.companyName} - ${accreditationLabel}`
+
+    const eventRows = events.map((event) => [
+      { text: event.number },
+      { text: event.kind },
+      { text: event.createdAt },
+      { html: `<code>${JSON.stringify(event.payload)}</code>` },
+      { text: event.closingBalance.amount },
+      { text: event.closingBalance.availableAmount }
+    ])
+
+    return h.view('routes/waste-balance-events/index', {
+      breadcrumbs: [
+        { text: 'Organisations', href: '/organisations' },
+        {
+          text: 'Organisation overview',
+          href: `/organisations/${organisationId}/overview`
+        },
+        ...(registration
+          ? [
+              {
+                text: 'Registration overview',
+                href: `/organisations/${organisationId}/registrations/${registration.id}/overview`
+              }
+            ]
+          : [])
+      ],
+      pageTitle: request.route.settings.app.pageTitle,
+      heading,
+      eventRows
+    })
+  }
+}

--- a/src/server/routes/waste-balance-events/controller.get.js
+++ b/src/server/routes/waste-balance-events/controller.get.js
@@ -1,5 +1,7 @@
+import { errorCodes } from '#server/common/enums/error-codes.js'
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
 import { fetchOrganisationOverview } from '#server/common/helpers/fetch-organisation-overview.js'
+import { notFound } from '#server/common/helpers/logging/cdp-boom.js'
 
 /**
  * Find the registration linked to the given accreditation.
@@ -27,10 +29,20 @@ export const wasteBalanceEventsGETController = {
       accreditationId
     )
 
-    const accreditationLabel =
-      registration?.accreditation?.accreditationNumber ?? accreditationId
+    if (!registration) {
+      throw notFound(
+        'Accreditation not found',
+        errorCodes.accreditationNotFound,
+        {
+          event: {
+            action: 'fetch_waste_balance_events',
+            reason: `organisationId=${organisationId} accreditationId=${accreditationId}`
+          }
+        }
+      )
+    }
 
-    const heading = `${overview.companyName} - ${accreditationLabel}`
+    const heading = `${overview.companyName} - ${registration.accreditation.accreditationNumber}`
 
     const eventRows = events.map((event) => [
       { text: event.number },
@@ -48,14 +60,10 @@ export const wasteBalanceEventsGETController = {
           text: 'Organisation overview',
           href: `/organisations/${organisationId}/overview`
         },
-        ...(registration
-          ? [
-              {
-                text: 'Registration overview',
-                href: `/organisations/${organisationId}/registrations/${registration.id}/overview`
-              }
-            ]
-          : [])
+        {
+          text: 'Registration overview',
+          href: `/organisations/${organisationId}/registrations/${registration.id}/overview`
+        }
       ],
       pageTitle: request.route.settings.app.pageTitle,
       heading,

--- a/src/server/routes/waste-balance-events/get.integration.test.js
+++ b/src/server/routes/waste-balance-events/get.integration.test.js
@@ -131,7 +131,7 @@ describe('#wasteBalanceEventsController', () => {
         () => HttpResponse.json(overviewResponse)
       ),
       http.get(
-        `${backendUrl}/v1/admin/organisations/${organisationId}/accreditations/${accreditationId}/waste-balance-events`,
+        `${backendUrl}/v1/admin/registrations/reg-001/accreditations/${accreditationId}/waste-balance-events`,
         () => HttpResponse.json(eventsResponse)
       )
     )

--- a/src/server/routes/waste-balance-events/get.integration.test.js
+++ b/src/server/routes/waste-balance-events/get.integration.test.js
@@ -1,0 +1,348 @@
+import { config } from '#config/config.js'
+import { statusCodes } from '#server/common/constants/status-codes.js'
+import { getUserSession } from '#server/common/helpers/auth/get-user-session.js'
+import { mockUserSession } from '#server/common/test-helpers/fixtures.js'
+import { createMockOidcServer } from '#server/common/test-helpers/mock-oidc.js'
+import { createServer } from '#server/server.js'
+import { http, HttpResponse, server as mswServer } from '#vite/setup-msw.js'
+import {
+  getAllByRole,
+  getByRole,
+  getByText,
+  queryByRole
+} from '@testing-library/dom'
+import { Window } from 'happy-dom'
+import { vi } from 'vitest'
+
+vi.mock('#server/common/helpers/auth/get-user-session.js', () => ({
+  getUserSession: vi.fn().mockReturnValue(null)
+}))
+
+describe('#wasteBalanceEventsController', () => {
+  const originalBackendUrl = config.get('eprBackendUrl')
+  const backendUrl = 'http://mock-backend'
+  const organisationId = '69c3b4f0abda9efa68dd6697'
+  const accreditationId = '69c3b4f0abda9efa68dd6698'
+  const url = `/organisations/${organisationId}/accreditations/${accreditationId}/waste-balance-events`
+  let server
+
+  beforeAll(async () => {
+    config.set('eprBackendUrl', backendUrl)
+    createMockOidcServer()
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    config.set('eprBackendUrl', originalBackendUrl)
+    await server.stop({ timeout: 0 })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const mockOverview = {
+    id: organisationId,
+    companyName: 'ACME ltd',
+    registrations: [
+      {
+        id: 'reg-001',
+        registrationNumber: 'REG-50030-001',
+        status: 'approved',
+        processingType: 'reprocessing',
+        material: 'glass',
+        site: 'Site A',
+        accreditation: {
+          id: accreditationId,
+          accreditationNumber: 'ACC-50030-001',
+          status: 'approved'
+        }
+      }
+    ]
+  }
+
+  const mockOverviewNoAccreditationLink = {
+    id: organisationId,
+    companyName: 'ACME ltd',
+    registrations: [
+      {
+        id: 'reg-001',
+        registrationNumber: 'REG-50030-001',
+        status: 'approved',
+        processingType: 'reprocessing',
+        material: 'glass',
+        site: 'Site A',
+        accreditation: null
+      }
+    ]
+  }
+
+  const mockEvents = [
+    {
+      id: 'evt-1',
+      registrationId: 'reg-001',
+      accreditationId,
+      organisationId,
+      number: 1,
+      kind: 'SUMMARY_LOG_SUBMITTED',
+      payload: { summaryLogId: 'sl-1', creditTotal: 100 },
+      openingBalance: { amount: 0, availableAmount: 0 },
+      closingBalance: { amount: 100, availableAmount: 100 },
+      createdAt: '2026-01-15T10:00:00.000Z',
+      createdBy: { id: 'user-1', name: 'Test User' }
+    },
+    {
+      id: 'evt-2',
+      registrationId: 'reg-001',
+      accreditationId,
+      organisationId,
+      number: 2,
+      kind: 'PRN_CREATED',
+      payload: { prnId: 'prn-1', amount: 50 },
+      openingBalance: { amount: 100, availableAmount: 100 },
+      closingBalance: { amount: 100, availableAmount: 50 },
+      createdAt: '2026-01-16T14:30:00.000Z',
+      createdBy: { id: 'user-1', name: 'Test User' }
+    }
+  ]
+
+  const renderPage = (html) => {
+    const window = new Window()
+    window.document.body.innerHTML = html
+    return /** @type {HTMLElement} */ (
+      /** @type {unknown} */ (window.document.body)
+    )
+  }
+
+  const getEventsTable = (container) =>
+    getByRole(container, 'table', { name: 'Waste balance events' })
+
+  const getDataRows = (table) => getAllByRole(table, 'row').slice(1)
+
+  const useMockBackend = (
+    overviewResponse = mockOverview,
+    eventsResponse = mockEvents
+  ) => {
+    mswServer.use(
+      http.get(
+        `${backendUrl}/v1/organisations/${organisationId}/overview`,
+        () => HttpResponse.json(overviewResponse)
+      ),
+      http.get(
+        `${backendUrl}/v1/admin/organisations/${organisationId}/accreditations/${accreditationId}/stream-events`,
+        () => HttpResponse.json(eventsResponse)
+      )
+    )
+  }
+
+  describe('When user is unauthenticated', () => {
+    test('Should return unauthorised status code', async () => {
+      const { statusCode } = await server.inject({ method: 'GET', url })
+
+      expect(statusCode).toBe(statusCodes.unauthorised)
+    })
+  })
+
+  describe('When user is authenticated', () => {
+    beforeAll(() => {
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+    })
+
+    test('Should return OK', async () => {
+      useMockBackend()
+
+      const { statusCode } = await server.inject({
+        method: 'GET',
+        url,
+        auth: { strategy: 'session', credentials: mockUserSession }
+      })
+
+      expect(statusCode).toBe(statusCodes.ok)
+    })
+
+    test('Should render the heading with company name and accreditation number', async () => {
+      useMockBackend()
+
+      const { result } = await server.inject({
+        method: 'GET',
+        url,
+        auth: { strategy: 'session', credentials: mockUserSession }
+      })
+
+      const body = renderPage(result)
+
+      expect(getByRole(body, 'heading', { level: 1 })).toHaveTextContent(
+        'ACME ltd - ACC-50030-001'
+      )
+    })
+
+    test('Should fall back to accreditationId in heading when no registration links to it', async () => {
+      useMockBackend(mockOverviewNoAccreditationLink)
+
+      const { result } = await server.inject({
+        method: 'GET',
+        url,
+        auth: { strategy: 'session', credentials: mockUserSession }
+      })
+
+      const body = renderPage(result)
+
+      expect(getByRole(body, 'heading', { level: 1 })).toHaveTextContent(
+        `ACME ltd - ${accreditationId}`
+      )
+    })
+
+    test('Should render breadcrumbs back to registration overview', async () => {
+      useMockBackend()
+
+      const { result } = await server.inject({
+        method: 'GET',
+        url,
+        auth: { strategy: 'session', credentials: mockUserSession }
+      })
+
+      const body = renderPage(result)
+      const breadcrumbs = getByRole(body, 'navigation', {
+        name: 'Breadcrumb'
+      })
+
+      expect(
+        getAllByRole(breadcrumbs, 'link').map((l) => ({
+          text: l.textContent?.trim(),
+          href: l.getAttribute('href')
+        }))
+      ).toEqual([
+        { text: 'Organisations', href: '/organisations' },
+        {
+          text: 'Organisation overview',
+          href: `/organisations/${organisationId}/overview`
+        },
+        {
+          text: 'Registration overview',
+          href: `/organisations/${organisationId}/registrations/reg-001/overview`
+        }
+      ])
+    })
+
+    test('Should omit registration breadcrumb when no registration links to the accreditation', async () => {
+      useMockBackend(mockOverviewNoAccreditationLink)
+
+      const { result } = await server.inject({
+        method: 'GET',
+        url,
+        auth: { strategy: 'session', credentials: mockUserSession }
+      })
+
+      const body = renderPage(result)
+      const breadcrumbs = getByRole(body, 'navigation', {
+        name: 'Breadcrumb'
+      })
+
+      expect(
+        getAllByRole(breadcrumbs, 'link').map((l) => ({
+          text: l.textContent?.trim(),
+          href: l.getAttribute('href')
+        }))
+      ).toEqual([
+        { text: 'Organisations', href: '/organisations' },
+        {
+          text: 'Organisation overview',
+          href: `/organisations/${organisationId}/overview`
+        }
+      ])
+    })
+
+    test('Should render events table with correct columns', async () => {
+      useMockBackend()
+
+      const { result } = await server.inject({
+        method: 'GET',
+        url,
+        auth: { strategy: 'session', credentials: mockUserSession }
+      })
+
+      const body = renderPage(result)
+
+      expect(
+        getAllByRole(getEventsTable(body), 'columnheader').map((h) =>
+          h.textContent?.trim()
+        )
+      ).toEqual([
+        'Number',
+        'Kind',
+        'Date',
+        'Payload',
+        'Closing balance',
+        'Closing available'
+      ])
+    })
+
+    test('Should render event rows with correct data', async () => {
+      useMockBackend()
+
+      const { result } = await server.inject({
+        method: 'GET',
+        url,
+        auth: { strategy: 'session', credentials: mockUserSession }
+      })
+
+      const body = renderPage(result)
+      const rows = getDataRows(getEventsTable(body))
+
+      expect(rows).toHaveLength(2)
+
+      const firstCells = getAllByRole(rows[0], 'cell')
+      expect(firstCells[0]).toHaveTextContent('1')
+      expect(firstCells[1]).toHaveTextContent('SUMMARY_LOG_SUBMITTED')
+      expect(firstCells[4]).toHaveTextContent('100')
+      expect(firstCells[5]).toHaveTextContent('100')
+
+      const secondCells = getAllByRole(rows[1], 'cell')
+      expect(secondCells[0]).toHaveTextContent('2')
+      expect(secondCells[1]).toHaveTextContent('PRN_CREATED')
+      expect(secondCells[4]).toHaveTextContent('100')
+      expect(secondCells[5]).toHaveTextContent('50')
+    })
+
+    test('Should render "No waste balance events" when events list is empty', async () => {
+      useMockBackend(mockOverview, [])
+
+      const { result } = await server.inject({
+        method: 'GET',
+        url,
+        auth: { strategy: 'session', credentials: mockUserSession }
+      })
+
+      const body = renderPage(result)
+
+      expect(
+        queryByRole(body, 'table', { name: 'Waste balance events' })
+      ).toBeNull()
+      expect(getByText(body, 'No waste balance events')).toBeInTheDocument()
+    })
+
+    test('Should show 500 error page when backend returns a non-OK response', async () => {
+      mswServer.use(
+        http.get(
+          `${backendUrl}/v1/organisations/${organisationId}/overview`,
+          () => {
+            throw HttpResponse.text('', { status: 500 })
+          }
+        )
+      )
+
+      const { result } = await server.inject({
+        method: 'GET',
+        url,
+        auth: { strategy: 'session', credentials: mockUserSession }
+      })
+
+      const body = renderPage(result)
+
+      expect(
+        getByText(body, 'Sorry, there is a problem with the service')
+      ).toBeInTheDocument()
+    })
+  })
+})

--- a/src/server/routes/waste-balance-events/get.integration.test.js
+++ b/src/server/routes/waste-balance-events/get.integration.test.js
@@ -178,20 +178,16 @@ describe('#wasteBalanceEventsController', () => {
       )
     })
 
-    test('Should fall back to accreditationId in heading when no registration links to it', async () => {
+    test('Should return 404 when no registration links to the accreditation', async () => {
       useMockBackend(mockOverviewNoAccreditationLink)
 
-      const { result } = await server.inject({
+      const { statusCode } = await server.inject({
         method: 'GET',
         url,
         auth: { strategy: 'session', credentials: mockUserSession }
       })
 
-      const body = renderPage(result)
-
-      expect(getByRole(body, 'heading', { level: 1 })).toHaveTextContent(
-        `ACME ltd - ${accreditationId}`
-      )
+      expect(statusCode).toBe(statusCodes.notFound)
     })
 
     test('Should render breadcrumbs back to registration overview', async () => {
@@ -222,34 +218,6 @@ describe('#wasteBalanceEventsController', () => {
         {
           text: 'Registration overview',
           href: `/organisations/${organisationId}/registrations/reg-001/overview`
-        }
-      ])
-    })
-
-    test('Should omit registration breadcrumb when no registration links to the accreditation', async () => {
-      useMockBackend(mockOverviewNoAccreditationLink)
-
-      const { result } = await server.inject({
-        method: 'GET',
-        url,
-        auth: { strategy: 'session', credentials: mockUserSession }
-      })
-
-      const body = renderPage(result)
-      const breadcrumbs = getByRole(body, 'navigation', {
-        name: 'Breadcrumb'
-      })
-
-      expect(
-        getAllByRole(breadcrumbs, 'link').map((l) => ({
-          text: l.textContent?.trim(),
-          href: l.getAttribute('href')
-        }))
-      ).toEqual([
-        { text: 'Organisations', href: '/organisations' },
-        {
-          text: 'Organisation overview',
-          href: `/organisations/${organisationId}/overview`
         }
       ])
     })

--- a/src/server/routes/waste-balance-events/get.integration.test.js
+++ b/src/server/routes/waste-balance-events/get.integration.test.js
@@ -130,7 +130,7 @@ describe('#wasteBalanceEventsController', () => {
         () => HttpResponse.json(overviewResponse)
       ),
       http.get(
-        `${backendUrl}/v1/admin/organisations/${organisationId}/accreditations/${accreditationId}/stream-events`,
+        `${backendUrl}/v1/admin/organisations/${organisationId}/accreditations/${accreditationId}/waste-balance-events`,
         () => HttpResponse.json(eventsResponse)
       )
     )

--- a/src/server/routes/waste-balance-events/get.integration.test.js
+++ b/src/server/routes/waste-balance-events/get.integration.test.js
@@ -42,6 +42,7 @@ describe('#wasteBalanceEventsController', () => {
     vi.clearAllMocks()
   })
 
+  /** @type {{ id: string, companyName: string, registrations: Array<{ id: string, registrationNumber: string, status: string, processingType: string, material: string, site: string, accreditation: { id: string, accreditationNumber: string, status: string } | null }> }} */
   const mockOverview = {
     id: organisationId,
     companyName: 'ACME ltd',

--- a/src/server/routes/waste-balance-events/index.js
+++ b/src/server/routes/waste-balance-events/index.js
@@ -1,0 +1,19 @@
+import { wasteBalanceEventsGETController } from './controller.get.js'
+
+export const wasteBalanceEvents = {
+  plugin: {
+    name: 'wasteBalanceEvents',
+    register(server) {
+      server.route([
+        {
+          method: 'GET',
+          path: '/organisations/{organisationId}/accreditations/{accreditationId}/waste-balance-events',
+          ...wasteBalanceEventsGETController,
+          options: {
+            app: { pageTitle: 'Waste balance events' }
+          }
+        }
+      ])
+    }
+  }
+}

--- a/src/server/routes/waste-balance-events/index.njk
+++ b/src/server/routes/waste-balance-events/index.njk
@@ -1,0 +1,30 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% block content %}
+  <div class="govuk-width-container">
+    <h1 class="govuk-heading-xl">{{ heading }}</h1>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        {% if eventRows and eventRows.length %}
+          {{ govukTable({
+            caption: "Waste balance events",
+            captionClasses: "govuk-table__caption--m",
+            head: [
+              { text: "Number" },
+              { text: "Kind" },
+              { text: "Date" },
+              { text: "Payload" },
+              { text: "Closing balance" },
+              { text: "Closing available" }
+            ],
+            rows: eventRows
+          }) }}
+        {% else %}
+          <p class="govuk-body">No waste balance events</p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
## Summary

- New admin page at `/organisations/{orgId}/accreditations/{accId}/waste-balance-events` displaying the ledger event stream for an accreditation
- Table shows: event number, kind, date, payload (raw JSON), closing balance, closing available balance
- Linked from the registration overview page's summary list (new "Waste balance events" row in the accreditation section)
- Breadcrumbs navigate back through Registration overview, Organisation overview, and Organisations

## Why

Support and service maintainers need visibility into the waste balance event stream to diagnose balance discrepancies and understand the history of submissions and PRN movements for a given accreditation.

## Dependencies

Requires DEFRA/epr-backend#1236 (the backend endpoint) to be merged first.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



https://github.com/user-attachments/assets/4b1e57e4-8d2b-4f6a-ae0e-9560e30bafee

