### PR TITLE
PAE-000: finish govuk-frontend v6 header migration

### DIFF
--- a/src/client/javascripts/application.js
+++ b/src/client/javascripts/application.js
@@ -4,6 +4,7 @@ import {
   createAll,
   ErrorSummary,
   Radios,
+  ServiceNavigation,
   SkipLink
 } from 'govuk-frontend'
 
@@ -11,4 +12,5 @@ createAll(Button)
 createAll(Checkboxes)
 createAll(ErrorSummary)
 createAll(Radios)
+createAll(ServiceNavigation)
 createAll(SkipLink)

--- a/src/client/javascripts/application.test.js
+++ b/src/client/javascripts/application.test.js
@@ -8,6 +8,7 @@ vi.mock('govuk-frontend', () => ({
   Checkboxes: 'MockCheckboxes',
   ErrorSummary: 'MockErrorSummary',
   Radios: 'MockRadios',
+  ServiceNavigation: 'MockServiceNavigation',
   SkipLink: 'MockSkipLink'
 }))
 
@@ -20,11 +21,12 @@ describe('#application', () => {
     test('Should call createAll once for each component', async () => {
       await import('./application.js')
 
-      expect(mockCreateAll).toHaveBeenCalledTimes(5)
+      expect(mockCreateAll).toHaveBeenCalledTimes(6)
       expect(mockCreateAll).toHaveBeenCalledWith('MockButton')
       expect(mockCreateAll).toHaveBeenCalledWith('MockCheckboxes')
       expect(mockCreateAll).toHaveBeenCalledWith('MockErrorSummary')
       expect(mockCreateAll).toHaveBeenCalledWith('MockRadios')
+      expect(mockCreateAll).toHaveBeenCalledWith('MockServiceNavigation')
       expect(mockCreateAll).toHaveBeenCalledWith('MockSkipLink')
     })
   })


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)

completes the govuk-frontend v6 header migration. v6 removed the `Header` js component and moved the mobile menu toggle to the `ServiceNavigation` component, which was never initialised after the v6 bump — so the service navigation didn't collapse behind a menu button on mobile (it rendered fully expanded; progressive-enhancement degradation, not a hard break).

changes:
1. **service nav js** — adds `createAll(ServiceNavigation)` so the mobile menu toggle works.