### PR TITLE
PAE-1382: Show actor on waste balance events table

### DIFF
--- a/src/server/routes/waste-balance-events/controller.get.js
+++ b/src/server/routes/waste-balance-events/controller.get.js
@@ -47,6 +47,7 @@ export const wasteBalanceEventsGETController = {
       { text: event.number },
       { text: event.kind },
       { text: event.createdAt },
+      { text: event.createdBy.name },
       { html: `<code>${JSON.stringify(event.payload)}</code>` },
       { text: event.closingBalance.amount },
       { text: event.closingBalance.availableAmount }

--- a/src/server/routes/waste-balance-events/get.integration.test.js
+++ b/src/server/routes/waste-balance-events/get.integration.test.js
@@ -241,6 +241,7 @@ describe('#wasteBalanceEventsController', () => {
         'Number',
         'Kind',
         'Date',
+        'Created by',
         'Payload',
         'Closing balance',
         'Closing available'
@@ -264,14 +265,16 @@ describe('#wasteBalanceEventsController', () => {
       const firstCells = getAllByRole(rows[0], 'cell')
       expect(firstCells[0]).toHaveTextContent('1')
       expect(firstCells[1]).toHaveTextContent('SUMMARY_LOG_SUBMITTED')
-      expect(firstCells[4]).toHaveTextContent('100')
+      expect(firstCells[3]).toHaveTextContent('Test User')
       expect(firstCells[5]).toHaveTextContent('100')
+      expect(firstCells[6]).toHaveTextContent('100')
 
       const secondCells = getAllByRole(rows[1], 'cell')
       expect(secondCells[0]).toHaveTextContent('2')
       expect(secondCells[1]).toHaveTextContent('PRN_CREATED')
-      expect(secondCells[4]).toHaveTextContent('100')
-      expect(secondCells[5]).toHaveTextContent('50')
+      expect(secondCells[3]).toHaveTextContent('Test User')
+      expect(secondCells[5]).toHaveTextContent('100')
+      expect(secondCells[6]).toHaveTextContent('50')
     })
 
     test('Should render "No waste balance events" when events list is empty', async () => {

--- a/src/server/routes/waste-balance-events/index.njk
+++ b/src/server/routes/waste-balance-events/index.njk
@@ -15,6 +15,7 @@
               { text: "Number" },
               { text: "Kind" },
               { text: "Date" },
+              { text: "Created by" },
               { text: "Payload" },
               { text: "Closing balance" },
               { text: "Closing available" }


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
## Summary

- Add a "Created by" column to the waste balance events table, displaying the actor name from each event's `createdBy` field
- The backend already exposes this data; it was being fetched but not rendered

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ