### PR TITLE
PAE-250: Fix joi vulnerability and declare joi dependency

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,5 +4,5 @@ ignore:
   'SNYK-JS-POSTCSSSELECTORPARSER-16873882':
     - '*':
         reason: 'No upstream fix available. postcss-selector-parser is pulled in transitively by cssnano during the webpack CSS build only and is never reached at application runtime, so the uncontrolled-recursion DoS is not exploitable here. Revisit when a patched version is published.'
-        expires: '2026-11-27T00:00:00.000Z'
+        expires: '2027-06-12T00:00:00.000Z'
 patch: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "@defra/cdp-auditing": "0.6.0",
+        "@defra/cdp-auditing": "0.6.1",
         "@defra/hapi-secure-context": "0.4.0",
         "@defra/hapi-tracing": "1.30.0",
         "@elastic/ecs-pino-format": "1.5.0",
@@ -39,6 +39,7 @@
         "hapi-pino": "13.0.0",
         "hapi-pulse": "3.0.1",
         "ioredis": "5.10.1",
+        "joi": "18.2.1",
         "jose": "6.2.2",
         "jsoneditor": "10.4.2",
         "lodash": "4.18.1",
@@ -1922,13 +1923,12 @@
       "license": "MIT"
     },
     "node_modules/@defra/cdp-auditing": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@defra/cdp-auditing/-/cdp-auditing-0.6.0.tgz",
-      "integrity": "sha512-CVysJOutZ3CLn8McdMxA0hIs+XgoaHOOwRQGmMt7BZU2SGSbjfdb/T+pLVg1SZk1XsIK6VQ7cufIc6t7L3T2XQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@defra/cdp-auditing/-/cdp-auditing-0.6.1.tgz",
+      "integrity": "sha512-KJiKDTpAqolaxbm/8D345kKeZeK2uqDxhD7QOAI9sd7hEQzy9qj4pcAZSh0Xo6/7VNi6AuN0Y+jllTZZBPcIyA==",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "joi": "18.0.2",
         "pino": "10.1.0"
       },
       "engines": {
@@ -9032,9 +9032,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
-      "integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
+      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/address": "^5.1.1",
@@ -9043,7 +9043,7 @@
         "@hapi/pinpoint": "^2.0.1",
         "@hapi/tlds": "^1.1.1",
         "@hapi/topo": "^6.0.2",
-        "@standard-schema/spec": "^1.0.0"
+        "@standard-schema/spec": "^1.1.0"
       },
       "engines": {
         "node": ">= 20"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "author": "Defra DDTS",
   "license": "OGL-UK-3.0",
   "dependencies": {
-    "@defra/cdp-auditing": "0.6.0",
+    "@defra/cdp-auditing": "0.6.1",
     "@defra/hapi-secure-context": "0.4.0",
     "@defra/hapi-tracing": "1.30.0",
     "@elastic/ecs-pino-format": "1.5.0",
@@ -71,6 +71,7 @@
     "hapi-pino": "13.0.0",
     "hapi-pulse": "3.0.1",
     "ioredis": "5.10.1",
+    "joi": "18.2.1",
     "jose": "6.2.2",
     "jsoneditor": "10.4.2",
     "lodash": "4.18.1",


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
Fixes a joi advisory path and corrects an undeclared dependency.

- Bumps `@defra/cdp-auditing` to 0.6.1, which drops its `joi` dependency entirely and removes the joi 18.x path that surfaced GHSA-q7cg-457f-vx79.
- Declares `joi` 18.2.1 as a direct dependency. Three route modules import `joi` directly but it was never listed in `package.json` — it resolved only by hoisting (joi 18.0.2 on main). Declaring it explicitly closes that latent gap and patches the application's own joi usage to the non-vulnerable 18.2.1.

The `postcss-selector-parser` Snyk ignore was confirmed still needed (no upstream fix; reachable only during the CSS build) and its expiry refreshed.

A `joi` advisory (GHSA-q7cg-457f-vx79, moderate DoS) remains via hapi packages (`@hapi/bell`, `@hapi/catbox-redis`, `@hapi/jwt`, `hapi-pulse`) that pin joi 17.x with no fixed 17.x release published; clearing it would require a coordinated joi 17→18 major upgrade, tracked separately. The `@hapi/inert` and `@hapi/wreck` advisories were already resolved on main by a merged security PR.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ