### PR TITLE
PAE-000: use caret node engine range for lts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
         "webpack-cli": "7.0.3"
       },
       "engines": {
-        "node": ">=24.16.0 <25"
+        "node": "^24.16.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "#vite/*": "./.vite/*"
   },
   "engines": {
-    "node": ">=24.16.0 <25"
+    "node": "^24.16.0"
   },
   "scripts": {
     "schema:compile": "ajv compile --all-errors --verbose --data -c ajv-formats -s ./src/server/common/schemas/organisation.json -o ./src/server/common/schemas/organisation.ajv.js --code-es5 && node -e \"const fs=require('fs');const f='./src/server/common/schemas/organisation.ajv.js';fs.writeFileSync(f,'// @ts-nocheck\\n'+fs.readFileSync(f,'utf8'))\"",


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
follows the shared preset change (epr-re-ex-service#297). switch the node engines constraint to a single `^x.y.z` token — semantically identical to `>=x <25` (same `engine-strict` guardrail against 25/26) but a single renovate-managed token that advances cleanly to the next lts. node base image is unaffected (defradigital, managed separately).

- engines: `>=24.16.0 <25` -> `^24.16.0`