### PR TITLE
PAE-1673: Add registration-scoped waste-record and PRN downloads

### DIFF
--- a/src/server/common/helpers/proxy-csv-stream.js
+++ b/src/server/common/helpers/proxy-csv-stream.js
@@ -1,0 +1,54 @@
+import { Readable } from 'node:stream'
+
+import { streamFromBackend } from '#server/common/helpers/stream-from-backend.js'
+
+/** @import { HapiRequest } from '#server/common/hapi-types.js' */
+/** @import { ReadableStream as WebReadableStream } from 'node:stream/web' */
+
+const DEFAULT_CONTENT_TYPE = 'text/csv; charset=utf-8'
+
+/**
+ * Proxy a backend CSV stream straight through to the browser, preserving the
+ * backend's Content-Type and Content-Disposition headers. Throws when the
+ * backend responds without a body so callers can surface a download error.
+ *
+ * @param {HapiRequest} request
+ * @param {object} h - Hapi response toolkit
+ * @param {string} backendPath - Backend path (with any query string) to stream
+ * @param {string} fallbackFilename - Filename used if the backend omits Content-Disposition
+ * @returns {Promise<object>} the Hapi response
+ */
+export const proxyCsvStream = async (
+  request,
+  h,
+  backendPath,
+  fallbackFilename
+) => {
+  const response = await streamFromBackend(request, backendPath)
+
+  if (!response.body) {
+    throw new Error(
+      `Backend returned a successful response with no body for ${backendPath}`
+    )
+  }
+
+  // `response.body` from the Fetch API is a Web ReadableStream. Hapi only
+  // understands strings, Buffers, and Node Readable streams — given a Web
+  // stream it serialises the object, which produces `{}` instead of the CSV
+  // payload. Adapt to a Node Readable so Hapi proxies the chunks. The cast
+  // works around an upstream `@types/node` mismatch between the Web
+  // `ReadableStream<Uint8Array<ArrayBuffer>>` and the older signature
+  // `Readable.fromWeb` expects.
+  const body = /** @type {WebReadableStream} */ (
+    /** @type {unknown} */ (response.body)
+  )
+
+  return h
+    .response(Readable.fromWeb(body))
+    .type(response.headers.get('content-type') ?? DEFAULT_CONTENT_TYPE)
+    .header(
+      'Content-Disposition',
+      response.headers.get('content-disposition') ??
+        `attachment; filename="${fallbackFilename}"`
+    )
+}

--- a/src/server/common/helpers/proxy-csv-stream.test.js
+++ b/src/server/common/helpers/proxy-csv-stream.test.js
@@ -1,0 +1,99 @@
+import { Readable } from 'node:stream'
+
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+import { proxyCsvStream } from './proxy-csv-stream.js'
+import { streamFromBackend } from '#server/common/helpers/stream-from-backend.js'
+
+vi.mock('#server/common/helpers/stream-from-backend.js', () => ({
+  streamFromBackend: vi.fn()
+}))
+
+const buildWebStream = (chunks) =>
+  new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(new TextEncoder().encode(chunk))
+      }
+      controller.close()
+    }
+  })
+
+const collectNodeStream = (stream) =>
+  new Promise((resolve, reject) => {
+    const parts = []
+    stream.on('data', (c) => parts.push(c))
+    stream.on('end', () => resolve(Buffer.concat(parts).toString('utf-8')))
+    stream.on('error', reject)
+  })
+
+const buildHapiH = () => {
+  const calls = { type: [], header: [] }
+  const responseBuilder = {
+    type: vi.fn(function (...args) {
+      calls.type.push(args)
+      return this
+    }),
+    header: vi.fn(function (...args) {
+      calls.header.push(args)
+      return this
+    })
+  }
+  const h = { response: vi.fn(() => responseBuilder) }
+  return { h, calls }
+}
+
+describe('proxyCsvStream', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('streams the backend body as a Node Readable, preserving headers', async () => {
+    streamFromBackend.mockResolvedValue({
+      body: buildWebStream(['header\n', 'a,b\n']),
+      headers: new Headers({
+        'content-type': 'text/csv; charset=utf-8',
+        'content-disposition': 'attachment; filename="scoped.csv"'
+      })
+    })
+
+    const { h, calls } = buildHapiH()
+    const request = {}
+
+    await proxyCsvStream(request, h, '/some/path?x=1', 'fallback.csv')
+
+    expect(streamFromBackend).toHaveBeenCalledWith(request, '/some/path?x=1')
+
+    const passedBody = h.response.mock.calls[0][0]
+    expect(passedBody).toBeInstanceOf(Readable)
+    expect(await collectNodeStream(passedBody)).toBe('header\na,b\n')
+    expect(calls.type).toEqual([['text/csv; charset=utf-8']])
+    expect(calls.header).toEqual([
+      ['Content-Disposition', 'attachment; filename="scoped.csv"']
+    ])
+  })
+
+  it('falls back to default content-type and the given filename when headers are missing', async () => {
+    streamFromBackend.mockResolvedValue({
+      body: buildWebStream([]),
+      headers: new Headers({})
+    })
+
+    const { h, calls } = buildHapiH()
+
+    await proxyCsvStream({}, h, '/some/path', 'fallback.csv')
+
+    expect(calls.type).toEqual([['text/csv; charset=utf-8']])
+    expect(calls.header).toEqual([
+      ['Content-Disposition', 'attachment; filename="fallback.csv"']
+    ])
+  })
+
+  it('throws when the backend response has no body', async () => {
+    streamFromBackend.mockResolvedValue({ body: null, headers: new Headers() })
+
+    const { h } = buildHapiH()
+
+    await expect(
+      proxyCsvStream({}, h, '/some/path', 'fallback.csv')
+    ).rejects.toThrow(/no body/)
+  })
+})

--- a/src/server/common/helpers/proxy-csv-stream.test.js
+++ b/src/server/common/helpers/proxy-csv-stream.test.js
@@ -28,35 +28,31 @@ const collectNodeStream = (stream) =>
   })
 
 const buildHapiH = () => {
-  const calls = { type: [], header: [] }
   const responseBuilder = {
-    type: vi.fn(function (...args) {
-      calls.type.push(args)
-      return this
-    }),
-    header: vi.fn(function (...args) {
-      calls.header.push(args)
-      return this
-    })
+    type: vi.fn().mockReturnThis(),
+    header: vi.fn().mockReturnThis()
   }
-  const h = { response: vi.fn(() => responseBuilder) }
-  return { h, calls }
+  const h = { response: vi.fn().mockReturnValue(responseBuilder) }
+  return { h, responseBuilder }
 }
+
+const request = /** @type {any} */ ({})
 
 describe('proxyCsvStream', () => {
   beforeEach(() => vi.clearAllMocks())
 
   it('streams the backend body as a Node Readable, preserving headers', async () => {
-    streamFromBackend.mockResolvedValue({
-      body: buildWebStream(['header\n', 'a,b\n']),
-      headers: new Headers({
-        'content-type': 'text/csv; charset=utf-8',
-        'content-disposition': 'attachment; filename="scoped.csv"'
+    vi.mocked(streamFromBackend).mockResolvedValue(
+      /** @type {any} */ ({
+        body: buildWebStream(['header\n', 'a,b\n']),
+        headers: new Headers({
+          'content-type': 'text/csv; charset=utf-8',
+          'content-disposition': 'attachment; filename="scoped.csv"'
+        })
       })
-    })
+    )
 
-    const { h, calls } = buildHapiH()
-    const request = {}
+    const { h, responseBuilder } = buildHapiH()
 
     await proxyCsvStream(request, h, '/some/path?x=1', 'fallback.csv')
 
@@ -65,35 +61,41 @@ describe('proxyCsvStream', () => {
     const passedBody = h.response.mock.calls[0][0]
     expect(passedBody).toBeInstanceOf(Readable)
     expect(await collectNodeStream(passedBody)).toBe('header\na,b\n')
-    expect(calls.type).toEqual([['text/csv; charset=utf-8']])
-    expect(calls.header).toEqual([
-      ['Content-Disposition', 'attachment; filename="scoped.csv"']
-    ])
+    expect(responseBuilder.type).toHaveBeenCalledWith('text/csv; charset=utf-8')
+    expect(responseBuilder.header).toHaveBeenCalledWith(
+      'Content-Disposition',
+      'attachment; filename="scoped.csv"'
+    )
   })
 
   it('falls back to default content-type and the given filename when headers are missing', async () => {
-    streamFromBackend.mockResolvedValue({
-      body: buildWebStream([]),
-      headers: new Headers({})
-    })
+    vi.mocked(streamFromBackend).mockResolvedValue(
+      /** @type {any} */ ({
+        body: buildWebStream([]),
+        headers: new Headers({})
+      })
+    )
 
-    const { h, calls } = buildHapiH()
+    const { h, responseBuilder } = buildHapiH()
 
-    await proxyCsvStream({}, h, '/some/path', 'fallback.csv')
+    await proxyCsvStream(request, h, '/some/path', 'fallback.csv')
 
-    expect(calls.type).toEqual([['text/csv; charset=utf-8']])
-    expect(calls.header).toEqual([
-      ['Content-Disposition', 'attachment; filename="fallback.csv"']
-    ])
+    expect(responseBuilder.type).toHaveBeenCalledWith('text/csv; charset=utf-8')
+    expect(responseBuilder.header).toHaveBeenCalledWith(
+      'Content-Disposition',
+      'attachment; filename="fallback.csv"'
+    )
   })
 
   it('throws when the backend response has no body', async () => {
-    streamFromBackend.mockResolvedValue({ body: null, headers: new Headers() })
+    vi.mocked(streamFromBackend).mockResolvedValue(
+      /** @type {any} */ ({ body: null, headers: new Headers() })
+    )
 
     const { h } = buildHapiH()
 
     await expect(
-      proxyCsvStream({}, h, '/some/path', 'fallback.csv')
+      proxyCsvStream(request, h, '/some/path', 'fallback.csv')
     ).rejects.toThrow(/no body/)
   })
 })

--- a/src/server/routes/prn-activity/controller.download.js
+++ b/src/server/routes/prn-activity/controller.download.js
@@ -11,12 +11,12 @@ function getDisplayName(org) {
   return org.tradingName || org.name || ''
 }
 
-async function fetchAllPrns(request) {
+export async function fetchAllPrns(request, accreditationId) {
   const allItems = []
   let cursor = null
 
   do {
-    const url = buildPrnApiUrl(cursor)
+    const url = buildPrnApiUrl(cursor, accreditationId)
     const data = await fetchJsonFromBackend(request, url)
     const items = data?.items || []
     allItems.push(...items)
@@ -27,7 +27,7 @@ async function fetchAllPrns(request) {
   return allItems
 }
 
-function generateCsv(items) {
+export function generateCsv(items) {
   const rows = [
     [
       'PRN Number',

--- a/src/server/routes/prn-activity/controller.js
+++ b/src/server/routes/prn-activity/controller.js
@@ -31,10 +31,13 @@ function mapPrns(data) {
   }))
 }
 
-export function buildPrnApiUrl(cursor) {
+export function buildPrnApiUrl(cursor, accreditationId) {
   let url = `/v1/admin/packaging-recycling-notes?statuses=${statuses}`
   if (cursor) {
     url += `&cursor=${encodeURIComponent(cursor)}`
+  }
+  if (accreditationId) {
+    url += `&accreditationId=${encodeURIComponent(accreditationId)}`
   }
   return url
 }

--- a/src/server/routes/prn-activity/controller.scoped-download.js
+++ b/src/server/routes/prn-activity/controller.scoped-download.js
@@ -1,0 +1,34 @@
+import { fetchAllPrns, generateCsv } from './controller.download.js'
+
+/**
+ * Downloads PRN activity for a single accreditation as CSV. Triggered from the
+ * registration overview page so a regulator can download just one org's PRNs.
+ */
+export const prnActivityScopedDownloadController = {
+  async handler(request, h) {
+    const { organisationId, registrationId, accreditationId } = request.params
+
+    try {
+      const items = await fetchAllPrns(request, accreditationId)
+      const csv = await generateCsv(items)
+
+      return h
+        .response(csv)
+        .header('Content-Type', 'text/csv')
+        .header(
+          'Content-Disposition',
+          `attachment; filename="prn-activity-${accreditationId}.csv"`
+        )
+    } catch (error) {
+      const errorMessage =
+        error.output?.payload?.message ||
+        'There was a problem downloading the PRN activity data. Please try again.'
+
+      request.yar.set('error', errorMessage)
+
+      return h.redirect(
+        `/organisations/${organisationId}/registrations/${registrationId}/overview`
+      )
+    }
+  }
+}

--- a/src/server/routes/prn-activity/controller.scoped-download.test.js
+++ b/src/server/routes/prn-activity/controller.scoped-download.test.js
@@ -1,0 +1,114 @@
+import { vi, describe, test, expect, beforeEach } from 'vitest'
+import Boom from '@hapi/boom'
+
+import { prnActivityScopedDownloadController } from './controller.scoped-download.js'
+import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
+
+vi.mock('#server/common/helpers/fetch-json-from-backend.js', () => ({
+  fetchJsonFromBackend: vi.fn()
+}))
+
+const mockPrn = {
+  prnNumber: 'PRN-001',
+  status: 'awaiting_acceptance',
+  issuedToOrganisation: { name: 'Org A' },
+  tonnage: 100,
+  material: 'Glass',
+  processToBeUsed: 'R3',
+  isDecemberWaste: true,
+  issuedAt: '2025-06-15T10:30:00.000Z',
+  issuedBy: { name: 'John', position: 'Manager' },
+  accreditationNumber: 'ACC-2025-001',
+  accreditationYear: 2025,
+  organisationName: 'Reprocessor Ltd',
+  wasteProcessingType: 'reprocessor'
+}
+
+describe('prn-activity scoped download controller', () => {
+  let request
+  let h
+  let responseBuilder
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    request = {
+      params: {
+        organisationId: 'org-1',
+        registrationId: 'reg-1',
+        accreditationId: 'acc-9'
+      },
+      yar: { set: vi.fn() }
+    }
+
+    responseBuilder = { header: vi.fn().mockReturnThis() }
+    h = {
+      response: vi.fn().mockReturnValue(responseBuilder),
+      redirect: vi.fn().mockReturnValue('redirect-response')
+    }
+  })
+
+  test('Should fetch PRNs filtered by the accreditation id', async () => {
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+      items: [],
+      hasMore: false
+    })
+
+    await prnActivityScopedDownloadController.handler(request, h)
+
+    expect(fetchJsonFromBackend).toHaveBeenCalledWith(
+      request,
+      expect.stringContaining('accreditationId=acc-9')
+    )
+  })
+
+  test('Should generate CSV and set an accreditation-scoped filename', async () => {
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+      items: [mockPrn],
+      hasMore: false
+    })
+
+    await prnActivityScopedDownloadController.handler(request, h)
+
+    const csvContent = h.response.mock.calls[0][0]
+    expect(csvContent).toContain('PRN-001')
+    expect(responseBuilder.header).toHaveBeenCalledWith(
+      'Content-Type',
+      'text/csv'
+    )
+    expect(responseBuilder.header).toHaveBeenCalledWith(
+      'Content-Disposition',
+      'attachment; filename="prn-activity-acc-9.csv"'
+    )
+  })
+
+  test('Should redirect to the registration overview with a flash error on failure', async () => {
+    vi.mocked(fetchJsonFromBackend).mockRejectedValue(
+      new Error('Network error')
+    )
+
+    const result = await prnActivityScopedDownloadController.handler(request, h)
+
+    expect(request.yar.set).toHaveBeenCalledWith(
+      'error',
+      'There was a problem downloading the PRN activity data. Please try again.'
+    )
+    expect(h.redirect).toHaveBeenCalledWith(
+      '/organisations/org-1/registrations/reg-1/overview'
+    )
+    expect(result).toBe('redirect-response')
+  })
+
+  test('Should use the backend error message when available', async () => {
+    vi.mocked(fetchJsonFromBackend).mockRejectedValue(
+      Boom.badRequest('Custom backend error message')
+    )
+
+    await prnActivityScopedDownloadController.handler(request, h)
+
+    expect(request.yar.set).toHaveBeenCalledWith(
+      'error',
+      'Custom backend error message'
+    )
+  })
+})

--- a/src/server/routes/prn-activity/controller.test.js
+++ b/src/server/routes/prn-activity/controller.test.js
@@ -335,4 +335,16 @@ describe('buildPrnApiUrl', () => {
     const url = buildPrnApiUrl('abc 123')
     expect(url).toContain('cursor=abc%20123')
   })
+
+  test('Should append accreditationId when provided', () => {
+    const url = buildPrnApiUrl(null, 'acc-9')
+    expect(url).toBe(
+      `/v1/admin/packaging-recycling-notes?statuses=${expectedStatuses}&accreditationId=acc-9`
+    )
+  })
+
+  test('Should encode the accreditationId value', () => {
+    const url = buildPrnApiUrl(null, 'acc 9')
+    expect(url).toContain('accreditationId=acc%209')
+  })
 })

--- a/src/server/routes/prn-activity/controller.test.js
+++ b/src/server/routes/prn-activity/controller.test.js
@@ -335,16 +335,4 @@ describe('buildPrnApiUrl', () => {
     const url = buildPrnApiUrl('abc 123')
     expect(url).toContain('cursor=abc%20123')
   })
-
-  test('Should append accreditationId when provided', () => {
-    const url = buildPrnApiUrl(null, 'acc-9')
-    expect(url).toBe(
-      `/v1/admin/packaging-recycling-notes?statuses=${expectedStatuses}&accreditationId=acc-9`
-    )
-  })
-
-  test('Should encode the accreditationId value', () => {
-    const url = buildPrnApiUrl(null, 'acc 9')
-    expect(url).toContain('accreditationId=acc%209')
-  })
 })

--- a/src/server/routes/prn-activity/index.js
+++ b/src/server/routes/prn-activity/index.js
@@ -1,5 +1,12 @@
+import Joi from 'joi'
+
 import { prnActivityController } from './controller.js'
 import { prnActivityDownloadController } from './controller.download.js'
+import { prnActivityScopedDownloadController } from './controller.scoped-download.js'
+
+const idParam = Joi.string()
+  .pattern(/^[\w-]+$/)
+  .required()
 
 export const prnActivity = {
   plugin: {
@@ -18,6 +25,20 @@ export const prnActivity = {
           method: 'GET',
           path: '/prn-activity/download',
           ...prnActivityDownloadController
+        },
+        {
+          method: 'GET',
+          path: '/organisations/{organisationId}/registrations/{registrationId}/accreditations/{accreditationId}/prn-activity/download',
+          ...prnActivityScopedDownloadController,
+          options: {
+            validate: {
+              params: Joi.object({
+                organisationId: idParam,
+                registrationId: idParam,
+                accreditationId: idParam
+              })
+            }
+          }
         }
       ])
     }

--- a/src/server/routes/registration-overview/controller.get.js
+++ b/src/server/routes/registration-overview/controller.get.js
@@ -53,6 +53,9 @@ export const registrationOverviewGETController = {
   async handler(request, h) {
     const { organisationId, registrationId } = request.params
 
+    const errorMessage = request.yar.get('error')
+    await request.yar.clear('error')
+
     const [overview, calendar, { summaryLogs }] = await Promise.all([
       fetchOrganisationOverview(request, organisationId),
       fetchJsonFromBackend(
@@ -109,6 +112,7 @@ export const registrationOverviewGETController = {
       })),
       summaryLogRows,
       wasteBalance,
+      error: errorMessage,
       wasteBalanceEventsUrl: registration.accreditation
         ? `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${registration.accreditation.id}/waste-balance-events`
         : null,
@@ -116,7 +120,11 @@ export const registrationOverviewGETController = {
         registration.accreditation &&
         registration.processingType === EXPORTER_PROCESSING_TYPE
           ? `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${registration.accreditation.id}/overseas-sites`
-          : null
+          : null,
+      wasteRecordsDownloadUrl: `/organisations/${organisationId}/registrations/${registrationId}/waste-records/download`,
+      prnActivityDownloadUrl: registration.accreditation
+        ? `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${registration.accreditation.id}/prn-activity/download`
+        : null
     })
   }
 }

--- a/src/server/routes/registration-overview/get.integration.test.js
+++ b/src/server/routes/registration-overview/get.integration.test.js
@@ -410,6 +410,66 @@ describe('#registrationOverviewController', () => {
       expect(queryByText(body, 'Overseas sites', { selector: 'dt' })).toBeNull()
     })
 
+    test('Should render a waste records download link', async () => {
+      useMockBackend()
+
+      const { result } = await server.inject({
+        method: 'GET',
+        url,
+        auth: { strategy: 'session', credentials: mockUserSession }
+      })
+
+      const body = renderPage(result)
+      const value = getSummaryRowValue(body, 'Waste records')
+      const link = within(value).getByRole('link', { name: 'Download' })
+
+      expect(link).toHaveAttribute(
+        'href',
+        `/organisations/${organisationId}/registrations/${registrationId}/waste-records/download`
+      )
+    })
+
+    test('Should render a PRN activity download link when accreditation exists', async () => {
+      useMockBackend()
+
+      const { result } = await server.inject({
+        method: 'GET',
+        url,
+        auth: { strategy: 'session', credentials: mockUserSession }
+      })
+
+      const body = renderPage(result)
+      const value = getSummaryRowValue(body, 'PRN activity')
+      const link = within(value).getByRole('link', { name: 'Download' })
+
+      expect(link).toHaveAttribute(
+        'href',
+        `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/prn-activity/download`
+      )
+    })
+
+    test('Should render the waste records link but no PRN activity link when accreditation is absent', async () => {
+      useMockBackend({
+        ...mockOverview,
+        registrations: [{ ...mockRegistration, accreditation: null }]
+      })
+
+      const { result } = await server.inject({
+        method: 'GET',
+        url,
+        auth: { strategy: 'session', credentials: mockUserSession }
+      })
+
+      const body = renderPage(result)
+
+      expect(
+        within(getSummaryRowValue(body, 'Waste records')).getByRole('link', {
+          name: 'Download'
+        })
+      ).toBeInTheDocument()
+      expect(queryByText(body, 'PRN activity', { selector: 'dt' })).toBeNull()
+    })
+
     test('Should render the reporting periods table', async () => {
       useMockBackend()
 

--- a/src/server/routes/registration-overview/index.njk
+++ b/src/server/routes/registration-overview/index.njk
@@ -2,9 +2,21 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% block content %}
   <div class="govuk-width-container">
+    {% if error %}
+      {{ govukErrorSummary({
+        titleText: "There is a problem",
+        errorList: [
+          {
+            text: error
+          }
+        ]
+      }) }}
+    {% endif %}
+
     <h1 class="govuk-heading-xl">{{ heading }}</h1>
 
     {% set summaryRows = [
@@ -26,6 +38,17 @@
           { key: { text: "Overseas sites" }, value: { html: '<a class="govuk-link govuk-link--no-visited-state" href="' ~ overseasSitesUrl ~ '">View</a>' } }
         ]) %}
       {% endif %}
+    {% endif %}
+
+    {% if wasteRecordsDownloadUrl %}
+      {% set summaryRows = summaryRows.concat([
+        { key: { text: "Waste records" }, value: { html: '<a class="govuk-link govuk-link--no-visited-state" href="' ~ wasteRecordsDownloadUrl ~ '">Download</a>' } }
+      ]) %}
+    {% endif %}
+    {% if prnActivityDownloadUrl %}
+      {% set summaryRows = summaryRows.concat([
+        { key: { text: "PRN activity" }, value: { html: '<a class="govuk-link govuk-link--no-visited-state" href="' ~ prnActivityDownloadUrl ~ '">Download</a>' } }
+      ]) %}
     {% endif %}
 
     <div class="govuk-grid-row">

--- a/src/server/routes/waste-records-export/controller.post.js
+++ b/src/server/routes/waste-records-export/controller.post.js
@@ -1,44 +1,17 @@
-import { Readable } from 'node:stream'
-
-import { streamFromBackend } from '#server/common/helpers/stream-from-backend.js'
+import { proxyCsvStream } from '#server/common/helpers/proxy-csv-stream.js'
 import { createLogger } from '#server/common/helpers/logging/logger.js'
-
-/** @import { ReadableStream as WebReadableStream } from 'node:stream/web' */
 
 const logger = createLogger()
 
 export const wasteRecordsExportPostController = {
   async handler(request, h) {
     try {
-      const response = await streamFromBackend(
+      return await proxyCsvStream(
         request,
-        '/v1/admin/waste-records/export.csv'
+        h,
+        '/v1/admin/waste-records/export.csv',
+        'waste-records.csv'
       )
-
-      if (!response.body) {
-        throw new Error(
-          'Backend returned a successful response with no body for waste-records export'
-        )
-      }
-
-      // `response.body` from the Fetch API is a Web ReadableStream. Hapi only
-      // understands strings, Buffers, and Node Readable streams — given a Web
-      // stream it serialises the object, which produces `{}` instead of the
-      // CSV payload. Adapt to a Node Readable so Hapi proxies the chunks.
-      // The cast works around an upstream `@types/node` mismatch between the
-      // Web `ReadableStream<Uint8Array<ArrayBuffer>>` and the older signature
-      // `Readable.fromWeb` expects.
-      const body = /** @type {WebReadableStream} */ (
-        /** @type {unknown} */ (response.body)
-      )
-      return h
-        .response(Readable.fromWeb(body))
-        .type(response.headers.get('content-type') ?? 'text/csv; charset=utf-8')
-        .header(
-          'Content-Disposition',
-          response.headers.get('content-disposition') ??
-            'attachment; filename="waste-records.csv"'
-        )
     } catch (error) {
       logger.error({
         message: 'Failed to stream waste records export',

--- a/src/server/routes/waste-records-export/controller.registration-download.js
+++ b/src/server/routes/waste-records-export/controller.registration-download.js
@@ -1,0 +1,42 @@
+import { proxyCsvStream } from '#server/common/helpers/proxy-csv-stream.js'
+import { createLogger } from '#server/common/helpers/logging/logger.js'
+
+const logger = createLogger()
+
+/**
+ * Streams the waste records CSV for a single registration. Triggered from the
+ * registration overview page so a regulator can download just one org's data.
+ */
+export const wasteRecordsRegistrationDownloadController = {
+  async handler(request, h) {
+    const { organisationId, registrationId } = request.params
+
+    const query = new URLSearchParams({
+      organisationId,
+      registrationId
+    })
+
+    try {
+      return await proxyCsvStream(
+        request,
+        h,
+        `/v1/admin/waste-records/export.csv?${query}`,
+        'waste-records.csv'
+      )
+    } catch (error) {
+      logger.error({
+        message: 'Failed to stream waste records export for registration',
+        err: error
+      })
+
+      const errorMessage =
+        error.output?.payload?.message ||
+        'There was a problem downloading the waste records. Please try again.'
+
+      request.yar.set('error', errorMessage)
+      return h.redirect(
+        `/organisations/${organisationId}/registrations/${registrationId}/overview`
+      )
+    }
+  }
+}

--- a/src/server/routes/waste-records-export/controller.registration-download.test.js
+++ b/src/server/routes/waste-records-export/controller.registration-download.test.js
@@ -1,0 +1,100 @@
+import { Readable } from 'node:stream'
+
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+import { wasteRecordsRegistrationDownloadController } from './controller.registration-download.js'
+import { streamFromBackend } from '#server/common/helpers/stream-from-backend.js'
+
+vi.mock('#server/common/helpers/stream-from-backend.js', () => ({
+  streamFromBackend: vi.fn()
+}))
+
+const { mockLoggerError } = vi.hoisted(() => ({ mockLoggerError: vi.fn() }))
+vi.mock('#server/common/helpers/logging/logger.js', () => ({
+  createLogger: () => ({ error: mockLoggerError })
+}))
+
+const buildWebStream = (chunks) =>
+  new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(new TextEncoder().encode(chunk))
+      }
+      controller.close()
+    }
+  })
+
+const buildHapiH = () => {
+  const responseBuilder = {
+    type: vi.fn().mockReturnThis(),
+    header: vi.fn().mockReturnThis()
+  }
+  const h = {
+    response: vi.fn(() => responseBuilder),
+    redirect: vi.fn().mockReturnValue('redirect-response')
+  }
+  return { h, responseBuilder }
+}
+
+const buildRequest = () => ({
+  params: { organisationId: 'org-1', registrationId: 'reg-1' },
+  yar: { set: vi.fn() }
+})
+
+describe('wasteRecordsRegistrationDownloadController', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('streams the export scoped to the organisation and registration', async () => {
+    streamFromBackend.mockResolvedValue({
+      body: buildWebStream(['header\n']),
+      headers: new Headers({ 'content-type': 'text/csv; charset=utf-8' })
+    })
+
+    const { h } = buildHapiH()
+    const request = buildRequest()
+
+    await wasteRecordsRegistrationDownloadController.handler(request, h)
+
+    expect(streamFromBackend).toHaveBeenCalledWith(
+      request,
+      '/v1/admin/waste-records/export.csv?organisationId=org-1&registrationId=reg-1'
+    )
+    expect(h.response.mock.calls[0][0]).toBeInstanceOf(Readable)
+  })
+
+  it('redirects back to the registration overview with a flash error on failure', async () => {
+    const error = new Error('boom')
+    streamFromBackend.mockRejectedValue(error)
+
+    const { h } = buildHapiH()
+    const request = buildRequest()
+
+    const result = await wasteRecordsRegistrationDownloadController.handler(
+      request,
+      h
+    )
+
+    expect(mockLoggerError).toHaveBeenCalledWith({
+      message: 'Failed to stream waste records export for registration',
+      err: error
+    })
+    expect(request.yar.set).toHaveBeenCalledWith('error', expect.any(String))
+    expect(h.redirect).toHaveBeenCalledWith(
+      '/organisations/org-1/registrations/reg-1/overview'
+    )
+    expect(result).toBe('redirect-response')
+  })
+
+  it('uses the Boom payload message when available', async () => {
+    const error = new Error('upstream')
+    error.output = { payload: { message: 'Backend exploded' } }
+    streamFromBackend.mockRejectedValue(error)
+
+    const { h } = buildHapiH()
+    const request = buildRequest()
+
+    await wasteRecordsRegistrationDownloadController.handler(request, h)
+
+    expect(request.yar.set).toHaveBeenCalledWith('error', 'Backend exploded')
+  })
+})

--- a/src/server/routes/waste-records-export/controller.registration-download.test.js
+++ b/src/server/routes/waste-records-export/controller.registration-download.test.js
@@ -30,25 +30,28 @@ const buildHapiH = () => {
     header: vi.fn().mockReturnThis()
   }
   const h = {
-    response: vi.fn(() => responseBuilder),
+    response: vi.fn().mockReturnValue(responseBuilder),
     redirect: vi.fn().mockReturnValue('redirect-response')
   }
   return { h, responseBuilder }
 }
 
-const buildRequest = () => ({
-  params: { organisationId: 'org-1', registrationId: 'reg-1' },
-  yar: { set: vi.fn() }
-})
+const buildRequest = () =>
+  /** @type {any} */ ({
+    params: { organisationId: 'org-1', registrationId: 'reg-1' },
+    yar: { set: vi.fn() }
+  })
 
 describe('wasteRecordsRegistrationDownloadController', () => {
   beforeEach(() => vi.clearAllMocks())
 
   it('streams the export scoped to the organisation and registration', async () => {
-    streamFromBackend.mockResolvedValue({
-      body: buildWebStream(['header\n']),
-      headers: new Headers({ 'content-type': 'text/csv; charset=utf-8' })
-    })
+    vi.mocked(streamFromBackend).mockResolvedValue(
+      /** @type {any} */ ({
+        body: buildWebStream(['header\n']),
+        headers: new Headers({ 'content-type': 'text/csv; charset=utf-8' })
+      })
+    )
 
     const { h } = buildHapiH()
     const request = buildRequest()
@@ -64,7 +67,7 @@ describe('wasteRecordsRegistrationDownloadController', () => {
 
   it('redirects back to the registration overview with a flash error on failure', async () => {
     const error = new Error('boom')
-    streamFromBackend.mockRejectedValue(error)
+    vi.mocked(streamFromBackend).mockRejectedValue(error)
 
     const { h } = buildHapiH()
     const request = buildRequest()
@@ -86,9 +89,9 @@ describe('wasteRecordsRegistrationDownloadController', () => {
   })
 
   it('uses the Boom payload message when available', async () => {
-    const error = new Error('upstream')
+    const error = /** @type {any} */ (new Error('upstream'))
     error.output = { payload: { message: 'Backend exploded' } }
-    streamFromBackend.mockRejectedValue(error)
+    vi.mocked(streamFromBackend).mockRejectedValue(error)
 
     const { h } = buildHapiH()
     const request = buildRequest()

--- a/src/server/routes/waste-records-export/index.js
+++ b/src/server/routes/waste-records-export/index.js
@@ -1,5 +1,12 @@
+import Joi from 'joi'
+
 import { wasteRecordsExportGetController } from './controller.get.js'
 import { wasteRecordsExportPostController } from './controller.post.js'
+import { wasteRecordsRegistrationDownloadController } from './controller.registration-download.js'
+
+const idParam = Joi.string()
+  .pattern(/^[\w-]+$/)
+  .required()
 
 export const wasteRecordsExport = {
   plugin: {
@@ -15,6 +22,19 @@ export const wasteRecordsExport = {
           method: 'POST',
           path: '/waste-records-export',
           ...wasteRecordsExportPostController
+        },
+        {
+          method: 'GET',
+          path: '/organisations/{organisationId}/registrations/{registrationId}/waste-records/download',
+          ...wasteRecordsRegistrationDownloadController,
+          options: {
+            validate: {
+              params: Joi.object({
+                organisationId: idParam,
+                registrationId: idParam
+              })
+            }
+          }
         }
       ])
     }

--- a/src/server/routes/waste-records-export/index.test.js
+++ b/src/server/routes/waste-records-export/index.test.js
@@ -19,11 +19,11 @@ describe('#waste-records-export routes plugin', () => {
     expect(typeof wasteRecordsExport.plugin.register).toBe('function')
   })
 
-  test('registers two routes', () => {
+  test('registers three routes', () => {
     wasteRecordsExport.plugin.register(mockServer)
 
     const routes = mockServer.route.mock.calls[0][0]
-    expect(routes).toHaveLength(2)
+    expect(routes).toHaveLength(3)
   })
 
   test('registers GET /waste-records-export', () => {
@@ -46,5 +46,16 @@ describe('#waste-records-export routes plugin', () => {
       path: '/waste-records-export'
     })
     expect(routes[1]).toHaveProperty('handler')
+  })
+
+  test('registers the registration-scoped download route', () => {
+    wasteRecordsExport.plugin.register(mockServer)
+
+    const routes = mockServer.route.mock.calls[0][0]
+    expect(routes[2]).toMatchObject({
+      method: 'GET',
+      path: '/organisations/{organisationId}/registrations/{registrationId}/waste-records/download'
+    })
+    expect(routes[2]).toHaveProperty('handler')
   })
 })


### PR DESCRIPTION
Ticket: [PAE-1673](https://eaflood.atlassian.net/browse/PAE-1673)
## PAE-1673 — Add registration-scoped waste-record and PRN downloads

Adds two **Download** links to the registration overview page, each scoped to the registration being reviewed. This lets a regulator download just one org's data instead of slicing the full all-orgs CSV by hand — smaller files, and no risk of sending one org another org's data.

### Changes

- **Registration overview page** — new summary-list rows:
  - **Waste records — Download** (always shown).
  - **PRN activity — Download** (only when the registration is accredited, since PRNs hang off an accreditation).
- **New GET proxy routes**, scoped by org/registration (and accreditation for PRN):
  - `/organisations/{organisationId}/registrations/{registrationId}/waste-records/download`
  - `/organisations/{organisationId}/registrations/{registrationId}/accreditations/{accreditationId}/prn-activity/download`
- **Shared `proxyCsvStream` helper** extracted from the existing waste-records-export controller so the global tab and the new scoped download share one stream-adaptation implementation.
- Download failures flash an error back on the overview page.

Both downloads use the existing backend endpoints (extended with optional filters in the companion PR).

### Companion PR

- Backend: DEFRA/epr-backend `PAE-1673-registration-scoped-downloads`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PAE-1673]: https://eaflood.atlassian.net/browse/PAE-1673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ