### PR TITLE
PAE-1382: Surface actor email on waste balance events table

### DIFF
--- a/src/server/routes/waste-balance-events/controller.get.js
+++ b/src/server/routes/waste-balance-events/controller.get.js
@@ -27,7 +27,8 @@ export const wasteBalanceEventsGETController = {
       { text: event.number },
       { text: event.kind },
       { text: event.createdAt },
-      { text: event.createdBy.name },
+      { text: event.createdBy.name ?? '' },
+      { text: event.createdBy.email ?? '' },
       { html: `<code>${JSON.stringify(event.payload)}</code>` },
       { text: event.closingBalance.amount },
       { text: event.closingBalance.availableAmount }

--- a/src/server/routes/waste-balance-events/controller.get.js
+++ b/src/server/routes/waste-balance-events/controller.get.js
@@ -11,7 +11,9 @@ import {
  */
 const formatActor = (actor) => {
   const { name, email } = actor
-  if (name && email) return `${name} (${email})`
+  if (name && email) {
+    return `${name} (${email})`
+  }
   return name ?? email ?? ''
 }
 

--- a/src/server/routes/waste-balance-events/controller.get.js
+++ b/src/server/routes/waste-balance-events/controller.get.js
@@ -4,6 +4,17 @@ import {
   findRegistration
 } from '#server/common/helpers/fetch-organisation-overview.js'
 
+/**
+ * Format an actor for display: "Name (email)", "Name", "email", or "".
+ * @param {{ id: string, name?: string, email?: string }} actor
+ * @returns {string}
+ */
+const formatActor = (actor) => {
+  const { name, email } = actor
+  if (name && email) return `${name} (${email})`
+  return name ?? email ?? ''
+}
+
 export const wasteBalanceEventsGETController = {
   async handler(request, h) {
     const { organisationId, registrationId, accreditationId } = request.params
@@ -27,8 +38,7 @@ export const wasteBalanceEventsGETController = {
       { text: event.number },
       { text: event.kind },
       { text: event.createdAt },
-      { text: event.createdBy.name ?? '' },
-      { text: event.createdBy.email ?? '' },
+      { text: formatActor(event.createdBy) },
       { html: `<code>${JSON.stringify(event.payload)}</code>` },
       { text: event.closingBalance.amount },
       { text: event.closingBalance.availableAmount }

--- a/src/server/routes/waste-balance-events/get.integration.test.js
+++ b/src/server/routes/waste-balance-events/get.integration.test.js
@@ -237,7 +237,6 @@ describe('#wasteBalanceEventsController', () => {
         'Kind',
         'Date',
         'Created by',
-        'Email',
         'Payload',
         'Closing balance',
         'Closing available'
@@ -261,21 +260,21 @@ describe('#wasteBalanceEventsController', () => {
       const firstCells = getAllByRole(rows[0], 'cell')
       expect(firstCells[0]).toHaveTextContent('1')
       expect(firstCells[1]).toHaveTextContent('SUMMARY_LOG_SUBMITTED')
-      expect(firstCells[3]).toHaveTextContent('Test User')
-      expect(firstCells[4]).toHaveTextContent('test.user@example.com')
+      expect(firstCells[3]).toHaveTextContent(
+        'Test User (test.user@example.com)'
+      )
+      expect(firstCells[5]).toHaveTextContent('100')
       expect(firstCells[6]).toHaveTextContent('100')
-      expect(firstCells[7]).toHaveTextContent('100')
 
       const secondCells = getAllByRole(rows[1], 'cell')
       expect(secondCells[0]).toHaveTextContent('2')
       expect(secondCells[1]).toHaveTextContent('PRN_CREATED')
       expect(secondCells[3]).toHaveTextContent('Test User')
-      expect(secondCells[4]).toBeEmptyDOMElement()
-      expect(secondCells[6]).toHaveTextContent('100')
-      expect(secondCells[7]).toHaveTextContent('50')
+      expect(secondCells[5]).toHaveTextContent('100')
+      expect(secondCells[6]).toHaveTextContent('50')
     })
 
-    test('Should render empty string for name and email when createdBy fields are absent', async () => {
+    test('Should render empty Created by when actor has only id', async () => {
       useMockBackend(mockOverview, [
         {
           id: 'evt-3',
@@ -303,7 +302,39 @@ describe('#wasteBalanceEventsController', () => {
       const cells = getAllByRole(rows[0], 'cell')
 
       expect(cells[3]).toBeEmptyDOMElement()
-      expect(cells[4]).toBeEmptyDOMElement()
+    })
+
+    test('Should render email as Created by when actor has no name', async () => {
+      useMockBackend(mockOverview, [
+        {
+          id: 'evt-4',
+          registrationId: 'reg-001',
+          accreditationId,
+          organisationId,
+          number: 4,
+          kind: 'PRN_ISSUED',
+          payload: { prnId: 'prn-3', amount: 20 },
+          openingBalance: { amount: 50, availableAmount: 40 },
+          closingBalance: { amount: 50, availableAmount: 40 },
+          createdAt: '2026-01-18T11:00:00.000Z',
+          createdBy: /** @type {any} */ ({
+            id: 'user-3',
+            email: 'only@example.com'
+          })
+        }
+      ])
+
+      const { result } = await server.inject({
+        method: 'GET',
+        url,
+        auth: { strategy: 'session', credentials: mockUserSession }
+      })
+
+      const body = renderPage(result)
+      const rows = getDataRows(getEventsTable(body))
+      const cells = getAllByRole(rows[0], 'cell')
+
+      expect(cells[3]).toHaveTextContent('only@example.com')
     })
 
     test('Should render "No waste balance events" when events list is empty', async () => {

--- a/src/server/routes/waste-balance-events/get.integration.test.js
+++ b/src/server/routes/waste-balance-events/get.integration.test.js
@@ -82,7 +82,11 @@ describe('#wasteBalanceEventsController', () => {
       openingBalance: { amount: 0, availableAmount: 0 },
       closingBalance: { amount: 100, availableAmount: 100 },
       createdAt: '2026-01-15T10:00:00.000Z',
-      createdBy: { id: 'user-1', name: 'Test User' }
+      createdBy: {
+        id: 'user-1',
+        name: 'Test User',
+        email: 'test.user@example.com'
+      }
     },
     {
       id: 'evt-2',
@@ -233,6 +237,7 @@ describe('#wasteBalanceEventsController', () => {
         'Kind',
         'Date',
         'Created by',
+        'Email',
         'Payload',
         'Closing balance',
         'Closing available'
@@ -257,15 +262,48 @@ describe('#wasteBalanceEventsController', () => {
       expect(firstCells[0]).toHaveTextContent('1')
       expect(firstCells[1]).toHaveTextContent('SUMMARY_LOG_SUBMITTED')
       expect(firstCells[3]).toHaveTextContent('Test User')
-      expect(firstCells[5]).toHaveTextContent('100')
+      expect(firstCells[4]).toHaveTextContent('test.user@example.com')
       expect(firstCells[6]).toHaveTextContent('100')
+      expect(firstCells[7]).toHaveTextContent('100')
 
       const secondCells = getAllByRole(rows[1], 'cell')
       expect(secondCells[0]).toHaveTextContent('2')
       expect(secondCells[1]).toHaveTextContent('PRN_CREATED')
       expect(secondCells[3]).toHaveTextContent('Test User')
-      expect(secondCells[5]).toHaveTextContent('100')
-      expect(secondCells[6]).toHaveTextContent('50')
+      expect(secondCells[4]).toBeEmptyDOMElement()
+      expect(secondCells[6]).toHaveTextContent('100')
+      expect(secondCells[7]).toHaveTextContent('50')
+    })
+
+    test('Should render empty string for name and email when createdBy fields are absent', async () => {
+      useMockBackend(mockOverview, [
+        {
+          id: 'evt-3',
+          registrationId: 'reg-001',
+          accreditationId,
+          organisationId,
+          number: 3,
+          kind: 'PRN_CREATED',
+          payload: { prnId: 'prn-2', amount: 10 },
+          openingBalance: { amount: 50, availableAmount: 50 },
+          closingBalance: { amount: 50, availableAmount: 40 },
+          createdAt: '2026-01-17T09:00:00.000Z',
+          createdBy: { id: 'user-2' }
+        }
+      ])
+
+      const { result } = await server.inject({
+        method: 'GET',
+        url,
+        auth: { strategy: 'session', credentials: mockUserSession }
+      })
+
+      const body = renderPage(result)
+      const rows = getDataRows(getEventsTable(body))
+      const cells = getAllByRole(rows[0], 'cell')
+
+      expect(cells[3]).toBeEmptyDOMElement()
+      expect(cells[4]).toBeEmptyDOMElement()
     })
 
     test('Should render "No waste balance events" when events list is empty', async () => {

--- a/src/server/routes/waste-balance-events/get.integration.test.js
+++ b/src/server/routes/waste-balance-events/get.integration.test.js
@@ -288,7 +288,7 @@ describe('#wasteBalanceEventsController', () => {
           openingBalance: { amount: 50, availableAmount: 50 },
           closingBalance: { amount: 50, availableAmount: 40 },
           createdAt: '2026-01-17T09:00:00.000Z',
-          createdBy: { id: 'user-2' }
+          createdBy: { id: 'user-2', name: undefined, email: undefined }
         }
       ])
 

--- a/src/server/routes/waste-balance-events/get.integration.test.js
+++ b/src/server/routes/waste-balance-events/get.integration.test.js
@@ -288,7 +288,7 @@ describe('#wasteBalanceEventsController', () => {
           openingBalance: { amount: 50, availableAmount: 50 },
           closingBalance: { amount: 50, availableAmount: 40 },
           createdAt: '2026-01-17T09:00:00.000Z',
-          createdBy: { id: 'user-2', name: undefined, email: undefined }
+          createdBy: /** @type {any} */ ({ id: 'user-2' })
         }
       ])
 

--- a/src/server/routes/waste-balance-events/index.njk
+++ b/src/server/routes/waste-balance-events/index.njk
@@ -16,6 +16,7 @@
               { text: "Kind" },
               { text: "Date" },
               { text: "Created by" },
+              { text: "Email" },
               { text: "Payload" },
               { text: "Closing balance" },
               { text: "Closing available" }

--- a/src/server/routes/waste-balance-events/index.njk
+++ b/src/server/routes/waste-balance-events/index.njk
@@ -16,7 +16,6 @@
               { text: "Kind" },
               { text: "Date" },
               { text: "Created by" },
-              { text: "Email" },
               { text: "Payload" },
               { text: "Closing balance" },
               { text: "Closing available" }


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
## Summary
- Adds an "Email" column to the waste balance events table, showing `createdBy.email` when present
- Guards `createdBy.name` with a fallback for events where the name is absent (id-only actors)
- Covers all three actor shapes in integration tests: full (name + email), name-only, and id-only

## Test plan
- [ ] Verify the waste balance events table renders with the new Email column
- [ ] Confirm events with email show it; events without show an empty cell
- [ ] Confirm events with no name show an empty Created by cell

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ