### PR TITLE
PAE-1556 Shows users role and scopes in system logs

### DIFF
--- a/src/server/routes/system-logs/get.integration.test.js
+++ b/src/server/routes/system-logs/get.integration.test.js
@@ -234,6 +234,69 @@ describe('GET /system-logs', () => {
       })
     })
 
+    describe('user scope and role rendering', () => {
+      it('renders the scopes under "Scopes" and the role under "Role"', async () => {
+        stubBackendResponse(
+          HttpResponse.json({
+            systemLogs: [
+              {
+                createdBy: { scope: ['admin'], role: 'super-admin' },
+                event: {},
+                context: {}
+              }
+            ]
+          })
+        )
+
+        const { $, statusCode } = await loadPage(
+          new URLSearchParams({ referenceNumber: 'ORG-123' })
+        )
+
+        expect(statusCode).toBe(statusCodes.ok)
+
+        const scopesRow = $('.govuk-summary-card .govuk-summary-list__row').has(
+          'dt:contains("Scopes")'
+        )
+        expect(
+          scopesRow.find('dd.govuk-summary-list__value').text().trim()
+        ).toBe('admin')
+
+        const roleRow = $('.govuk-summary-card .govuk-summary-list__row').has(
+          'dt:contains("Role")'
+        )
+        expect(roleRow.find('dd.govuk-summary-list__value').text().trim()).toBe(
+          'super-admin'
+        )
+      })
+
+      it('renders an empty "Role" value when role is null', async () => {
+        stubBackendResponse(
+          HttpResponse.json({
+            systemLogs: [
+              {
+                createdBy: { scope: ['admin'], role: null },
+                event: {},
+                context: {}
+              }
+            ]
+          })
+        )
+
+        const { $, statusCode } = await loadPage(
+          new URLSearchParams({ referenceNumber: 'ORG-123' })
+        )
+
+        expect(statusCode).toBe(statusCodes.ok)
+
+        const roleRow = $('.govuk-summary-card .govuk-summary-list__row').has(
+          'dt:contains("Role")'
+        )
+        expect(roleRow.find('dd.govuk-summary-list__value').text().trim()).toBe(
+          ''
+        )
+      })
+    })
+
     describe('system log with previous & next rendering', () => {
       it('includes context.previous and context.next in <details> elements', async () => {
         stubBackendResponse(

--- a/src/server/routes/system-logs/index.njk
+++ b/src/server/routes/system-logs/index.njk
@@ -107,8 +107,12 @@
               value: { html: systemLog.user.email }
             },
             {
-              key: { text: "User roles" },
+              key: { text: "Scopes" },
               value: { html: systemLog.user.scope }
+            },
+            {
+              key: { text: "Role" },
+              value: { html: systemLog.user.role }
             }
           ] %}
 


### PR DESCRIPTION
Ticket: [PAE-1556](https://eaflood.atlassian.net/browse/PAE-1556)
## Description

Updates system logs rendering to
- label scopes as "Scopes" (previously this was labelled Roles")
- render the user's role (renders empty if the role is `null`)

<img width="500" alt="Screenshot 2026-06-24 at 10 32 47" src="https://github.com/user-attachments/assets/919838bf-6ee1-429f-abee-1495565327d4" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/7f3b2b6d-c4ec-4195-aedd-a52b08a612f3" />


---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1556]: https://eaflood.atlassian.net/browse/PAE-1556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ