### PR TITLE
PAE-1599: grant registration admin UI journey

### DIFF
--- a/src/server/common/helpers/status-transition/applies-from-date.js
+++ b/src/server/common/helpers/status-transition/applies-from-date.js
@@ -1,0 +1,54 @@
+/**
+ * Builds a YYYY-MM-DD date from GDS date-input parts, or null when the parts
+ * do not form a real calendar date.
+ * @param {string} day
+ * @param {string} month
+ * @param {string} year
+ * @returns {string | null}
+ */
+const toIsoDate = (day, month, year) => {
+  if (
+    !/^\d{1,2}$/.test(day) ||
+    !/^\d{1,2}$/.test(month) ||
+    !/^\d{4}$/.test(year)
+  ) {
+    return null
+  }
+
+  const iso = `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`
+  const date = new Date(`${iso}T00:00:00.000Z`)
+  if (Number.isNaN(date.getTime()) || !date.toISOString().startsWith(iso)) {
+    return null
+  }
+
+  return iso
+}
+
+/**
+ * Parses and validates the "applies from" GDS date-input fields from a
+ * confirm-page POST. Shared between accreditation-status-transition and
+ * registration-status-transition, whose confirm pages both collect this date
+ * alongside a transition-specific identifier field.
+ * @param {Record<string, string | undefined>} payload
+ * @returns {{
+ *   day: string,
+ *   month: string,
+ *   year: string,
+ *   appliesFrom: string | null,
+ *   error?: string
+ * }}
+ */
+export const parseAppliesFromDate = (payload) => {
+  const day = (payload['appliesFrom-day'] ?? '').trim()
+  const month = (payload['appliesFrom-month'] ?? '').trim()
+  const year = (payload['appliesFrom-year'] ?? '').trim()
+  const appliesFrom = toIsoDate(day, month, year)
+
+  return {
+    day,
+    month,
+    year,
+    appliesFrom,
+    error: appliesFrom ? undefined : 'Enter a valid applies from date'
+  }
+}

--- a/src/server/common/helpers/status-transition/post-status-transition.js
+++ b/src/server/common/helpers/status-transition/post-status-transition.js
@@ -1,0 +1,66 @@
+import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
+import { statusCodes } from '#server/common/constants/status-codes.js'
+
+/**
+ * @typedef {object} StatusTransitionErrorCopy
+ * @property {string} errorMessage - Flash fallback when the backend gives no message
+ * @property {string} logMessage
+ */
+
+/**
+ * Posts a status-transition body to the backend status-history endpoint.
+ * Shared between accreditation-status-transition and
+ * registration-status-transition — only the backend URL and the transition's
+ * own error copy differ; the request/response handling is identical.
+ *
+ * Returns `null` on success, or when a 5xx/network failure has already been
+ * flashed on the request's session (the caller redirects to the overview
+ * either way). Returns `{ backendError }` when a client-side (4xx) rejection
+ * of grant fields should instead re-render the confirm page, preserving what
+ * the admin typed.
+ * @param {string} statusHistoryUrl
+ * @param {Record<string, string | undefined>} body
+ * @param {StatusTransitionErrorCopy} transition
+ * @param {Record<string, string> | undefined} grantValues - Parsed grant
+ *   field values, present only when the transition collects them; used to
+ *   decide whether a 4xx rejection re-renders the confirm page
+ * @returns {Promise<{ backendError: string } | null>}
+ */
+export const postStatusTransition = async (
+  request,
+  statusHistoryUrl,
+  body,
+  transition,
+  grantValues
+) => {
+  try {
+    await fetchJsonFromBackend(request, statusHistoryUrl, {
+      method: 'POST',
+      body: JSON.stringify(body)
+    })
+    return null
+  } catch (error) {
+    request.logger.error({
+      err: error,
+      message: transition.logMessage
+    })
+
+    // Only surface backend messages for client errors: 5xx and network
+    // failures carry Boom's generic message (or the raw fetch error, which
+    // leaks the backend URL), so those get the friendly fallback instead.
+    const { statusCode, payload } = error.output
+    const errorMessage =
+      (statusCode < statusCodes.internalServerError && payload?.message) ||
+      transition.errorMessage
+
+    // A backend rejection of the grant fields re-renders the confirm page
+    // so the admin keeps what they typed; 5xx and network failures still
+    // flash on the overview, where retrying immediately won't help.
+    if (grantValues && statusCode < statusCodes.internalServerError) {
+      return { backendError: errorMessage }
+    }
+
+    request.yar.set('error', errorMessage)
+    return null
+  }
+}

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -27,6 +27,7 @@ import { unlinkOrganisation } from './routes/unlink-organisation/index.js'
 import { accreditationOverseasSites } from './routes/accreditation-overseas-sites/index.js'
 import { creditedTonnage } from './routes/credited-tonnage/index.js'
 import { accreditationStatusTransition } from './routes/accreditation-status-transition/index.js'
+import { registrationStatusTransition } from './routes/registration-status-transition/index.js'
 
 import { serveStaticFiles } from './common/helpers/serve-static-files.js'
 
@@ -66,7 +67,8 @@ export const router = {
         unlinkOrganisation,
         accreditationOverseasSites,
         creditedTonnage,
-        accreditationStatusTransition
+        accreditationStatusTransition,
+        registrationStatusTransition
       ])
 
       await server.register([serveStaticFiles])

--- a/src/server/routes/accreditation-status-transition/controller.post.js
+++ b/src/server/routes/accreditation-status-transition/controller.post.js
@@ -1,4 +1,4 @@
-import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
+import { postStatusTransition } from '#server/common/helpers/status-transition/post-status-transition.js'
 import { statusCodes } from '#server/common/constants/status-codes.js'
 import { buildConfirmView } from './confirm-view.js'
 import { parseGrantForm } from './grant-form.js'
@@ -51,45 +51,24 @@ export const createTransitionPostController = (action, transition) => ({
       body.accreditationNumber = values.accreditationNumber
     }
 
-    try {
-      await fetchJsonFromBackend(
-        request,
-        `/v1/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/status-history`,
-        {
-          method: 'POST',
-          body: JSON.stringify(body)
-        }
-      )
-    } catch (error) {
-      request.logger.error({
-        err: error,
-        message: transition.logMessage
-      })
+    const outcome = await postStatusTransition(
+      request,
+      `/v1/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/status-history`,
+      body,
+      transition,
+      grantValues
+    )
 
-      // Only surface backend messages for client errors: 5xx and network
-      // failures carry Boom's generic message (or the raw fetch error, which
-      // leaks the backend URL), so those get the friendly fallback instead.
-      const { statusCode, payload } = error.output
-      const errorMessage =
-        (statusCode < statusCodes.internalServerError && payload?.message) ||
-        transition.errorMessage
-
-      // A backend rejection of the grant fields re-renders the confirm page
-      // so the admin keeps what they typed; 5xx and network failures still
-      // flash on the overview, where retrying immediately won't help.
-      if (grantValues && statusCode < statusCodes.internalServerError) {
-        return h
-          .view(
-            CONFIRM_VIEW,
-            buildConfirmView(action, transition, request.params, {
-              values: grantValues,
-              backendError: errorMessage
-            })
-          )
-          .code(statusCodes.badRequest)
-      }
-
-      request.yar.set('error', errorMessage)
+    if (outcome) {
+      return h
+        .view(
+          CONFIRM_VIEW,
+          buildConfirmView(action, transition, request.params, {
+            values: grantValues,
+            backendError: outcome.backendError
+          })
+        )
+        .code(statusCodes.badRequest)
     }
 
     return h.redirect(overviewUrl)

--- a/src/server/routes/accreditation-status-transition/grant-form.js
+++ b/src/server/routes/accreditation-status-transition/grant-form.js
@@ -1,28 +1,4 @@
-/**
- * Builds a YYYY-MM-DD date from GDS date-input parts, or null when the parts
- * do not form a real calendar date.
- * @param {string} day
- * @param {string} month
- * @param {string} year
- * @returns {string | null}
- */
-const toIsoDate = (day, month, year) => {
-  if (
-    !/^\d{1,2}$/.test(day) ||
-    !/^\d{1,2}$/.test(month) ||
-    !/^\d{4}$/.test(year)
-  ) {
-    return null
-  }
-
-  const iso = `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`
-  const date = new Date(`${iso}T00:00:00.000Z`)
-  if (Number.isNaN(date.getTime()) || !date.toISOString().startsWith(iso)) {
-    return null
-  }
-
-  return iso
-}
+import { parseAppliesFromDate } from '#server/common/helpers/status-transition/applies-from-date.js'
 
 /**
  * Parses and validates the grant fields (applies from date parts and
@@ -35,17 +11,19 @@ const toIsoDate = (day, month, year) => {
  * }}
  */
 export const parseGrantForm = (payload) => {
-  const day = (payload['appliesFrom-day'] ?? '').trim()
-  const month = (payload['appliesFrom-month'] ?? '').trim()
-  const year = (payload['appliesFrom-year'] ?? '').trim()
+  const {
+    day,
+    month,
+    year,
+    appliesFrom,
+    error: appliesFromError
+  } = parseAppliesFromDate(payload)
   const accreditationNumber = (payload.accreditationNumber ?? '').trim()
-
-  const appliesFrom = toIsoDate(day, month, year)
 
   /** @type {{ appliesFrom?: string, accreditationNumber?: string }} */
   const errors = {}
-  if (!appliesFrom) {
-    errors.appliesFrom = 'Enter a valid applies from date'
+  if (appliesFromError) {
+    errors.appliesFrom = appliesFromError
   }
   if (!accreditationNumber) {
     errors.accreditationNumber = 'Enter an accreditation number'

--- a/src/server/routes/registration-overview/get.integration.test.js
+++ b/src/server/routes/registration-overview/get.integration.test.js
@@ -1510,5 +1510,81 @@ describe('#registrationOverviewController', () => {
         ).toBeNull()
       })
     })
+
+    describe('Approve registration link visibility', () => {
+      afterEach(() => {
+        vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+      })
+
+      test('Should render the Approve action on the Status row for a created registration when the user has admin.write scope', async () => {
+        useMockBackend({
+          ...mockOverview,
+          registrations: [{ ...mockRegistration, status: 'created' }]
+        })
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        const body = renderPage(result)
+        const statusRow = getSummaryRow(body, 'Status')
+        const approveLink = within(statusRow).getByRole('link', {
+          name: /^approve registration$/i
+        })
+
+        expect(approveLink).toHaveAttribute(
+          'href',
+          `/organisations/${organisationId}/registrations/${registrationId}/approve/confirm`
+        )
+      })
+
+      test('Should not render the Approve action when the registration status is not created', async () => {
+        useMockBackend()
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        const body = renderPage(result)
+        const statusRow = getSummaryRow(body, 'Status')
+
+        expect(
+          within(statusRow).queryByRole('link', {
+            name: /^approve registration$/i
+          })
+        ).toBeNull()
+      })
+
+      test('Should not render the Approve action when the user lacks admin.write scope', async () => {
+        const readOnlySession = {
+          ...mockUserSession,
+          scopes: ['admin.read']
+        }
+        vi.mocked(getUserSession).mockResolvedValue(readOnlySession)
+        useMockBackend({
+          ...mockOverview,
+          registrations: [{ ...mockRegistration, status: 'created' }]
+        })
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: readOnlySession }
+        })
+
+        const body = renderPage(result)
+        const statusRow = getSummaryRow(body, 'Status')
+
+        expect(
+          within(statusRow).queryByRole('link', {
+            name: /^approve registration$/i
+          })
+        ).toBeNull()
+      })
+    })
   })
 })

--- a/src/server/routes/registration-overview/index.njk
+++ b/src/server/routes/registration-overview/index.njk
@@ -19,8 +19,18 @@
 
     <h1 class="govuk-heading-xl">{{ heading }}</h1>
 
+    {% set registrationStatusActions = [] %}
+    {% if SCOPES.adminWrite in scopes %}
+      {% set registrationBaseUrl = '/organisations/' ~ organisationId ~ '/registrations/' ~ registrationId %}
+      {% if registration.status === 'created' %}
+        {% set registrationStatusActions = registrationStatusActions.concat([
+          { href: registrationBaseUrl ~ '/approve/confirm', text: "Approve", visuallyHiddenText: "registration" }
+        ]) %}
+      {% endif %}
+    {% endif %}
+
     {% set summaryRows = [
-      { key: { text: "Status" }, value: { html: govukTag({ text: registration.status }) } },
+      { key: { text: "Status" }, value: { html: govukTag({ text: registration.status }) }, actions: { items: registrationStatusActions } },
       { key: { text: "Processing type" }, value: { text: registration.processingType } },
       { key: { text: "Material" }, value: { text: registration.material } },
       { key: { text: "Site" }, value: { text: registration.site } }

--- a/src/server/routes/registration-status-transition/confirm-view.js
+++ b/src/server/routes/registration-status-transition/confirm-view.js
@@ -1,0 +1,53 @@
+/** @import {RegistrationStatusTransition} from './transitions.js' */
+
+/**
+ * Builds the view context for a transition's confirm page. Used by the GET
+ * controller and by the POST controller when re-rendering with field errors
+ * or a backend rejection.
+ * @param {string} action - URL action segment (e.g. 'approve')
+ * @param {RegistrationStatusTransition} transition
+ * @param {{ organisationId: string, registrationId: string }} params
+ * @param {{
+ *   values?: { day: string, month: string, year: string, registrationNumber: string },
+ *   errors?: { appliesFrom?: string, registrationNumber?: string } | null,
+ *   backendError?: string
+ * }} [state]
+ */
+export const buildConfirmView = (
+  action,
+  transition,
+  { organisationId, registrationId },
+  {
+    values = { day: '', month: '', year: '', registrationNumber: '' },
+    errors = null,
+    backendError
+  } = {}
+) => {
+  const errorList = []
+  if (backendError) {
+    errorList.push({ text: backendError })
+  }
+  if (errors?.appliesFrom) {
+    errorList.push({ text: errors.appliesFrom, href: '#applies-from-day' })
+  }
+  if (errors?.registrationNumber) {
+    errorList.push({
+      text: errors.registrationNumber,
+      href: '#registration-number'
+    })
+  }
+
+  return {
+    pageTitle: transition.pageTitle,
+    heading: transition.heading,
+    warningText: transition.warningText,
+    buttonText: transition.buttonText,
+    buttonClasses: transition.buttonClasses,
+    hasGrantFields: Boolean(transition.hasGrantFields),
+    values,
+    errors,
+    errorList,
+    overviewUrl: `/organisations/${organisationId}/registrations/${registrationId}/overview`,
+    postUrl: `/organisations/${organisationId}/registrations/${registrationId}/${action}`
+  }
+}

--- a/src/server/routes/registration-status-transition/confirm.njk
+++ b/src/server/routes/registration-status-transition/confirm.njk
@@ -1,0 +1,64 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errorList.length %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorList
+        }) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-xl">{{ heading }}</h1>
+
+      {{ govukWarningText({
+        text: warningText,
+        iconFallbackText: "Warning"
+      }) }}
+
+      <form method="POST" action="{{ postUrl }}">
+        <input type="hidden" name="crumb" value="{{ crumb }}" />
+
+        {% if hasGrantFields %}
+          {{ govukDateInput({
+            id: "applies-from",
+            namePrefix: "appliesFrom",
+            fieldset: {
+              legend: { text: "Applies from", classes: "govuk-fieldset__legend--s" }
+            },
+            hint: { text: "For example, 27 3 2026" },
+            errorMessage: { text: errors.appliesFrom } if errors and errors.appliesFrom,
+            items: [
+              { name: "day", classes: "govuk-input--width-2", value: values.day },
+              { name: "month", classes: "govuk-input--width-2", value: values.month },
+              { name: "year", classes: "govuk-input--width-4", value: values.year }
+            ]
+          }) }}
+
+          {{ govukInput({
+            id: "registration-number",
+            name: "registrationNumber",
+            label: { text: "Registration number", classes: "govuk-label--s" },
+            classes: "govuk-input--width-20",
+            value: values.registrationNumber,
+            errorMessage: { text: errors.registrationNumber } if errors and errors.registrationNumber
+          }) }}
+        {% endif %}
+
+        {{ govukButton({
+          text: buttonText,
+          classes: buttonClasses
+        }) }}
+        <p class="govuk-body">
+          <a class="govuk-link" href="{{ overviewUrl }}">Cancel</a>
+        </p>
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/src/server/routes/registration-status-transition/controller.get-confirm.js
+++ b/src/server/routes/registration-status-transition/controller.get-confirm.js
@@ -1,0 +1,17 @@
+import { buildConfirmView } from './confirm-view.js'
+
+/** @import {RegistrationStatusTransition} from './transitions.js' */
+
+/**
+ * Builds the confirm-page GET controller for a status transition action.
+ * @param {string} action - URL action segment (e.g. 'approve')
+ * @param {RegistrationStatusTransition} transition
+ */
+export const createConfirmGetController = (action, transition) => ({
+  handler(request, h) {
+    return h.view(
+      'routes/registration-status-transition/confirm',
+      buildConfirmView(action, transition, request.params)
+    )
+  }
+})

--- a/src/server/routes/registration-status-transition/controller.post.js
+++ b/src/server/routes/registration-status-transition/controller.post.js
@@ -1,0 +1,97 @@
+import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
+import { statusCodes } from '#server/common/constants/status-codes.js'
+import { buildConfirmView } from './confirm-view.js'
+import { parseGrantForm } from './grant-form.js'
+
+/** @import {RegistrationStatusTransition} from './transitions.js' */
+
+const CONFIRM_VIEW = 'routes/registration-status-transition/confirm'
+
+/**
+ * Builds the POST controller for a status transition action. Posts the
+ * transition's from/to statuses (plus grant fields where the transition
+ * collects them) to the backend status-history endpoint and redirects to the
+ * registration overview, flashing any backend error. Invalid grant fields —
+ * and backend rejections of them — re-render the confirm page with an error
+ * summary instead.
+ * @param {string} action - URL action segment (e.g. 'approve')
+ * @param {RegistrationStatusTransition} transition
+ */
+export const createTransitionPostController = (action, transition) => ({
+  async handler(request, h) {
+    const { organisationId, registrationId } = request.params
+    const overviewUrl = `/organisations/${organisationId}/registrations/${registrationId}/overview`
+
+    /** @type {{ fromStatus: string, toStatus: string, appliesFrom?: string, registrationNumber?: string }} */
+    const body = {
+      fromStatus: transition.fromStatus,
+      toStatus: transition.toStatus
+    }
+
+    /** @type {{ day: string, month: string, year: string, registrationNumber: string } | undefined} */
+    let grantValues
+
+    if (transition.hasGrantFields) {
+      const { values, errors, appliesFrom } = parseGrantForm(request.payload)
+      grantValues = values
+
+      if (errors) {
+        return h
+          .view(
+            CONFIRM_VIEW,
+            buildConfirmView(action, transition, request.params, {
+              values,
+              errors
+            })
+          )
+          .code(statusCodes.badRequest)
+      }
+
+      body.appliesFrom = /** @type {string} */ (appliesFrom)
+      body.registrationNumber = values.registrationNumber
+    }
+
+    try {
+      await fetchJsonFromBackend(
+        request,
+        `/v1/organisations/${organisationId}/registrations/${registrationId}/status-history`,
+        {
+          method: 'POST',
+          body: JSON.stringify(body)
+        }
+      )
+    } catch (error) {
+      request.logger.error({
+        err: error,
+        message: transition.logMessage
+      })
+
+      // Only surface backend messages for client errors: 5xx and network
+      // failures carry Boom's generic message (or the raw fetch error, which
+      // leaks the backend URL), so those get the friendly fallback instead.
+      const { statusCode, payload } = error.output
+      const errorMessage =
+        (statusCode < statusCodes.internalServerError && payload?.message) ||
+        transition.errorMessage
+
+      // A backend rejection of the grant fields re-renders the confirm page
+      // so the admin keeps what they typed; 5xx and network failures still
+      // flash on the overview, where retrying immediately won't help.
+      if (grantValues && statusCode < statusCodes.internalServerError) {
+        return h
+          .view(
+            CONFIRM_VIEW,
+            buildConfirmView(action, transition, request.params, {
+              values: grantValues,
+              backendError: errorMessage
+            })
+          )
+          .code(statusCodes.badRequest)
+      }
+
+      request.yar.set('error', errorMessage)
+    }
+
+    return h.redirect(overviewUrl)
+  }
+})

--- a/src/server/routes/registration-status-transition/controller.post.js
+++ b/src/server/routes/registration-status-transition/controller.post.js
@@ -1,4 +1,4 @@
-import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
+import { postStatusTransition } from '#server/common/helpers/status-transition/post-status-transition.js'
 import { statusCodes } from '#server/common/constants/status-codes.js'
 import { buildConfirmView } from './confirm-view.js'
 import { parseGrantForm } from './grant-form.js'
@@ -51,45 +51,24 @@ export const createTransitionPostController = (action, transition) => ({
       body.registrationNumber = values.registrationNumber
     }
 
-    try {
-      await fetchJsonFromBackend(
-        request,
-        `/v1/organisations/${organisationId}/registrations/${registrationId}/status-history`,
-        {
-          method: 'POST',
-          body: JSON.stringify(body)
-        }
-      )
-    } catch (error) {
-      request.logger.error({
-        err: error,
-        message: transition.logMessage
-      })
+    const outcome = await postStatusTransition(
+      request,
+      `/v1/organisations/${organisationId}/registrations/${registrationId}/status-history`,
+      body,
+      transition,
+      grantValues
+    )
 
-      // Only surface backend messages for client errors: 5xx and network
-      // failures carry Boom's generic message (or the raw fetch error, which
-      // leaks the backend URL), so those get the friendly fallback instead.
-      const { statusCode, payload } = error.output
-      const errorMessage =
-        (statusCode < statusCodes.internalServerError && payload?.message) ||
-        transition.errorMessage
-
-      // A backend rejection of the grant fields re-renders the confirm page
-      // so the admin keeps what they typed; 5xx and network failures still
-      // flash on the overview, where retrying immediately won't help.
-      if (grantValues && statusCode < statusCodes.internalServerError) {
-        return h
-          .view(
-            CONFIRM_VIEW,
-            buildConfirmView(action, transition, request.params, {
-              values: grantValues,
-              backendError: errorMessage
-            })
-          )
-          .code(statusCodes.badRequest)
-      }
-
-      request.yar.set('error', errorMessage)
+    if (outcome) {
+      return h
+        .view(
+          CONFIRM_VIEW,
+          buildConfirmView(action, transition, request.params, {
+            values: grantValues,
+            backendError: outcome.backendError
+          })
+        )
+        .code(statusCodes.badRequest)
     }
 
     return h.redirect(overviewUrl)

--- a/src/server/routes/registration-status-transition/controller.post.test.js
+++ b/src/server/routes/registration-status-transition/controller.post.test.js
@@ -1,6 +1,8 @@
 import { createTransitionPostController } from './controller.post.js'
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
 
+/** @import {RegistrationStatusTransition} from './transitions.js' */
+
 vi.mock('#server/common/helpers/fetch-json-from-backend.js', () => ({
   fetchJsonFromBackend: vi.fn()
 }))
@@ -17,9 +19,15 @@ describe('createTransitionPostController without grant fields', () => {
   const registrationId = 'reg-1'
   const overviewUrl = `/organisations/${organisationId}/registrations/${registrationId}/overview`
 
+  /** @type {RegistrationStatusTransition} */
   const fakeTransition = {
     fromStatus: 'approved',
     toStatus: 'cancelled',
+    pageTitle: 'Cancel registration',
+    heading: 'Cancel registration',
+    warningText: 'This is a fake transition used only to test the factory.',
+    buttonText: 'Cancel registration now',
+    buttonClasses: 'govuk-button--warning',
     errorMessage:
       'There was a problem cancelling the registration. Please try again.',
     logMessage: 'Cancel registration failed'

--- a/src/server/routes/registration-status-transition/controller.post.test.js
+++ b/src/server/routes/registration-status-transition/controller.post.test.js
@@ -1,0 +1,76 @@
+import { createTransitionPostController } from './controller.post.js'
+import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
+
+vi.mock('#server/common/helpers/fetch-json-from-backend.js', () => ({
+  fetchJsonFromBackend: vi.fn()
+}))
+
+const mockFetchJsonFromBackend = vi.mocked(fetchJsonFromBackend)
+
+// Registration transitions currently registered (transitions.js) all collect
+// grant fields, so the "no grant fields" branch of the shared post-controller
+// factory can't be reached through a real route yet. It's still a genuine,
+// designed-for case — the sibling accreditation module has transitions
+// without grant fields — so it's covered here directly against the factory.
+describe('createTransitionPostController without grant fields', () => {
+  const organisationId = 'org-1'
+  const registrationId = 'reg-1'
+  const overviewUrl = `/organisations/${organisationId}/registrations/${registrationId}/overview`
+
+  const fakeTransition = {
+    fromStatus: 'approved',
+    toStatus: 'cancelled',
+    errorMessage:
+      'There was a problem cancelling the registration. Please try again.',
+    logMessage: 'Cancel registration failed'
+  }
+
+  let mockRequest
+  let mockH
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRequest = {
+      params: { organisationId, registrationId },
+      payload: {},
+      logger: { error: vi.fn() },
+      yar: { set: vi.fn() }
+    }
+    mockH = {
+      redirect: vi.fn().mockReturnValue('redirect-response')
+    }
+  })
+
+  test('posts only fromStatus/toStatus and redirects to the overview', async () => {
+    mockFetchJsonFromBackend.mockResolvedValue({ status: 'cancelled' })
+
+    const controller = createTransitionPostController('cancel', fakeTransition)
+    const result = await controller.handler(mockRequest, mockH)
+
+    expect(fetchJsonFromBackend).toHaveBeenCalledWith(
+      mockRequest,
+      `/v1/organisations/${organisationId}/registrations/${registrationId}/status-history`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ fromStatus: 'approved', toStatus: 'cancelled' })
+      }
+    )
+    expect(mockH.redirect).toHaveBeenCalledWith(overviewUrl)
+    expect(result).toBe('redirect-response')
+  })
+
+  test('a backend failure flashes the transition error and redirects to the overview', async () => {
+    mockFetchJsonFromBackend.mockRejectedValue({
+      output: { statusCode: 422, payload: { message: undefined } }
+    })
+
+    const controller = createTransitionPostController('cancel', fakeTransition)
+    await controller.handler(mockRequest, mockH)
+
+    expect(mockRequest.yar.set).toHaveBeenCalledWith(
+      'error',
+      fakeTransition.errorMessage
+    )
+    expect(mockH.redirect).toHaveBeenCalledWith(overviewUrl)
+  })
+})

--- a/src/server/routes/registration-status-transition/grant-form.js
+++ b/src/server/routes/registration-status-transition/grant-form.js
@@ -1,0 +1,59 @@
+/**
+ * Builds a YYYY-MM-DD date from GDS date-input parts, or null when the parts
+ * do not form a real calendar date.
+ * @param {string} day
+ * @param {string} month
+ * @param {string} year
+ * @returns {string | null}
+ */
+const toIsoDate = (day, month, year) => {
+  if (
+    !/^\d{1,2}$/.test(day) ||
+    !/^\d{1,2}$/.test(month) ||
+    !/^\d{4}$/.test(year)
+  ) {
+    return null
+  }
+
+  const iso = `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`
+  const date = new Date(`${iso}T00:00:00.000Z`)
+  if (Number.isNaN(date.getTime()) || !date.toISOString().startsWith(iso)) {
+    return null
+  }
+
+  return iso
+}
+
+/**
+ * Parses and validates the grant fields (applies from date parts and
+ * registration number) from a confirm-page POST.
+ * @param {Record<string, string | undefined>} payload
+ * @returns {{
+ *   values: { day: string, month: string, year: string, registrationNumber: string },
+ *   errors: { appliesFrom?: string, registrationNumber?: string } | null,
+ *   appliesFrom: string | null
+ * }}
+ */
+export const parseGrantForm = (payload) => {
+  const day = (payload['appliesFrom-day'] ?? '').trim()
+  const month = (payload['appliesFrom-month'] ?? '').trim()
+  const year = (payload['appliesFrom-year'] ?? '').trim()
+  const registrationNumber = (payload.registrationNumber ?? '').trim()
+
+  const appliesFrom = toIsoDate(day, month, year)
+
+  /** @type {{ appliesFrom?: string, registrationNumber?: string }} */
+  const errors = {}
+  if (!appliesFrom) {
+    errors.appliesFrom = 'Enter a valid applies from date'
+  }
+  if (!registrationNumber) {
+    errors.registrationNumber = 'Enter a registration number'
+  }
+
+  return {
+    values: { day, month, year, registrationNumber },
+    errors: Object.keys(errors).length > 0 ? errors : null,
+    appliesFrom
+  }
+}

--- a/src/server/routes/registration-status-transition/grant-form.js
+++ b/src/server/routes/registration-status-transition/grant-form.js
@@ -1,28 +1,4 @@
-/**
- * Builds a YYYY-MM-DD date from GDS date-input parts, or null when the parts
- * do not form a real calendar date.
- * @param {string} day
- * @param {string} month
- * @param {string} year
- * @returns {string | null}
- */
-const toIsoDate = (day, month, year) => {
-  if (
-    !/^\d{1,2}$/.test(day) ||
-    !/^\d{1,2}$/.test(month) ||
-    !/^\d{4}$/.test(year)
-  ) {
-    return null
-  }
-
-  const iso = `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`
-  const date = new Date(`${iso}T00:00:00.000Z`)
-  if (Number.isNaN(date.getTime()) || !date.toISOString().startsWith(iso)) {
-    return null
-  }
-
-  return iso
-}
+import { parseAppliesFromDate } from '#server/common/helpers/status-transition/applies-from-date.js'
 
 /**
  * Parses and validates the grant fields (applies from date parts and
@@ -35,17 +11,19 @@ const toIsoDate = (day, month, year) => {
  * }}
  */
 export const parseGrantForm = (payload) => {
-  const day = (payload['appliesFrom-day'] ?? '').trim()
-  const month = (payload['appliesFrom-month'] ?? '').trim()
-  const year = (payload['appliesFrom-year'] ?? '').trim()
+  const {
+    day,
+    month,
+    year,
+    appliesFrom,
+    error: appliesFromError
+  } = parseAppliesFromDate(payload)
   const registrationNumber = (payload.registrationNumber ?? '').trim()
-
-  const appliesFrom = toIsoDate(day, month, year)
 
   /** @type {{ appliesFrom?: string, registrationNumber?: string }} */
   const errors = {}
-  if (!appliesFrom) {
-    errors.appliesFrom = 'Enter a valid applies from date'
+  if (appliesFromError) {
+    errors.appliesFrom = appliesFromError
   }
   if (!registrationNumber) {
     errors.registrationNumber = 'Enter a registration number'

--- a/src/server/routes/registration-status-transition/index.integration.test.js
+++ b/src/server/routes/registration-status-transition/index.integration.test.js
@@ -1,0 +1,384 @@
+import { vi } from 'vitest'
+import * as cheerio from 'cheerio'
+import { config } from '#config/config.js'
+import { statusCodes } from '#server/common/constants/status-codes.js'
+import { mockUserSession } from '#server/common/test-helpers/fixtures.js'
+import { getUserSession } from '#server/common/helpers/auth/get-user-session.js'
+import { createMockOidcServer } from '#server/common/test-helpers/mock-oidc.js'
+import { getCsrfToken } from '#server/common/test-helpers/csrf-helper.js'
+import { http, server as mswServer, HttpResponse } from '#vite/setup-msw.js'
+import { createServer } from '#server/server.js'
+
+vi.mock('#server/common/helpers/auth/get-user-session.js', () => ({
+  getUserSession: vi.fn().mockReturnValue(null)
+}))
+
+describe('registration-status-transition', () => {
+  const backendUrl = config.get('eprBackendUrl')
+  const organisationId = 'aaa111bbb222ccc333ddd4444'
+  const registrationId = 'eee555fff666ggg777hhh8888'
+  const overviewUrl = `/organisations/${organisationId}/registrations/${registrationId}/overview`
+  const confirmUrl = `/organisations/${organisationId}/registrations/${registrationId}/approve/confirm`
+  const postUrl = `/organisations/${organisationId}/registrations/${registrationId}/approve`
+  const backendStatusHistoryUrl = `${backendUrl}/v1/organisations/${organisationId}/registrations/${registrationId}/status-history`
+
+  const readOnlySession = { ...mockUserSession, scopes: ['admin.read'] }
+
+  const writeAuth = { strategy: 'session', credentials: mockUserSession }
+  const readAuth = { strategy: 'session', credentials: readOnlySession }
+
+  const heading = 'Approve registration'
+  const warningText =
+    'This action must only be taken following the required legal process for approval and following instruction from an industry regulator. Approving a registration registers the operator for this site and material — they must submit the registered-only summary log and report quarterly. It does not permit PRN/PERN issuing (an accreditation is required for that).'
+  const buttonText = 'Approve now'
+  const fallbackError =
+    'There was a problem approving the registration. Please try again.'
+
+  const validFormPayload = {
+    'appliesFrom-day': '1',
+    'appliesFrom-month': '8',
+    'appliesFrom-year': '2026',
+    registrationNumber: 'REG999999'
+  }
+
+  const expectedBody = {
+    fromStatus: 'created',
+    toStatus: 'approved',
+    appliesFrom: '2026-08-01',
+    registrationNumber: 'REG999999'
+  }
+
+  let server
+
+  beforeAll(async () => {
+    createMockOidcServer()
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    await server.stop({ timeout: 0 })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const stubOverview = (status = 'approved') =>
+    mswServer.use(
+      http.get(
+        `${backendUrl}/v1/organisations/${organisationId}/overview`,
+        () =>
+          HttpResponse.json({
+            id: organisationId,
+            companyName: 'ACME Ltd',
+            registrations: [
+              {
+                id: registrationId,
+                status,
+                processingType: 'reprocessor',
+                material: 'plastic',
+                site: 'Site 1',
+                accreditation: null
+              }
+            ]
+          })
+      )
+    )
+
+  const stubCalendarAndSummaryLogs = () => {
+    mswServer.use(
+      http.get(
+        `${backendUrl}/v1/organisations/${organisationId}/registrations/${registrationId}/reports/calendar`,
+        () => HttpResponse.json({ cadence: 'monthly', reportingPeriods: [] })
+      ),
+      http.get(
+        `${backendUrl}/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs`,
+        () => HttpResponse.json({ summaryLogs: [] })
+      )
+    )
+  }
+
+  const stubTransitionSuccess = (targetStatus, receivedBodies = []) =>
+    mswServer.use(
+      http.post(backendStatusHistoryUrl, async ({ request }) => {
+        receivedBodies.push(await request.json())
+        return HttpResponse.json({ status: targetStatus })
+      })
+    )
+
+  const stubTransitionFailure = (status = 422) =>
+    mswServer.use(
+      http.post(backendStatusHistoryUrl, () =>
+        HttpResponse.json(
+          { message: 'Registration number REG999999 is already in use' },
+          { status }
+        )
+      )
+    )
+
+  const stubTransitionFailureWithoutMessage = (status = 400) =>
+    mswServer.use(
+      http.post(backendStatusHistoryUrl, () =>
+        HttpResponse.json({ error: 'Bad request' }, { status })
+      )
+    )
+
+  const postApprove = async (payloadOverrides) => {
+    const { cookie, crumb } = await getCsrfToken(server, confirmUrl, writeAuth)
+    return server.inject({
+      method: 'POST',
+      url: postUrl,
+      auth: writeAuth,
+      headers: { cookie },
+      payload: { crumb, ...validFormPayload, ...payloadOverrides }
+    })
+  }
+
+  const expectOverviewFlash = async (redirectCookie, message) => {
+    stubOverview()
+    stubCalendarAndSummaryLogs()
+    const { result } = await server.inject({
+      method: 'GET',
+      url: overviewUrl,
+      headers: { cookie: redirectCookie },
+      auth: writeAuth
+    })
+    const $ = cheerio.load(result)
+    expect($('.govuk-error-summary').text()).toContain(message)
+  }
+
+  test('confirm page is rejected with 401 when unauthenticated', async () => {
+    const { statusCode } = await server.inject({
+      method: 'GET',
+      url: confirmUrl
+    })
+    expect(statusCode).toBe(statusCodes.unauthorised)
+  })
+
+  test('confirm page returns 403 for a read-only admin', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(readOnlySession)
+    const { statusCode } = await server.inject({
+      method: 'GET',
+      url: confirmUrl,
+      auth: readAuth
+    })
+    expect(statusCode).toBe(statusCodes.forbidden)
+  })
+
+  test('confirm page renders the warning copy verbatim, both grant fields, Approve now and Cancel', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+
+    const { result, statusCode } = await server.inject({
+      method: 'GET',
+      url: confirmUrl,
+      auth: writeAuth
+    })
+
+    expect(statusCode).toBe(statusCodes.ok)
+    const $ = cheerio.load(result)
+    expect($('h1').text().trim()).toBe(heading)
+    expect(result).toContain(warningText)
+    expect($('input[name="appliesFrom-day"]')).toHaveLength(1)
+    expect($('input[name="appliesFrom-month"]')).toHaveLength(1)
+    expect($('input[name="appliesFrom-year"]')).toHaveLength(1)
+    expect($('input[name="registrationNumber"]')).toHaveLength(1)
+    expect($('form').attr('action')).toBe(postUrl)
+    expect($(`button:contains("${buttonText}")`).length).toBe(1)
+    expect($('a:contains("Cancel")').attr('href')).toBe(overviewUrl)
+  })
+
+  test('POST is rejected with 401 when unauthenticated', async () => {
+    const { statusCode } = await server.inject({
+      method: 'POST',
+      url: postUrl
+    })
+    expect(statusCode).toBe(statusCodes.unauthorised)
+  })
+
+  test('POST is rejected with 403 for a read-only admin', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(readOnlySession)
+    const { cookie, crumb } = await getCsrfToken(server, confirmUrl, readAuth)
+    const { statusCode } = await server.inject({
+      method: 'POST',
+      url: postUrl,
+      auth: readAuth,
+      headers: { cookie },
+      payload: { crumb }
+    })
+    expect(statusCode).toBe(statusCodes.forbidden)
+  })
+
+  test('successful approve posts the from/to transition and grant fields to the backend status-history endpoint and redirects to the overview', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+    const receivedBodies = []
+    stubTransitionSuccess('approved', receivedBodies)
+
+    const postResponse = await postApprove()
+    expect(postResponse.statusCode).toBe(statusCodes.found)
+    expect(postResponse.headers.location).toBe(overviewUrl)
+    expect(receivedBodies).toEqual([expectedBody])
+  })
+
+  test('failed approve when the backend is unreachable falls back to the generic flash error', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+    mswServer.use(
+      http.post(backendStatusHistoryUrl, () => HttpResponse.error())
+    )
+
+    const postResponse = await postApprove()
+    expect(postResponse.statusCode).toBe(statusCodes.found)
+    expect(postResponse.headers.location).toBe(overviewUrl)
+
+    const postCookies = [postResponse.headers['set-cookie']]
+      .flat()
+      .filter(Boolean)
+    const redirectCookie = postCookies.map((c) => c.split(';')[0]).join('; ')
+
+    await expectOverviewFlash(redirectCookie, fallbackError)
+  })
+
+  test('missing registration number re-renders the page with an error, preserving the date', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+    const receivedBodies = []
+    stubTransitionSuccess('approved', receivedBodies)
+
+    const response = await postApprove({ registrationNumber: '  ' })
+
+    expect(response.statusCode).toBe(statusCodes.badRequest)
+    const $ = cheerio.load(response.result)
+    expect($('.govuk-error-summary').text()).toContain(
+      'Enter a registration number'
+    )
+    expect($('input[name="appliesFrom-day"]').attr('value')).toBe('1')
+    expect($('input[name="appliesFrom-year"]').attr('value')).toBe('2026')
+    expect(receivedBodies).toEqual([])
+  })
+
+  test.each([
+    ['a missing day', { 'appliesFrom-day': '' }],
+    ['a non-numeric month', { 'appliesFrom-month': 'August' }],
+    ['a month past December', { 'appliesFrom-month': '13' }],
+    ['a two-digit year', { 'appliesFrom-year': '26' }],
+    [
+      'an impossible date',
+      { 'appliesFrom-month': '2', 'appliesFrom-day': '30' }
+    ]
+  ])(
+    'an invalid applies from date (%s) re-renders the page with an error, preserving the number',
+    async (_label, payloadOverrides) => {
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+      const receivedBodies = []
+      stubTransitionSuccess('approved', receivedBodies)
+
+      const response = await postApprove(payloadOverrides)
+
+      expect(response.statusCode).toBe(statusCodes.badRequest)
+      const $ = cheerio.load(response.result)
+      expect($('.govuk-error-summary').text()).toContain(
+        'Enter a valid applies from date'
+      )
+      expect($('input[name="registrationNumber"]').attr('value')).toBe(
+        'REG999999'
+      )
+      expect(receivedBodies).toEqual([])
+    }
+  )
+
+  test('missing both fields lists both errors in the summary', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+
+    const response = await postApprove({
+      'appliesFrom-day': '',
+      'appliesFrom-month': '',
+      'appliesFrom-year': '',
+      registrationNumber: ''
+    })
+
+    expect(response.statusCode).toBe(statusCodes.badRequest)
+    const $ = cheerio.load(response.result)
+    const summary = $('.govuk-error-summary').text()
+    expect(summary).toContain('Enter a valid applies from date')
+    expect(summary).toContain('Enter a registration number')
+  })
+
+  test('a submission without any grant fields lists both errors in the summary', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+    const { cookie, crumb } = await getCsrfToken(server, confirmUrl, writeAuth)
+
+    const response = await server.inject({
+      method: 'POST',
+      url: postUrl,
+      auth: writeAuth,
+      headers: { cookie },
+      payload: { crumb }
+    })
+
+    expect(response.statusCode).toBe(statusCodes.badRequest)
+    const $ = cheerio.load(response.result)
+    const summary = $('.govuk-error-summary').text()
+    expect(summary).toContain('Enter a valid applies from date')
+    expect(summary).toContain('Enter a registration number')
+  })
+
+  test('a backend rejection re-renders the page with the backend message, preserving input', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+    stubTransitionFailure()
+
+    const response = await postApprove()
+
+    expect(response.statusCode).toBe(statusCodes.badRequest)
+    const $ = cheerio.load(response.result)
+    expect($('.govuk-error-summary').text()).toContain(
+      'Registration number REG999999 is already in use'
+    )
+    expect($('input[name="appliesFrom-day"]').attr('value')).toBe('1')
+    expect($('input[name="appliesFrom-month"]').attr('value')).toBe('8')
+    expect($('input[name="appliesFrom-year"]').attr('value')).toBe('2026')
+    expect($('input[name="registrationNumber"]').attr('value')).toBe(
+      'REG999999'
+    )
+  })
+
+  test('a backend rejection without a message re-renders the page with the generic error', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+    stubTransitionFailureWithoutMessage()
+
+    const response = await postApprove()
+
+    expect(response.statusCode).toBe(statusCodes.badRequest)
+    const $ = cheerio.load(response.result)
+    expect($('.govuk-error-summary').text()).toContain(fallbackError)
+  })
+
+  test('a non-object backend error body falls back to the generic flash error', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+    mswServer.use(
+      http.post(backendStatusHistoryUrl, () =>
+        HttpResponse.json(null, { status: 422 })
+      )
+    )
+
+    const response = await postApprove()
+
+    expect(response.statusCode).toBe(statusCodes.badRequest)
+    const $ = cheerio.load(response.result)
+    expect($('.govuk-error-summary').text()).toContain(fallbackError)
+  })
+
+  test('a backend 5xx failure redirects to the overview with the generic flash error', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+    stubTransitionFailure(statusCodes.internalServerError)
+
+    const postResponse = await postApprove()
+    expect(postResponse.statusCode).toBe(statusCodes.found)
+    expect(postResponse.headers.location).toBe(overviewUrl)
+
+    const postCookies = [postResponse.headers['set-cookie']]
+      .flat()
+      .filter(Boolean)
+    const redirectCookie = postCookies.map((c) => c.split(';')[0]).join('; ')
+
+    await expectOverviewFlash(redirectCookie, fallbackError)
+  })
+})

--- a/src/server/routes/registration-status-transition/index.integration.test.js
+++ b/src/server/routes/registration-status-transition/index.integration.test.js
@@ -184,7 +184,7 @@ describe('registration-status-transition', () => {
     expect($('input[name="appliesFrom-year"]')).toHaveLength(1)
     expect($('input[name="registrationNumber"]')).toHaveLength(1)
     expect($('form').attr('action')).toBe(postUrl)
-    expect($(`button:contains("${buttonText}")`).length).toBe(1)
+    expect($(`button:contains("${buttonText}")`)).toHaveLength(1)
     expect($('a:contains("Cancel")').attr('href')).toBe(overviewUrl)
   })
 

--- a/src/server/routes/registration-status-transition/index.js
+++ b/src/server/routes/registration-status-transition/index.js
@@ -1,0 +1,38 @@
+import { REGISTRATION_STATUS_TRANSITIONS } from './transitions.js'
+import { createConfirmGetController } from './controller.get-confirm.js'
+import { createTransitionPostController } from './controller.post.js'
+import { requireScope } from '#server/common/helpers/auth/require-scope.js'
+import { SCOPES } from '#server/common/helpers/auth/scopes.js'
+
+const BASE = '/organisations/{organisationId}/registrations/{registrationId}'
+const requireWrite = [requireScope(SCOPES.adminWrite)]
+
+export const registrationStatusTransition = {
+  plugin: {
+    name: 'registration-status-transition',
+    register(server) {
+      for (const [action, transition] of Object.entries(
+        REGISTRATION_STATUS_TRANSITIONS
+      )) {
+        server.route([
+          {
+            method: 'GET',
+            path: `${BASE}/${action}/confirm`,
+            ...createConfirmGetController(action, transition),
+            options: {
+              pre: requireWrite
+            }
+          },
+          {
+            method: 'POST',
+            path: `${BASE}/${action}`,
+            ...createTransitionPostController(action, transition),
+            options: {
+              pre: requireWrite
+            }
+          }
+        ])
+      }
+    }
+  }
+}

--- a/src/server/routes/registration-status-transition/transitions.js
+++ b/src/server/routes/registration-status-transition/transitions.js
@@ -1,0 +1,37 @@
+/**
+ * @typedef {object} RegistrationStatusTransition
+ * @property {string} fromStatus - Status the registration must currently hold
+ * @property {string} toStatus - Status posted to the backend status-history endpoint
+ * @property {string} pageTitle
+ * @property {string} heading
+ * @property {string} warningText - Confirm-page warning copy
+ * @property {string} buttonText
+ * @property {string} buttonClasses
+ * @property {string} errorMessage - Flash fallback when the backend gives no message
+ * @property {string} logMessage
+ * @property {boolean} [hasGrantFields] - Confirm page collects appliesFrom + registrationNumber
+ */
+
+/**
+ * Registration status transitions the admin UI can action, keyed by the URL
+ * action segment. Each entry drives a confirm page and a POST of
+ * `{ fromStatus, toStatus, ...params }` to the backend status-history
+ * endpoint.
+ * @type {Record<string, RegistrationStatusTransition>}
+ */
+export const REGISTRATION_STATUS_TRANSITIONS = {
+  approve: {
+    fromStatus: 'created',
+    toStatus: 'approved',
+    pageTitle: 'Approve registration',
+    heading: 'Approve registration',
+    warningText:
+      'This action must only be taken following the required legal process for approval and following instruction from an industry regulator. Approving a registration registers the operator for this site and material — they must submit the registered-only summary log and report quarterly. It does not permit PRN/PERN issuing (an accreditation is required for that).',
+    buttonText: 'Approve now',
+    buttonClasses: '',
+    errorMessage:
+      'There was a problem approving the registration. Please try again.',
+    logMessage: 'Approve registration failed',
+    hasGrantFields: true
+  }
+}


### PR DESCRIPTION
## Summary

- Adds the admin-UI grant-registration journey (PAE-1599): an Approve action next to the registration Status row on the registration overview page, shown only for `created` registrations to users with admin write scope.
- New confirmation page with the legal-process warning, a mandatory "Applies from" date input and a mandatory "Registration number" input; "Approve now" POSTs `{ fromStatus: "created", toStatus: "approved", appliesFrom, registrationNumber }` to the new backend registration status-history endpoint, then returns to the overview showing the new status; "Cancel" returns unchanged.
- Validation errors and backend 4xx responses re-render the confirm page with a GDS error summary preserving input; backend 5xx/network failures flash on the overview via the existing yar mechanism.

Jira: [PAE-1599](https://eaflood.atlassian.net/browse/PAE-1599)


[PAE-1599]: https://eaflood.atlassian.net/browse/PAE-1599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ