### PR TITLE
PAE-1305: use shared journey-test-summary action

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Write journey test summary
         if: always()
-        uses: DEFRA/epr-re-ex-service/.github/actions/journey-test-summary@PAE-1305-journey-tests-action
+        uses: DEFRA/epr-re-ex-service/.github/actions/journey-test-summary@main
         with:
           build-start: ${{ steps.build-timer.outputs.start }}
           test-start: ${{ steps.test-timer.outputs.start }}

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -53,6 +53,9 @@ jobs:
     name: Run Journey Tests
     runs-on: ubuntu-latest
     needs: pr-prep
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -84,54 +87,7 @@ jobs:
 
       - name: Write journey test summary
         if: always()
-        run: |
-          {
-            if compgen -G "allure-results/*-result.json" > /dev/null; then
-              DOCKER_SECS=$(( ${{ steps.test-timer.outputs.start }} - ${{ steps.build-timer.outputs.start }} ))
-              TEST_SECS=$(( $(date +%s) - ${{ steps.test-timer.outputs.start }} ))
-
-              fmt_secs() {
-                if [ "$1" -ge 60 ]; then echo "$(( $1 / 60 ))m $(( $1 % 60 ))s"
-                else echo "${1}s"
-                fi
-              }
-
-              DOCKER_DUR=$(fmt_secs $DOCKER_SECS)
-              TEST_DUR=$(fmt_secs $TEST_SECS)
-
-              IFS=$'\t' read -r PASSED FAILED TOTAL < <(jq -sr '
-                [
-                  (map(select(.status == "passed")) | length),
-                  (map(select(.status == "failed" or .status == "broken")) | length),
-                  length
-                ] | @tsv
-              ' allure-results/*-result.json)
-
-              SLOW_JOURNEY=$(jq -sr '
-                def fmt_secs:
-                  if . >= 60 then "\(. / 60 | floor)m \(. % 60)s"
-                  else "\(.)s"
-                  end;
-                map(select(.start != null and .stop != null))
-                | sort_by(-.stop + .start) | .[0:5][]
-                | ((.stop - .start) / 1000 | round) as $secs
-                | "| \(.name) | \($secs | fmt_secs) |"
-              ' allure-results/*-result.json)
-
-              cat <<EOF
-          ## Journey Tests
-
-          | | Passed | Failed | Total |
-          |---|---|---|---|
-          | Tests | $PASSED | $FAILED | $TOTAL |
-
-          Docker build: $DOCKER_DUR | Tests: $TEST_DUR
-
-          ### Slowest Journey Tests
-
-          | Test | Duration |
-          |---|---|
-          $SLOW_JOURNEY
-          EOF
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
+        uses: DEFRA/epr-re-ex-service/.github/actions/journey-test-summary@PAE-1305-journey-tests-action
+        with:
+          build-start: ${{ steps.build-timer.outputs.start }}
+          test-start: ${{ steps.test-timer.outputs.start }}


### PR DESCRIPTION
replaces the inline jq journey-test summary block with the shared `journey-test-summary` action (DEFRA/epr-re-ex-service, now on main).

- the old jq summary intermittently failed the journey job on deeply-nested allure results even when the tests passed
- the shared node summary reads only top-level result fields, so it is robust to any nesting depth, and never fails the job
- adds a status line, passed/failed/skipped/total counts, a failed-tests table, and the slowest tests
- posts the summary as a sticky pr comment (hence `pull-requests: write` on the journey job)
- each service keeps its own `run-journey-tests` action unchanged