### PR TITLE
PAE-1339: wrap mocked fns in vi.mocked to fix test types

### DIFF
--- a/src/server/routes/linked-organisations/controller.test.js
+++ b/src/server/routes/linked-organisations/controller.test.js
@@ -33,7 +33,7 @@ describe('linked-organisations controller', () => {
   })
 
   test('Should fetch all linked organisations on GET', async () => {
-    fetchJsonFromBackend.mockResolvedValue([mockLinkedOrg])
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue([mockLinkedOrg])
 
     await linkedOrganisationsController.handler(mockRequest, mockH)
 
@@ -62,7 +62,7 @@ describe('linked-organisations controller', () => {
 
   test('Should pass search term as query param to backend', async () => {
     mockRequest.query = { search: ' acme ' }
-    fetchJsonFromBackend.mockResolvedValue([mockLinkedOrg])
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue([mockLinkedOrg])
 
     await linkedOrganisationsController.handler(mockRequest, mockH)
 
@@ -81,7 +81,7 @@ describe('linked-organisations controller', () => {
 
   test('Should fetch all when search term is empty', async () => {
     mockRequest.query = { search: '  ' }
-    fetchJsonFromBackend.mockResolvedValue([])
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue([])
 
     await linkedOrganisationsController.handler(mockRequest, mockH)
 
@@ -92,7 +92,7 @@ describe('linked-organisations controller', () => {
   })
 
   test('Should handle backend returning non-array', async () => {
-    fetchJsonFromBackend.mockResolvedValue({})
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({})
 
     await linkedOrganisationsController.handler(mockRequest, mockH)
 
@@ -106,7 +106,7 @@ describe('linked-organisations controller', () => {
 
   test('Should display error message from session and clear it', async () => {
     mockRequest.yar.get.mockReturnValue('Download failed')
-    fetchJsonFromBackend.mockResolvedValue([])
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue([])
 
     await linkedOrganisationsController.handler(mockRequest, mockH)
 
@@ -122,7 +122,7 @@ describe('linked-organisations controller', () => {
   })
 
   test('Should pass pageTitle from route settings', async () => {
-    fetchJsonFromBackend.mockResolvedValue([])
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue([])
 
     await linkedOrganisationsController.handler(mockRequest, mockH)
 
@@ -136,7 +136,7 @@ describe('linked-organisations controller', () => {
 
   test('Should encode special characters in search term', async () => {
     mockRequest.query = { search: 'Acme & Co' }
-    fetchJsonFromBackend.mockResolvedValue([])
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue([])
 
     await linkedOrganisationsController.handler(mockRequest, mockH)
 

--- a/src/server/routes/ors-upload/controller.list.get.test.js
+++ b/src/server/routes/ors-upload/controller.list.get.test.js
@@ -39,7 +39,7 @@ describe('orsListGetController', () => {
   })
 
   test('loads ORS data and maps null values for display', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       rows: [
         {
           orsId: '001',
@@ -165,7 +165,7 @@ describe('orsListGetController', () => {
       registrationNumber: ' REG-123 '
     }
 
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       rows: [{ orsId: '003', registrationNumber: 'REG-123' }],
       pagination: {
         page: 2,
@@ -210,7 +210,7 @@ describe('orsListGetController', () => {
   })
 
   test('returns empty rows when backend returns no values', async () => {
-    fetchJsonFromBackend.mockResolvedValue(undefined)
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue(undefined)
 
     await orsListGetController.handler(mockRequest, mockH)
 
@@ -226,7 +226,7 @@ describe('orsListGetController', () => {
   })
 
   test('returns empty rows when backend returns non-array payload', async () => {
-    fetchJsonFromBackend.mockResolvedValue(null)
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue(null)
 
     await orsListGetController.handler(mockRequest, mockH)
 
@@ -247,7 +247,7 @@ describe('orsListGetController', () => {
       pageSize: 'invalid'
     }
 
-    fetchJsonFromBackend.mockResolvedValue([
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue([
       {
         orsId: '010'
       }
@@ -289,7 +289,7 @@ describe('orsListGetController', () => {
   })
 
   test('returns empty rows for non-array rows payload in object response', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       rows: {},
       pagination: {
         page: 1,
@@ -315,7 +315,7 @@ describe('orsListGetController', () => {
   })
 
   test('supports legacy empty array payloads with zero total pages', async () => {
-    fetchJsonFromBackend.mockResolvedValue([])
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue([])
 
     await orsListGetController.handler(mockRequest, mockH)
 
@@ -336,7 +336,7 @@ describe('orsListGetController', () => {
       pageSize: '2'
     }
 
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       rows: [{ orsId: '002' }],
       pagination: {
         page: 2,
@@ -408,7 +408,7 @@ describe('orsListGetController', () => {
   })
 
   test('builds numbered pagination items for each page', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       rows: [{ orsId: '001' }],
       pagination: {
         page: 1,
@@ -477,7 +477,7 @@ describe('orsListGetController', () => {
       pageSize: '10'
     }
 
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       rows: [{ orsId: '006' }],
       pagination: {
         page: 6,
@@ -565,7 +565,7 @@ describe('orsListGetController', () => {
       pageSize: '2'
     }
 
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       rows: [{ orsId: '003' }],
       pagination: {
         page: 3,
@@ -630,7 +630,7 @@ describe('orsListGetController', () => {
 
   test('handles backend failure and renders error message', async () => {
     const error = new Error('Backend unavailable')
-    fetchJsonFromBackend.mockRejectedValue(error)
+    vi.mocked(fetchJsonFromBackend).mockRejectedValue(error)
 
     await orsListGetController.handler(mockRequest, mockH)
 

--- a/src/server/routes/prn-activity/controller.test.js
+++ b/src/server/routes/prn-activity/controller.test.js
@@ -35,7 +35,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should fetch PRNs with correct statuses', async () => {
-    fetchJsonFromBackend.mockResolvedValue({ items: [] })
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({ items: [] })
 
     await prnActivityController.handler(mockRequest, mockH)
 
@@ -46,7 +46,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should render view with pageTitle and mapped PRNs', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       items: [
         {
           prnNumber: 'PRN-001',
@@ -89,7 +89,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should map isDecemberWaste false to No', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       items: [
         {
           prnNumber: 'PRN-001',
@@ -107,7 +107,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should handle null/undefined optional fields', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       items: [
         {
           status: 'awaiting_authorisation',
@@ -132,7 +132,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should handle empty items array', async () => {
-    fetchJsonFromBackend.mockResolvedValue({ items: [] })
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({ items: [] })
 
     await prnActivityController.handler(mockRequest, mockH)
 
@@ -146,7 +146,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should handle null data from backend', async () => {
-    fetchJsonFromBackend.mockResolvedValue(null)
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue(null)
 
     await prnActivityController.handler(mockRequest, mockH)
 
@@ -155,7 +155,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should use tradingName over name for issuedToOrganisation', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       items: [
         {
           status: 'accepted',
@@ -175,7 +175,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should use name when tradingName is empty string', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       items: [
         {
           status: 'accepted',
@@ -192,7 +192,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should use name when tradingName is not present', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       items: [
         {
           status: 'accepted',
@@ -209,7 +209,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should return empty string when org has no name or tradingName', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       items: [
         {
           status: 'accepted',
@@ -227,7 +227,7 @@ describe('prn-activity controller', () => {
 
   test('Should display error message from session and clear it', async () => {
     mockRequest.yar.get.mockReturnValue('Download failed')
-    fetchJsonFromBackend.mockResolvedValue({ items: [] })
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({ items: [] })
 
     await prnActivityController.handler(mockRequest, mockH)
 
@@ -243,7 +243,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should return empty string when issuedToOrganisation is null', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       items: [
         {
           status: 'accepted',
@@ -261,7 +261,7 @@ describe('prn-activity controller', () => {
 
   test('Should pass cursor to backend when provided in query', async () => {
     mockRequest.query.cursor = 'abc123'
-    fetchJsonFromBackend.mockResolvedValue({ items: [] })
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({ items: [] })
 
     await prnActivityController.handler(mockRequest, mockH)
 
@@ -272,7 +272,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should include next pagination link when hasMore is true', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       items: [{ status: 'accepted', tonnage: 10 }],
       hasMore: true,
       nextCursor: 'cursor-xyz'
@@ -289,7 +289,7 @@ describe('prn-activity controller', () => {
   test('Should include previous pagination link when cursor is provided', async () => {
     mockRequest.query.cursor = 'abc123'
     mockRequest.query.page = '2'
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       items: [{ status: 'accepted', tonnage: 10 }],
       hasMore: false
     })
@@ -304,7 +304,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should not include pagination links on first page with no more results', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       items: [{ status: 'accepted', tonnage: 10 }],
       hasMore: false
     })

--- a/src/server/routes/prn-tonnage/controller.results.get.test.js
+++ b/src/server/routes/prn-tonnage/controller.results.get.test.js
@@ -31,7 +31,7 @@ describe('prn-tonnage results GET controller', () => {
   })
 
   test('Should fetch PRN tonnage data from backend and render results page', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       generatedAt: '2026-02-20T12:00:00.000Z',
       rows: [
         {
@@ -79,7 +79,7 @@ describe('prn-tonnage results GET controller', () => {
 
   test('Should display error message from session and clear it', async () => {
     mockRequest.yar.get.mockReturnValue('Download failed')
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       generatedAt: '2026-02-20T12:00:00.000Z',
       rows: []
     })
@@ -98,7 +98,7 @@ describe('prn-tonnage results GET controller', () => {
   })
 
   test('Should keep unknown values and blank tonnage band for missing band', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       generatedAt: '2026-02-20T12:00:00.000Z',
       rows: [
         {

--- a/src/server/routes/summary-log/controller.get.test.js
+++ b/src/server/routes/summary-log/controller.get.test.js
@@ -78,7 +78,7 @@ describe('summaryLogUploadsReportGetController', () => {
       generatedAt: '2026-02-06T14:30:00.000Z'
     }
 
-    fetchJsonFromBackend.mockResolvedValue(mockData)
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue(mockData)
     mockRequest.yar.get.mockReturnValue(null)
 
     await summaryLogUploadsReportGetController.handler(mockRequest, mockH)
@@ -136,7 +136,7 @@ describe('summaryLogUploadsReportGetController', () => {
       generatedAt: '2026-01-15T10:00:00.000Z'
     }
 
-    fetchJsonFromBackend.mockResolvedValue(mockData)
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue(mockData)
     mockRequest.yar.get.mockReturnValue(null)
 
     await summaryLogUploadsReportGetController.handler(mockRequest, mockH)
@@ -155,7 +155,7 @@ describe('summaryLogUploadsReportGetController', () => {
     const fetchError = new Error('Network error')
     fetchError.stack = 'Error stack trace...'
 
-    fetchJsonFromBackend.mockRejectedValue(fetchError)
+    vi.mocked(fetchJsonFromBackend).mockRejectedValue(fetchError)
     mockRequest.yar.get.mockReturnValue(null)
 
     await summaryLogUploadsReportGetController.handler(mockRequest, mockH)

--- a/src/server/routes/system-logs/controller.download.test.js
+++ b/src/server/routes/system-logs/controller.download.test.js
@@ -36,7 +36,7 @@ describe('system-log download controller', () => {
     const presignedUrl =
       'https://my-bucket.s3.eu-west-2.amazonaws.com/file.xlsx'
 
-    fetchRedirectFromBackend.mockResolvedValue(presignedUrl)
+    vi.mocked(fetchRedirectFromBackend).mockResolvedValue(presignedUrl)
     mswServer.use(
       http.get(
         presignedUrl,
@@ -59,7 +59,7 @@ describe('system-log download controller', () => {
       0x50, 0x4b, 0x03, 0x04, 0xff, 0xfe, 0x00, 0x80
     ])
 
-    fetchRedirectFromBackend.mockResolvedValue(presignedUrl)
+    vi.mocked(fetchRedirectFromBackend).mockResolvedValue(presignedUrl)
     mswServer.use(http.get(presignedUrl, () => new HttpResponse(binaryContent)))
 
     await systemLogDownloadController.handler(mockRequest, mockH)
@@ -81,7 +81,7 @@ describe('system-log download controller', () => {
     const presignedUrl = 'http://localhost:4566/bucket/file.xlsx'
     const binaryContent = new Uint8Array([0x50, 0x4b, 0x03, 0x04])
 
-    fetchRedirectFromBackend.mockResolvedValue(presignedUrl)
+    vi.mocked(fetchRedirectFromBackend).mockResolvedValue(presignedUrl)
     mswServer.use(http.get(presignedUrl, () => new HttpResponse(binaryContent)))
 
     await systemLogDownloadController.handler(mockRequest, mockH)
@@ -95,7 +95,7 @@ describe('system-log download controller', () => {
     const presignedUrl = 'http://floci:4566/bucket/file.xlsx'
     const binaryContent = new Uint8Array([0x50, 0x4b, 0x03, 0x04])
 
-    fetchRedirectFromBackend.mockResolvedValue(presignedUrl)
+    vi.mocked(fetchRedirectFromBackend).mockResolvedValue(presignedUrl)
     mswServer.use(http.get(presignedUrl, () => new HttpResponse(binaryContent)))
 
     await systemLogDownloadController.handler(mockRequest, mockH)
@@ -106,7 +106,7 @@ describe('system-log download controller', () => {
   })
 
   test('rejects invalid download URLs to prevent SSRF', async () => {
-    fetchRedirectFromBackend.mockResolvedValue(
+    vi.mocked(fetchRedirectFromBackend).mockResolvedValue(
       'https://evil-site.com/steal-data'
     )
 
@@ -119,7 +119,7 @@ describe('system-log download controller', () => {
     const presignedUrl =
       'https://my-bucket.s3.eu-west-2.amazonaws.com/file.xlsx'
 
-    fetchRedirectFromBackend.mockResolvedValue(presignedUrl)
+    vi.mocked(fetchRedirectFromBackend).mockResolvedValue(presignedUrl)
     mswServer.use(
       http.get(presignedUrl, () => new HttpResponse(null, { status: 500 }))
     )

--- a/src/server/routes/waste-balance-availability/controller.get.test.js
+++ b/src/server/routes/waste-balance-availability/controller.get.test.js
@@ -31,7 +31,7 @@ describe('waste-balance-availability GET controller', () => {
   })
 
   test('Should fetch balance data from backend and render page', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [
         { material: 'aluminium', availableAmount: 1234.56 },
@@ -63,7 +63,7 @@ describe('waste-balance-availability GET controller', () => {
   })
 
   test('Should format material names to display names', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [
         { material: 'plastic', availableAmount: 100 },
@@ -88,7 +88,7 @@ describe('waste-balance-availability GET controller', () => {
   })
 
   test('Should format amount values to 2 decimal places', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [
         { material: 'wood', availableAmount: 1000 },
@@ -112,7 +112,7 @@ describe('waste-balance-availability GET controller', () => {
   })
 
   test('Should treat null availableAmount as zero', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [{ material: 'plastic', availableAmount: null }],
       total: null
@@ -130,7 +130,7 @@ describe('waste-balance-availability GET controller', () => {
   })
 
   test('Should throw for unknown material names', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [{ material: 'unknown_material', availableAmount: 100 }],
       total: 100
@@ -142,7 +142,7 @@ describe('waste-balance-availability GET controller', () => {
   })
 
   test('Should handle empty materials array', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [],
       total: 0
@@ -165,7 +165,7 @@ describe('waste-balance-availability GET controller', () => {
   test('Should display error message from session and clear it', async () => {
     mockRequest.yar.get.mockReturnValue('Download failed')
 
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [],
       total: 0


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)
crush a batch of test type errors in the admin frontend.

- wrap mocked function references in `vi.mocked()` so vitest mock methods (`mockResolvedValue`/`mockRejectedValue`/`mockReturnValue`) type-check
- purely mechanical, 7 fully-cleared test files, no prod changes
- clears 54 of the 195 test type errors

first slice of a wider test type-error cleanup; further batches (request/fixture casts, session-mock fixes, stragglers) follow as separate PRs to keep diffs small.

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ