### PR TITLE
PAE-1547: admin UI journey to unlink org from Defra ID

### DIFF
--- a/src/server/common/helpers/fetch-json-from-backend.js
+++ b/src/server/common/helpers/fetch-json-from-backend.js
@@ -52,6 +52,10 @@ export const fetchJsonFromBackend = async (request, path, options) => {
       throw error
     }
 
+    if (response.status === 204) {
+      return null
+    }
+
     return await response.json()
   } catch (error) {
     // If it's already a Boom error, re-throw it

--- a/src/server/common/helpers/fetch-json-from-backend.js
+++ b/src/server/common/helpers/fetch-json-from-backend.js
@@ -1,6 +1,7 @@
 import Boom from '@hapi/boom'
 import { config } from '#config/config.js'
 import { errorCodes } from '#server/common/enums/error-codes.js'
+import { statusCodes } from '../constants/status-codes.js'
 import { classifierTail, internal } from './logging/cdp-boom.js'
 import { getUserSession } from './auth/get-user-session.js'
 import { withTraceId } from '@defra/hapi-tracing'
@@ -52,7 +53,7 @@ export const fetchJsonFromBackend = async (request, path, options) => {
       throw error
     }
 
-    if (response.status === 204) {
+    if (response.status === statusCodes.noContent) {
       return null
     }
 

--- a/src/server/common/helpers/fetch-json-from-backend.test.js
+++ b/src/server/common/helpers/fetch-json-from-backend.test.js
@@ -80,6 +80,19 @@ describe('#fetchJsonFromBackend', () => {
       expect(result).toEqual(mockOrganisations)
     })
 
+    test('returns null when backend responds with 204 No Content', async () => {
+      const path = '/v1/organisations/org-1/link'
+      const url = `${backendUrl}${path}`
+      const deleteHandler = http.delete(url, () => {
+        return new HttpResponse(null, { status: 204 })
+      })
+      mswServer.use(deleteHandler)
+
+      const result = await fetchJsonFromBackend({}, path, { method: 'DELETE' })
+
+      expect(result).toBeNull()
+    })
+
     test('adds the authorisation header with the user token', async () => {
       let capturedHeaders = null
 

--- a/src/server/common/helpers/fetch-json-from-backend.test.js
+++ b/src/server/common/helpers/fetch-json-from-backend.test.js
@@ -14,6 +14,15 @@ import { getUserSession } from '#server/common/helpers/auth/get-user-session.js'
 import { mockUserSession } from '#server/common/test-helpers/fixtures.js'
 import { http, HttpResponse, server as mswServer } from '#vite/setup-msw.js'
 
+/** @typedef {import('#server/common/hapi-types.js').HapiRequest} HapiRequest */
+
+/**
+ * The helper reads the request only via the mocked `getUserSession`, so an
+ * empty object cast to `HapiRequest` is sufficient for these tests.
+ * @type {HapiRequest}
+ */
+const mockRequest = /** @type {HapiRequest} */ ({})
+
 vi.mock('#server/common/helpers/auth/get-user-session.js', () => ({
   getUserSession: vi.fn().mockReturnValue(null)
 }))
@@ -31,7 +40,7 @@ vi.mock(import('@defra/hapi-tracing'), () => ({
 describe('#fetchJsonFromBackend', () => {
   const originalBackendUrl = config.get('eprBackendUrl')
   const backendUrl = 'http://mock-backend'
-  getUserSession.mockReturnValue(mockUserSession)
+  vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
 
   beforeAll(() => {
     config.set('eprBackendUrl', backendUrl)
@@ -72,7 +81,7 @@ describe('#fetchJsonFromBackend', () => {
       }
 
       const result = await fetchJsonFromBackend(
-        {},
+        mockRequest,
         '/v1/organisations',
         options
       )
@@ -88,7 +97,9 @@ describe('#fetchJsonFromBackend', () => {
       })
       mswServer.use(deleteHandler)
 
-      const result = await fetchJsonFromBackend({}, path, { method: 'DELETE' })
+      const result = await fetchJsonFromBackend(mockRequest, path, {
+        method: 'DELETE'
+      })
 
       expect(result).toBeNull()
     })
@@ -103,7 +114,9 @@ describe('#fetchJsonFromBackend', () => {
       })
       mswServer.use(getOrganisationsHandler)
 
-      await fetchJsonFromBackend({}, '/v1/organisations', { method: 'GET' })
+      await fetchJsonFromBackend(mockRequest, '/v1/organisations', {
+        method: 'GET'
+      })
 
       expect(capturedHeaders).toEqual(
         expect.objectContaining({
@@ -125,7 +138,7 @@ describe('#fetchJsonFromBackend', () => {
     mswServer.use(unauthorisedHandler)
 
     await expect(
-      fetchJsonFromBackend({}, '/secure', { method: 'GET' })
+      fetchJsonFromBackend(mockRequest, '/secure', { method: 'GET' })
     ).rejects.toMatchObject({
       isBoom: true,
       output: {
@@ -149,7 +162,7 @@ describe('#fetchJsonFromBackend', () => {
     mswServer.use(errorHandler)
 
     await expect(
-      fetchJsonFromBackend({}, path, { method: 'GET' })
+      fetchJsonFromBackend(mockRequest, path, { method: 'GET' })
     ).rejects.toMatchObject({
       isBoom: true,
       output: {
@@ -170,7 +183,7 @@ describe('#fetchJsonFromBackend', () => {
     mswServer.use(networkErrorHandler)
 
     await expect(
-      fetchJsonFromBackend({}, path, { method: 'GET' })
+      fetchJsonFromBackend(mockRequest, path, { method: 'GET' })
     ).rejects.toMatchObject({
       isBoom: true,
       output: {
@@ -204,7 +217,7 @@ describe('#fetchJsonFromBackend', () => {
     mswServer.use(errorHandler)
 
     await expect(
-      fetchJsonFromBackend({}, path, { method: 'GET' })
+      fetchJsonFromBackend(mockRequest, path, { method: 'GET' })
     ).rejects.toMatchObject({
       isBoom: true,
       output: {
@@ -233,7 +246,7 @@ describe('#fetchJsonFromBackend', () => {
     mswServer.use(errorHandler)
 
     await expect(
-      fetchJsonFromBackend({}, path, { method: 'GET' })
+      fetchJsonFromBackend(mockRequest, path, { method: 'GET' })
     ).rejects.toMatchObject({
       isBoom: true,
       output: {
@@ -256,7 +269,7 @@ describe('#fetchJsonFromBackend', () => {
     })
     mswServer.use(handler)
 
-    await fetchJsonFromBackend({}, path, { method: 'GET' })
+    await fetchJsonFromBackend(mockRequest, path, { method: 'GET' })
 
     expect(capturedHeaders['x-cdp-request-id']).toBe('mock-trace-id-1')
   })

--- a/src/server/common/helpers/fetch-organisation-overview.js
+++ b/src/server/common/helpers/fetch-organisation-overview.js
@@ -20,9 +20,17 @@ import { notFound } from '#server/common/helpers/logging/cdp-boom.js'
  * }} Registration
  *
  * @typedef {{
+ *   orgId: string,
+ *   orgName: string,
+ *   linkedAt: string,
+ *   linkedBy: { email: string }
+ * }} LinkedDefraOrganisation
+ *
+ * @typedef {{
  *   id: string,
  *   companyName: string,
- *   registrations: Registration[]
+ *   registrations: Registration[],
+ *   linkedDefraOrganisation?: LinkedDefraOrganisation
  * }} OrganisationOverview
  */
 

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -23,6 +23,7 @@ import { wasteRecordsExport } from './routes/waste-records-export/index.js'
 import { queueManagement } from './routes/queue-management/index.js'
 import { reportUnsubmit } from './routes/report-unsubmit/index.js'
 import { wasteBalanceEvents } from './routes/waste-balance-events/index.js'
+import { unlinkOrganisation } from './routes/unlink-organisation/index.js'
 
 import { serveStaticFiles } from './common/helpers/serve-static-files.js'
 
@@ -58,7 +59,8 @@ export const router = {
         wasteRecordsExport,
         queueManagement,
         reportUnsubmit,
-        wasteBalanceEvents
+        wasteBalanceEvents,
+        unlinkOrganisation
       ])
 
       await server.register([serveStaticFiles])

--- a/src/server/routes/organisation-overview/controller.get.js
+++ b/src/server/routes/organisation-overview/controller.get.js
@@ -6,6 +6,9 @@ export const organisationOverviewGETController = {
 
     const data = await fetchOrganisationOverview(request, id)
 
+    const unlinkResult = request.yar.get('unlinkResult')
+    request.yar.clear('unlinkResult')
+
     const pageTitle = request.route.settings.app.pageTitle
 
     return h.view('routes/organisation-overview/index', {
@@ -13,7 +16,9 @@ export const organisationOverviewGETController = {
       pageTitle,
       heading: data.companyName,
       organisationId: id,
-      registrations: data.registrations
+      registrations: data.registrations,
+      linkedDefraOrganisation: data.linkedDefraOrganisation,
+      unlinkResult
     })
   }
 }

--- a/src/server/routes/organisation-overview/get.integration.test.js
+++ b/src/server/routes/organisation-overview/get.integration.test.js
@@ -224,6 +224,69 @@ describe('#organisationOverviewController', () => {
       expect($(cells[6]).text().trim()).toEqual('-')
     })
 
+    describe('Defra ID link section', () => {
+      const readOnlySession = { ...mockUserSession, scopes: ['admin.read'] }
+      const linkedOverview = {
+        ...mockOverview,
+        linkedDefraOrganisation: {
+          orgId: '550e8400-e29b-41d4-a716-446655440001',
+          orgName: 'Lost Ark Adventures Ltd',
+          linkedAt: '2026-05-01T12:00:00.000Z',
+          linkedBy: { email: 'linker@example.com' }
+        }
+      }
+
+      const stubOverview = (overview) =>
+        mswServer.use(
+          http.get(
+            `${backendUrl}/v1/organisations/${organisationId}/overview`,
+            () => HttpResponse.json(overview)
+          )
+        )
+
+      const getOverview = (credentials) =>
+        server.inject({
+          method: 'GET',
+          url: `/organisations/${organisationId}/overview`,
+          auth: { strategy: 'session', credentials }
+        })
+
+      test('shows the linked Defra ID org and unlink button for a write admin', async () => {
+        getUserSession.mockReturnValue(mockUserSession)
+        stubOverview(linkedOverview)
+
+        const { result } = await getOverview(mockUserSession)
+
+        expect(result).toContain('Lost Ark Adventures Ltd')
+        const $ = cheerio.load(result)
+        expect($('a:contains("Unlink organisation")').attr('href')).toEqual(
+          `/organisations/${organisationId}/unlink-defra-id/confirm`
+        )
+      })
+
+      test('shows the linked Defra ID org but no unlink button for a read-only admin', async () => {
+        getUserSession.mockReturnValue(readOnlySession)
+        stubOverview(linkedOverview)
+
+        const { result } = await getOverview(readOnlySession)
+
+        expect(result).toContain('Lost Ark Adventures Ltd')
+        const $ = cheerio.load(result)
+        expect($('a:contains("Unlink organisation")')).toHaveLength(0)
+      })
+
+      test('shows "No linked organisation" when the org is not linked', async () => {
+        getUserSession.mockReturnValue(mockUserSession)
+        stubOverview(mockOverview)
+
+        const { result } = await getOverview(mockUserSession)
+
+        expect(result).toContain('No linked organisation')
+        const $ = cheerio.load(result)
+        expect($('a:contains("Unlink organisation")')).toHaveLength(0)
+      })
+    })
+
     test('Should show 500 error page when backend returns a non-OK response', async () => {
       mswServer.use(
         http.get(

--- a/src/server/routes/organisation-overview/get.integration.test.js
+++ b/src/server/routes/organisation-overview/get.integration.test.js
@@ -48,7 +48,7 @@ describe('#organisationOverviewController', () => {
 
   describe('When user is authenticated', () => {
     beforeAll(() => {
-      getUserSession.mockReturnValue(mockUserSession)
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
     })
 
     const mockOverview = {
@@ -252,7 +252,7 @@ describe('#organisationOverviewController', () => {
         })
 
       test('shows the linked Defra ID org and unlink button for a write admin', async () => {
-        getUserSession.mockReturnValue(mockUserSession)
+        vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
         stubOverview(linkedOverview)
 
         const { result } = await getOverview(mockUserSession)
@@ -265,7 +265,7 @@ describe('#organisationOverviewController', () => {
       })
 
       test('shows the linked Defra ID org but no unlink button for a read-only admin', async () => {
-        getUserSession.mockReturnValue(readOnlySession)
+        vi.mocked(getUserSession).mockResolvedValue(readOnlySession)
         stubOverview(linkedOverview)
 
         const { result } = await getOverview(readOnlySession)
@@ -276,7 +276,7 @@ describe('#organisationOverviewController', () => {
       })
 
       test('shows "No linked organisation" when the org is not linked', async () => {
-        getUserSession.mockReturnValue(mockUserSession)
+        vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
         stubOverview(mockOverview)
 
         const { result } = await getOverview(mockUserSession)

--- a/src/server/routes/organisation-overview/index.njk
+++ b/src/server/routes/organisation-overview/index.njk
@@ -1,10 +1,46 @@
 {% extends 'layout.njk' %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% block content %}
   <div class="govuk-width-container">
     <h1 class="govuk-heading-xl">{{ heading }}</h1>
+
+    {% if unlinkResult === 'success' %}
+      {% set unlinkSuccessHtml %}
+        <p class="govuk-body">Organisation unlinked from Defra ID.</p>
+      {% endset %}
+      {{ govukNotificationBanner({ html: unlinkSuccessHtml, type: "success" }) }}
+    {% elif unlinkResult === 'error' %}
+      {% set unlinkErrorHtml %}
+        <p class="govuk-body">The organisation could not be unlinked. Please try again.</p>
+      {% endset %}
+      {{ govukNotificationBanner({ titleText: "There is a problem", html: unlinkErrorHtml }) }}
+    {% endif %}
+
+    <h2 class="govuk-heading-l">Defra ID link</h2>
+    {% if linkedDefraOrganisation %}
+      {{ govukSummaryList({
+        rows: [
+          { key: { text: "Defra ID organisation" }, value: { text: linkedDefraOrganisation.orgName } },
+          { key: { text: "Defra organisation ID" }, value: { text: linkedDefraOrganisation.orgId } },
+          { key: { text: "Linked on" }, value: { text: linkedDefraOrganisation.linkedAt } },
+          { key: { text: "Linked by" }, value: { text: linkedDefraOrganisation.linkedBy.email } }
+        ]
+      }) }}
+      {% if SCOPES.adminWrite in scopes %}
+        {{ govukButton({
+          text: "Unlink organisation",
+          href: "/organisations/" ~ organisationId ~ "/unlink-defra-id/confirm",
+          classes: "govuk-button--warning"
+        }) }}
+      {% endif %}
+    {% else %}
+      <p class="govuk-body">No linked organisation</p>
+    {% endif %}
 
     {% set tableRows = [] %}
     {% for registration in registrations %}

--- a/src/server/routes/unlink-organisation/confirm.njk
+++ b/src/server/routes/unlink-organisation/confirm.njk
@@ -1,0 +1,32 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">{{ heading }}</h1>
+
+      <p class="govuk-body">
+        You are about to unlink <strong>{{ companyName }}</strong> from the Defra ID
+        organisation <strong>{{ defraOrgName }}</strong>.
+      </p>
+
+      {{ govukWarningText({
+        text: "The organisation will no longer be linked to this Defra ID organisation. The user can re-link it by signing in to the service again.",
+        iconFallbackText: "Warning"
+      }) }}
+
+      <form method="POST" action="{{ postUrl }}">
+        <input type="hidden" name="crumb" value="{{ crumb }}" />
+        {{ govukButton({
+          text: "Unlink organisation",
+          classes: "govuk-button--warning"
+        }) }}
+        <p class="govuk-body">
+          <a class="govuk-link" href="{{ overviewUrl }}">Cancel</a>
+        </p>
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/src/server/routes/unlink-organisation/controller.get-confirm.js
+++ b/src/server/routes/unlink-organisation/controller.get-confirm.js
@@ -1,0 +1,27 @@
+import { fetchOrganisationOverview } from '#server/common/helpers/fetch-organisation-overview.js'
+
+export const unlinkOrganisationConfirmGetController = {
+  async handler(request, h) {
+    const { organisationId } = request.params
+    const overviewUrl = `/organisations/${organisationId}/overview`
+
+    const overview = await fetchOrganisationOverview(request, organisationId)
+
+    if (!overview.linkedDefraOrganisation) {
+      return h.redirect(overviewUrl)
+    }
+
+    return h.view('routes/unlink-organisation/confirm', {
+      pageTitle: request.route.settings.app.pageTitle,
+      heading: 'Unlink organisation from Defra ID',
+      breadcrumbs: [
+        { text: 'Organisations', href: '/organisations' },
+        { text: 'Organisation overview', href: overviewUrl }
+      ],
+      overviewUrl,
+      postUrl: `/organisations/${organisationId}/unlink-defra-id`,
+      companyName: overview.companyName,
+      defraOrgName: overview.linkedDefraOrganisation.orgName
+    })
+  }
+}

--- a/src/server/routes/unlink-organisation/controller.post.js
+++ b/src/server/routes/unlink-organisation/controller.post.js
@@ -1,0 +1,25 @@
+import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
+
+export const unlinkOrganisationPostController = {
+  async handler(request, h) {
+    const { organisationId } = request.params
+    const overviewUrl = `/organisations/${organisationId}/overview`
+
+    try {
+      await fetchJsonFromBackend(
+        request,
+        `/v1/organisations/${organisationId}/link`,
+        { method: 'DELETE' }
+      )
+      request.yar.set('unlinkResult', 'success')
+    } catch (error) {
+      request.logger.error({
+        err: error,
+        message: 'Unlink organisation from Defra ID failed'
+      })
+      request.yar.set('unlinkResult', 'error')
+    }
+
+    return h.redirect(overviewUrl)
+  }
+}

--- a/src/server/routes/unlink-organisation/index.integration.test.js
+++ b/src/server/routes/unlink-organisation/index.integration.test.js
@@ -109,7 +109,7 @@ describe('unlink-organisation', () => {
   })
 
   test('confirm page returns 403 for a read-only admin', async () => {
-    getUserSession.mockReturnValue(readOnlySession)
+    vi.mocked(getUserSession).mockResolvedValue(readOnlySession)
     const { statusCode } = await server.inject({
       method: 'GET',
       url: confirmUrl,
@@ -119,7 +119,7 @@ describe('unlink-organisation', () => {
   })
 
   test('confirm page shows the organisation and Defra ID org names', async () => {
-    getUserSession.mockReturnValue(mockUserSession)
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
     stubOverview(linkedOverview)
 
     const { result, statusCode } = await server.inject({
@@ -138,7 +138,7 @@ describe('unlink-organisation', () => {
   })
 
   test('confirm page redirects to overview when the org is not linked', async () => {
-    getUserSession.mockReturnValue(mockUserSession)
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
     stubOverview(unlinkedOverview)
 
     const { statusCode, headers } = await server.inject({
@@ -160,7 +160,7 @@ describe('unlink-organisation', () => {
   })
 
   test('successful unlink redirects to overview and shows a success banner', async () => {
-    getUserSession.mockReturnValue(mockUserSession)
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
     stubOverview(linkedOverview)
     stubDeleteSuccess()
 
@@ -183,7 +183,7 @@ describe('unlink-organisation', () => {
   })
 
   test('failed unlink redirects to overview and shows an error banner', async () => {
-    getUserSession.mockReturnValue(mockUserSession)
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
     stubOverview(linkedOverview)
     stubDeleteFailure()
 

--- a/src/server/routes/unlink-organisation/index.integration.test.js
+++ b/src/server/routes/unlink-organisation/index.integration.test.js
@@ -1,0 +1,207 @@
+import { vi } from 'vitest'
+import * as cheerio from 'cheerio'
+import { config } from '#config/config.js'
+import { statusCodes } from '#server/common/constants/status-codes.js'
+import { mockUserSession } from '#server/common/test-helpers/fixtures.js'
+import { getUserSession } from '#server/common/helpers/auth/get-user-session.js'
+import { createMockOidcServer } from '#server/common/test-helpers/mock-oidc.js'
+import { getCsrfToken } from '#server/common/test-helpers/csrf-helper.js'
+import { http, server as mswServer, HttpResponse } from '#vite/setup-msw.js'
+import { createServer } from '#server/server.js'
+
+vi.mock('#server/common/helpers/auth/get-user-session.js', () => ({
+  getUserSession: vi.fn().mockReturnValue(null)
+}))
+
+describe('unlink-organisation', () => {
+  const backendUrl = config.get('eprBackendUrl')
+  const organisationId = 'aaa111bbb222ccc333ddd4444'
+  const overviewUrl = `/organisations/${organisationId}/overview`
+  const confirmUrl = `/organisations/${organisationId}/unlink-defra-id/confirm`
+  const postUrl = `/organisations/${organisationId}/unlink-defra-id`
+
+  const readOnlySession = { ...mockUserSession, scopes: ['admin.read'] }
+
+  const linkedOverview = {
+    id: organisationId,
+    companyName: 'ACME Ltd',
+    registrations: [],
+    linkedDefraOrganisation: {
+      orgId: '550e8400-e29b-41d4-a716-446655440001',
+      orgName: 'Lost Ark Adventures Ltd',
+      linkedAt: '2026-05-01T12:00:00.000Z',
+      linkedBy: { email: 'linker@example.com' }
+    }
+  }
+
+  const unlinkedOverview = {
+    id: organisationId,
+    companyName: 'ACME Ltd',
+    registrations: []
+  }
+
+  let server
+
+  beforeAll(async () => {
+    createMockOidcServer()
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    await server.stop({ timeout: 0 })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const stubOverview = (overview) =>
+    mswServer.use(
+      http.get(
+        `${backendUrl}/v1/organisations/${organisationId}/overview`,
+        () => HttpResponse.json(overview)
+      )
+    )
+
+  const stubDeleteSuccess = () =>
+    mswServer.use(
+      http.delete(
+        `${backendUrl}/v1/organisations/${organisationId}/link`,
+        () => new HttpResponse(null, { status: 204 })
+      )
+    )
+
+  const stubDeleteFailure = (status = 409) =>
+    mswServer.use(
+      http.delete(`${backendUrl}/v1/organisations/${organisationId}/link`, () =>
+        HttpResponse.json({ error: 'Conflict' }, { status })
+      )
+    )
+
+  const writeAuth = { strategy: 'session', credentials: mockUserSession }
+  const readAuth = { strategy: 'session', credentials: readOnlySession }
+
+  const postUnlink = async () => {
+    const { cookie, crumb } = await getCsrfToken(server, confirmUrl, writeAuth)
+    const postResponse = await server.inject({
+      method: 'POST',
+      url: postUrl,
+      auth: writeAuth,
+      headers: { cookie },
+      payload: { crumb }
+    })
+    const postCookies = [postResponse.headers['set-cookie']]
+      .flat()
+      .filter(Boolean)
+    const redirectCookie = postCookies.length
+      ? postCookies.map((c) => c.split(';')[0]).join('; ')
+      : cookie
+    return { postResponse, redirectCookie }
+  }
+
+  test('confirm page is rejected with 401 when unauthenticated', async () => {
+    const { statusCode } = await server.inject({
+      method: 'GET',
+      url: confirmUrl
+    })
+    expect(statusCode).toBe(statusCodes.unauthorised)
+  })
+
+  test('confirm page returns 403 for a read-only admin', async () => {
+    getUserSession.mockReturnValue(readOnlySession)
+    const { statusCode } = await server.inject({
+      method: 'GET',
+      url: confirmUrl,
+      auth: readAuth
+    })
+    expect(statusCode).toBe(statusCodes.forbidden)
+  })
+
+  test('confirm page shows the organisation and Defra ID org names', async () => {
+    getUserSession.mockReturnValue(mockUserSession)
+    stubOverview(linkedOverview)
+
+    const { result, statusCode } = await server.inject({
+      method: 'GET',
+      url: confirmUrl,
+      auth: writeAuth
+    })
+
+    expect(statusCode).toBe(statusCodes.ok)
+    const $ = cheerio.load(result)
+    expect($('h1').text().trim()).toBe('Unlink organisation from Defra ID')
+    expect(result).toContain('ACME Ltd')
+    expect(result).toContain('Lost Ark Adventures Ltd')
+    expect($('form').attr('action')).toBe(postUrl)
+    expect($('a:contains("Cancel")').attr('href')).toBe(overviewUrl)
+  })
+
+  test('confirm page redirects to overview when the org is not linked', async () => {
+    getUserSession.mockReturnValue(mockUserSession)
+    stubOverview(unlinkedOverview)
+
+    const { statusCode, headers } = await server.inject({
+      method: 'GET',
+      url: confirmUrl,
+      auth: writeAuth
+    })
+
+    expect(statusCode).toBe(statusCodes.found)
+    expect(headers.location).toBe(overviewUrl)
+  })
+
+  test('POST is rejected with 401 when unauthenticated', async () => {
+    const { statusCode } = await server.inject({
+      method: 'POST',
+      url: postUrl
+    })
+    expect(statusCode).toBe(statusCodes.unauthorised)
+  })
+
+  test('successful unlink redirects to overview and shows a success banner', async () => {
+    getUserSession.mockReturnValue(mockUserSession)
+    stubOverview(linkedOverview)
+    stubDeleteSuccess()
+
+    const { postResponse, redirectCookie } = await postUnlink()
+    expect(postResponse.statusCode).toBe(statusCodes.found)
+    expect(postResponse.headers.location).toBe(overviewUrl)
+
+    stubOverview(unlinkedOverview)
+    const { result } = await server.inject({
+      method: 'GET',
+      url: overviewUrl,
+      headers: { cookie: redirectCookie },
+      auth: writeAuth
+    })
+
+    const $ = cheerio.load(result)
+    expect($('[data-module="govuk-notification-banner"]').text()).toContain(
+      'Organisation unlinked from Defra ID'
+    )
+  })
+
+  test('failed unlink redirects to overview and shows an error banner', async () => {
+    getUserSession.mockReturnValue(mockUserSession)
+    stubOverview(linkedOverview)
+    stubDeleteFailure()
+
+    const { postResponse, redirectCookie } = await postUnlink()
+    expect(postResponse.statusCode).toBe(statusCodes.found)
+    expect(postResponse.headers.location).toBe(overviewUrl)
+
+    stubOverview(linkedOverview)
+    const { result } = await server.inject({
+      method: 'GET',
+      url: overviewUrl,
+      headers: { cookie: redirectCookie },
+      auth: writeAuth
+    })
+
+    const $ = cheerio.load(result)
+    expect($('[data-module="govuk-notification-banner"]').text()).toContain(
+      'could not be unlinked'
+    )
+  })
+})

--- a/src/server/routes/unlink-organisation/index.js
+++ b/src/server/routes/unlink-organisation/index.js
@@ -1,0 +1,34 @@
+import { unlinkOrganisationConfirmGetController } from './controller.get-confirm.js'
+import { unlinkOrganisationPostController } from './controller.post.js'
+import { requireScope } from '#server/common/helpers/auth/require-scope.js'
+import { SCOPES } from '#server/common/helpers/auth/scopes.js'
+
+const BASE = '/organisations/{organisationId}/unlink-defra-id'
+const requireWrite = [requireScope(SCOPES.adminWrite)]
+
+export const unlinkOrganisation = {
+  plugin: {
+    name: 'unlink-organisation',
+    register(server) {
+      server.route([
+        {
+          method: 'GET',
+          path: `${BASE}/confirm`,
+          ...unlinkOrganisationConfirmGetController,
+          options: {
+            pre: requireWrite,
+            app: { pageTitle: 'Unlink organisation from Defra ID' }
+          }
+        },
+        {
+          method: 'POST',
+          path: BASE,
+          ...unlinkOrganisationPostController,
+          options: {
+            pre: requireWrite
+          }
+        }
+      ])
+    }
+  }
+}


### PR DESCRIPTION
Ticket: [PAE-1547](https://eaflood.atlassian.net/browse/PAE-1547)
## Description

Adds the admin UI journey to unlink an organisation from its Defra ID organisation (PAE-1547, fixes INC2486016). Pairs with the backend work in DEFRA/epr-backend#1288.

## Summary

- The organisation overview page now shows a **Defra ID link** section — the linked organisation's name, id, linked date and linked-by, or **"No linked organisation"** when unlinked.
- A red **Unlink organisation** button appears only when the org is linked **and** the user has `admin.write` (the `service_maintainer_write` tier). It leads to a confirm page.
- Confirming calls the backend `DELETE /v1/organisations/{id}/link`, then redirects back to the overview page with a GOV.UK notification banner (success or, on failure, an "Important" banner).
- Fixes `fetchJsonFromBackend` to return `null` on `204 No Content` (the unlink endpoint's response), so the success path is not mistaken for an error.

## Changes

- `src/server/routes/unlink-organisation/` — new route module: confirm GET + POST handlers, confirm view, integration tests. Both routes gated on `admin.write`.
- `src/server/routes/organisation-overview/controller.get.js` / `index.njk` — render the Defra ID link section, the write-gated unlink button, and the post-unlink notification banner (read from a `yar` flash).
- `src/server/common/helpers/fetch-json-from-backend.js` — return `null` for 204 responses.
- `src/server/common/helpers/fetch-organisation-overview.js` — add `linkedDefraOrganisation` to the `OrganisationOverview` typedef.
- `src/server/router.js` — register the new route module.

## Dependency

Requires DEFRA/epr-backend#1288 (extends `/v1/organisations/{id}/overview` to return `linkedDefraOrganisation`, and provides the `DELETE …/link` endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PAE-1547]: https://eaflood.atlassian.net/browse/PAE-1547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="1445" height="706" alt="image" src="https://github.com/user-attachments/assets/f47b18a6-aa77-451a-b4dd-29218c742047" />
