### PR TITLE
PAE-1557: Remove FEATURE_FLAG_REPORT_UNSUBMIT feature flag

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -290,12 +290,6 @@ export const config = convict({
     default: 'http://localhost:3001',
     env: 'EPR_BACKEND_URL'
   },
-  featureFlagReportUnsubmit: {
-    doc: 'Feature Flag: Enable admin unsubmit UI for reports',
-    format: Boolean,
-    default: true,
-    env: 'FEATURE_FLAG_REPORT_UNSUBMIT'
-  },
   cdpUploaderUrl: {
     doc: 'CDP Uploader service URL (browser-visible, used in CSP form-action)',
     format: String,

--- a/src/config/nunjucks/globals/globals.js
+++ b/src/config/nunjucks/globals/globals.js
@@ -1,4 +1,1 @@
-import { config } from '#config/config.js'
-
 export { SCOPES } from '#server/common/helpers/auth/scopes.js'
-export const featureFlagReportUnsubmit = config.get('featureFlagReportUnsubmit')

--- a/src/server/routes/registration-overview/index.njk
+++ b/src/server/routes/registration-overview/index.njk
@@ -41,7 +41,7 @@
               {% if period.report %}
                 <a class="govuk-link govuk-link--no-visited-state" href="{{ reportUrl }}">View</a>
               {% endif %}
-              {% if featureFlagReportUnsubmit and period.report and period.report.status === 'submitted' and SCOPES.adminWrite in scopes %}
+              {% if period.report and period.report.status === 'submitted' and SCOPES.adminWrite in scopes %}
                 {% set unsubmitUrl = '/organisations/' ~ organisationId ~ '/registrations/' ~ registrationId ~ '/reports/' ~ period.year ~ '/' ~ cadence ~ '/' ~ period.period ~ '/unsubmit/confirm' %}
                 <br><a class="govuk-link govuk-link--no-visited-state" href="{{ unsubmitUrl }}">Unsubmit</a>
               {% endif %}

--- a/src/server/routes/report-unsubmit/constants.js
+++ b/src/server/routes/report-unsubmit/constants.js
@@ -1,2 +1,1 @@
-export const FEATURE_FLAG_KEY = 'featureFlagReportUnsubmit'
 export const PAGE_TITLE = 'Unsubmit report'

--- a/src/server/routes/report-unsubmit/index.integration.test.js
+++ b/src/server/routes/report-unsubmit/index.integration.test.js
@@ -46,14 +46,12 @@ describe('report-unsubmit', () => {
   let server
 
   beforeAll(async () => {
-    config.set('featureFlagReportUnsubmit', true)
     createMockOidcServer()
     server = await createServer()
     await server.initialize()
   })
 
   afterAll(async () => {
-    config.set('featureFlagReportUnsubmit', false)
     await server.stop({ timeout: 0 })
   })
 
@@ -239,42 +237,5 @@ describe('report-unsubmit', () => {
 
     expect(statusCode).toBe(statusCodes.found)
     expect(headers.location).toBe(overviewUrl)
-  })
-
-  describe('when feature flag is disabled', () => {
-    let serverWithFlagOff
-
-    beforeAll(async () => {
-      config.set('featureFlagReportUnsubmit', false)
-      serverWithFlagOff = await createServer()
-      await serverWithFlagOff.initialize()
-    })
-
-    afterAll(async () => {
-      await serverWithFlagOff.stop({ timeout: 0 })
-      config.set('featureFlagReportUnsubmit', true)
-    })
-
-    beforeEach(() => {
-      getUserSession.mockReturnValue(mockUserSession)
-    })
-
-    test('unsubmit routes are not registered and return 404', async () => {
-      const [confirmRes, resultRes] = await Promise.all([
-        serverWithFlagOff.inject({
-          method: 'GET',
-          url: confirmUrl,
-          auth: authOptions
-        }),
-        serverWithFlagOff.inject({
-          method: 'GET',
-          url: resultUrl,
-          auth: authOptions
-        })
-      ])
-
-      expect(confirmRes.statusCode).toBe(statusCodes.notFound)
-      expect(resultRes.statusCode).toBe(statusCodes.notFound)
-    })
   })
 })

--- a/src/server/routes/report-unsubmit/index.integration.test.js
+++ b/src/server/routes/report-unsubmit/index.integration.test.js
@@ -126,9 +126,9 @@ describe('report-unsubmit', () => {
   })
 
   test('confirm page shows report details and unsubmit action', async () => {
-    getUserSession.mockReturnValue(mockUserSession)
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
     stubOverview()
-    stubReport({ currentStatus: 'submitted', unsubmittedAt: null })
+    stubReport({ currentStatus: 'submitted', unsubmittedAt: undefined })
 
     const { result, statusCode } = await server.inject({
       method: 'GET',
@@ -146,14 +146,14 @@ describe('report-unsubmit', () => {
   })
 
   test('confirm page returns 404 when the registration is missing from the overview', async () => {
-    getUserSession.mockReturnValue(mockUserSession)
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
     mswServer.use(
       http.get(
         `${backendUrl}/v1/organisations/${organisationId}/overview`,
         () => HttpResponse.json({ ...mockOverview, registrations: [] })
       )
     )
-    stubReport({ currentStatus: 'submitted', unsubmittedAt: null })
+    stubReport({ currentStatus: 'submitted', unsubmittedAt: undefined })
 
     const { statusCode } = await server.inject({
       method: 'GET',
@@ -165,9 +165,9 @@ describe('report-unsubmit', () => {
   })
 
   test('confirm page redirects to overview for a non-submitted report', async () => {
-    getUserSession.mockReturnValue(mockUserSession)
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
     stubOverview()
-    stubReport({ currentStatus: 'ready_to_submit', unsubmittedAt: null })
+    stubReport({ currentStatus: 'ready_to_submit', unsubmittedAt: undefined })
 
     const { statusCode, headers } = await server.inject({
       method: 'GET',
@@ -180,9 +180,9 @@ describe('report-unsubmit', () => {
   })
 
   test('submitting the confirmation redirects to the success page', async () => {
-    getUserSession.mockReturnValue(mockUserSession)
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
     stubOverview()
-    stubReport({ currentStatus: 'submitted', unsubmittedAt: null })
+    stubReport({ currentStatus: 'submitted', unsubmittedAt: undefined })
     stubUnsubmitSuccess()
 
     const { statusCode, headers } = await postUnsubmit()
@@ -192,9 +192,9 @@ describe('report-unsubmit', () => {
   })
 
   test('backend failure shows the unsubmit failed page', async () => {
-    getUserSession.mockReturnValue(mockUserSession)
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
     stubOverview()
-    stubReport({ currentStatus: 'submitted', unsubmittedAt: null })
+    stubReport({ currentStatus: 'submitted', unsubmittedAt: undefined })
     stubUnsubmitFailure()
 
     const { result, statusCode } = await postUnsubmit()
@@ -205,7 +205,7 @@ describe('report-unsubmit', () => {
   })
 
   test('success page confirms the report was unsubmitted', async () => {
-    getUserSession.mockReturnValue(mockUserSession)
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
     stubOverview()
     stubReport()
 
@@ -225,9 +225,9 @@ describe('report-unsubmit', () => {
   })
 
   test('result page redirects to overview when accessed without completing unsubmit', async () => {
-    getUserSession.mockReturnValue(mockUserSession)
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
     stubOverview()
-    stubReport({ currentStatus: 'submitted', unsubmittedAt: null })
+    stubReport({ currentStatus: 'submitted', unsubmittedAt: undefined })
 
     const { statusCode, headers } = await server.inject({
       method: 'GET',

--- a/src/server/routes/report-unsubmit/index.js
+++ b/src/server/routes/report-unsubmit/index.js
@@ -1,10 +1,9 @@
-import { config } from '#config/config.js'
 import { reportUnsubmitConfirmGetController } from './controller.get-confirm.js'
 import { reportUnsubmitPostController } from './controller.post.js'
 import { reportUnsubmitResultGetController } from './controller.get-result.js'
 import { requireScope } from '#server/common/helpers/auth/require-scope.js'
 import { SCOPES } from '#server/common/helpers/auth/scopes.js'
-import { FEATURE_FLAG_KEY, PAGE_TITLE } from './constants.js'
+import { PAGE_TITLE } from './constants.js'
 
 const BASE =
   '/organisations/{organisationId}/registrations/{registrationId}/reports/{year}/{cadence}/{period}'
@@ -15,10 +14,6 @@ export const reportUnsubmit = {
   plugin: {
     name: 'report-unsubmit',
     register(server) {
-      if (!config.get(FEATURE_FLAG_KEY)) {
-        return
-      }
-
       server.route([
         {
           method: 'GET',


### PR DESCRIPTION
Ticket: [PAE-1557](https://eaflood.atlassian.net/browse/PAE-1557)
## Summary

- Removes the `FEATURE_FLAG_REPORT_UNSUBMIT` feature flag as the report unsubmit feature is now permanently enabled
[PAE-1557]: https://eaflood.atlassian.net/browse/PAE-1557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ