### PR TITLE
Revert undici bump from 7.24.6 to 8.4.1 (#423)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "pino": "10.3.1",
         "pino-pretty": "13.1.3",
         "semver": "7.8.4",
-        "undici": "8.4.1"
+        "undici": "7.24.6"
       },
       "devDependencies": {
         "@babel/preset-env": "7.29.7",
@@ -5496,16 +5496,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cheerio/node_modules/undici": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/chokidar": {
@@ -15063,12 +15053,12 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.4.1.tgz",
-      "integrity": "sha512-RNHlB4fxZK0IrkhBsxhlbx7s8kFWwr7rzzOqj5nvZugw3ig3RsB7KW3zVlV0eu8POl+rx5d1hmL7rRg0z1owow==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
       "license": "MIT",
       "engines": {
-        "node": ">=22.19.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "pino": "10.3.1",
     "pino-pretty": "13.1.3",
     "semver": "7.8.4",
-    "undici": "8.4.1"
+    "undici": "7.24.6"
   },
   "devDependencies": {
     "@babel/preset-env": "7.29.7",


### PR DESCRIPTION
Ticket: [PAE-1565](https://eaflood.atlassian.net/browse/PAE-1565)
## Summary

- Reverts #423 (Bump undici from 7.24.6 to 8.4.1)

## Reason

### undici 8.x
v8.0.0 enables HTTP/2 by default (`feat!: enable h2 by default`). The `ProxyAgent` in the proxy setup is constructed without options, so it will now attempt H2 first. Most corporate/CDP proxies do not support HTTP/2, which risks connection failures in deployed environments. Additionally, v8 removed legacy handler wrappers which could affect undici internals relied upon indirectly.

Reverted to 7.24.6 while the incompatibilities are investigated. See also epr-backend#1327 which reverts the same change there.

## Test plan

- [ ] CI passes
- [ ] No regression in proxy behaviour

[PAE-1565]: https://eaflood.atlassian.net/browse/PAE-1565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ