### PR TITLE
PAE-1548: pass registrationId in waste balance events URL

### DIFF
--- a/src/server/routes/registration-overview/controller.get.js
+++ b/src/server/routes/registration-overview/controller.get.js
@@ -108,7 +108,7 @@ export const registrationOverviewGETController = {
       summaryLogRows,
       wasteBalance,
       wasteBalanceEventsUrl: registration.accreditation
-        ? `/organisations/${organisationId}/accreditations/${registration.accreditation.id}/waste-balance-events`
+        ? `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${registration.accreditation.id}/waste-balance-events`
         : null
     })
   }

--- a/src/server/routes/registration-overview/get.integration.test.js
+++ b/src/server/routes/registration-overview/get.integration.test.js
@@ -339,7 +339,7 @@ describe('#registrationOverviewController', () => {
 
       expect(link).toHaveAttribute(
         'href',
-        `/organisations/${organisationId}/accreditations/${accreditationId}/waste-balance-events`
+        `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/waste-balance-events`
       )
     })
 

--- a/src/server/routes/waste-balance-events/controller.get.js
+++ b/src/server/routes/waste-balance-events/controller.get.js
@@ -1,47 +1,27 @@
-import { errorCodes } from '#server/common/enums/error-codes.js'
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
-import { fetchOrganisationOverview } from '#server/common/helpers/fetch-organisation-overview.js'
-import { notFound } from '#server/common/helpers/logging/cdp-boom.js'
-
-/**
- * Find the registration linked to the given accreditation.
- * @param {import('#server/common/helpers/fetch-organisation-overview.js').OrganisationOverview} overview
- * @param {string} accreditationId
- */
-const findRegistrationByAccreditation = (overview, accreditationId) =>
-  overview.registrations.find((r) => r.accreditation?.id === accreditationId)
+import {
+  fetchOrganisationOverview,
+  findRegistration
+} from '#server/common/helpers/fetch-organisation-overview.js'
 
 export const wasteBalanceEventsGETController = {
   async handler(request, h) {
-    const { organisationId, accreditationId } = request.params
+    const { organisationId, registrationId, accreditationId } = request.params
 
     const overview = await fetchOrganisationOverview(request, organisationId)
-
-    const registration = findRegistrationByAccreditation(
+    const registration = findRegistration(
       overview,
-      accreditationId
+      organisationId,
+      registrationId
     )
-
-    if (!registration?.accreditation) {
-      throw notFound(
-        'Accreditation not found',
-        errorCodes.accreditationNotFound,
-        {
-          event: {
-            action: 'fetch_waste_balance_events',
-            reason: `organisationId=${organisationId} accreditationId=${accreditationId}`
-          }
-        }
-      )
-    }
 
     const events = await fetchJsonFromBackend(
       request,
-      `/v1/admin/registrations/${registration.id}/accreditations/${accreditationId}/waste-balance-events`,
+      `/v1/admin/registrations/${registrationId}/accreditations/${accreditationId}/waste-balance-events`,
       {}
     )
 
-    const heading = `${overview.companyName} - ${registration.accreditation.accreditationNumber}`
+    const heading = `${overview.companyName} - ${registration.accreditation?.accreditationNumber}`
 
     const eventRows = events.map((event) => [
       { text: event.number },
@@ -62,7 +42,7 @@ export const wasteBalanceEventsGETController = {
         },
         {
           text: 'Registration overview',
-          href: `/organisations/${organisationId}/registrations/${registration.id}/overview`
+          href: `/organisations/${organisationId}/registrations/${registrationId}/overview`
         }
       ],
       pageTitle: request.route.settings.app.pageTitle,

--- a/src/server/routes/waste-balance-events/get.integration.test.js
+++ b/src/server/routes/waste-balance-events/get.integration.test.js
@@ -22,8 +22,9 @@ describe('#wasteBalanceEventsController', () => {
   const originalBackendUrl = config.get('eprBackendUrl')
   const backendUrl = 'http://mock-backend'
   const organisationId = '69c3b4f0abda9efa68dd6697'
+  const registrationId = 'reg-001'
   const accreditationId = '69c3b4f0abda9efa68dd6698'
-  const url = `/organisations/${organisationId}/accreditations/${accreditationId}/waste-balance-events`
+  const url = `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/waste-balance-events`
   let server
 
   beforeAll(async () => {
@@ -63,20 +64,10 @@ describe('#wasteBalanceEventsController', () => {
     ]
   }
 
-  const mockOverviewNoAccreditationLink = {
+  const mockOverviewNoMatchingRegistration = {
     id: organisationId,
     companyName: 'ACME ltd',
-    registrations: [
-      {
-        id: 'reg-001',
-        registrationNumber: 'REG-50030-001',
-        status: 'approved',
-        processingType: 'reprocessing',
-        material: 'glass',
-        site: 'Site A',
-        accreditation: null
-      }
-    ]
+    registrations: []
   }
 
   const mockEvents = [
@@ -178,8 +169,8 @@ describe('#wasteBalanceEventsController', () => {
       )
     })
 
-    test('Should return 404 when no registration links to the accreditation', async () => {
-      useMockBackend(mockOverviewNoAccreditationLink)
+    test('Should return 404 when registration is not found', async () => {
+      useMockBackend(mockOverviewNoMatchingRegistration)
 
       const { statusCode } = await server.inject({
         method: 'GET',

--- a/src/server/routes/waste-balance-events/index.js
+++ b/src/server/routes/waste-balance-events/index.js
@@ -7,7 +7,7 @@ export const wasteBalanceEvents = {
       server.route([
         {
           method: 'GET',
-          path: '/organisations/{organisationId}/accreditations/{accreditationId}/waste-balance-events',
+          path: '/organisations/{organisationId}/registrations/{registrationId}/accreditations/{accreditationId}/waste-balance-events',
           ...wasteBalanceEventsGETController,
           options: {
             app: { pageTitle: 'Waste balance events' }


### PR DESCRIPTION
Ticket: [PAE-1548](https://eaflood.atlassian.net/browse/PAE-1548)
## Summary

- Adds `registrationId` to the waste balance events route path so the page no longer infers it by reverse-looking up the accreditation from the organisation overview
- Removes the bespoke `findRegistrationByAccreditation` helper and uses the shared `findRegistration` helper instead
- Updates the registration overview "View" link to include `registrationId` in the URL

## Motivation

The old route carried only `organisationId` and `accreditationId`. The controller had to search through the organisation's registrations to find which one owned that accreditation. This is ambiguous when multiple registrations share an accreditation, and the arbitrary pick also affected breadcrumb back-links.

The `registrationId` is already in scope when the link is built on the registration overview page, so threading it through the URL removes the ambiguity entirely.


[PAE-1548]: https://eaflood.atlassian.net/browse/PAE-1548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ