### PR TITLE
PAE-1339: crush test type errors

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -21,7 +21,7 @@ describe('#index', () => {
       info: mockLoggerInfo,
       error: mockLoggerError
     })
-    mockStartServer.mockResolvedValue()
+    mockStartServer.mockResolvedValue(undefined)
   })
 
   beforeEach(() => {

--- a/src/server/common/helpers/auth/get-bell-options.test.js
+++ b/src/server/common/helpers/auth/get-bell-options.test.js
@@ -4,6 +4,8 @@ import { getBellOptions } from './get-bell-options.js'
 import { config } from '#config/config.js'
 import { verifyToken } from '#server/common/helpers/auth/verify-token.js'
 
+/** @import { EntraIdTokenPayload } from '#server/common/helpers/auth/types.js' */
+
 vi.mock(import('#config/config.js'))
 vi.mock(import('#server/common/helpers/auth/verify-token.js'))
 
@@ -32,7 +34,9 @@ describe('#getBellOptions', () => {
 
     config.get = vi.fn().mockImplementation((key) => mockConfig[key])
 
-    verifyToken.mockReturnValue(mockJwtPayload)
+    vi.mocked(verifyToken).mockResolvedValue(
+      /** @type {EntraIdTokenPayload} */ (mockJwtPayload)
+    )
   })
 
   afterEach(() => {
@@ -128,7 +132,9 @@ describe('#getBellOptions', () => {
       oid: 'user-id'
     }
 
-    verifyToken.mockReturnValue(noNamePayload)
+    vi.mocked(verifyToken).mockResolvedValue(
+      /** @type {EntraIdTokenPayload} */ (noNamePayload)
+    )
 
     const result = getBellOptions(mockOidcConfig)
     const mockCredentials = {
@@ -151,7 +157,9 @@ describe('#getBellOptions', () => {
       login_hint: 'john.doe@example-user.test'
     }
 
-    verifyToken.mockReturnValue(payloadWithLoginHint)
+    vi.mocked(verifyToken).mockResolvedValue(
+      /** @type {EntraIdTokenPayload} */ (payloadWithLoginHint)
+    )
 
     const result = getBellOptions(mockOidcConfig)
     const mockCredentials = { token: 'mock-jwt-token' }

--- a/src/server/common/helpers/auth/get-cookie-options.test.js
+++ b/src/server/common/helpers/auth/get-cookie-options.test.js
@@ -21,7 +21,7 @@ describe('#getCookieOptions', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     config.get = vi.fn().mockImplementation((key) => mockConfig[key])
-    validateAndRefreshSession.mockImplementation((userSession) =>
+    vi.mocked(validateAndRefreshSession).mockImplementation((userSession) =>
       Promise.resolve(userSession)
     )
   })
@@ -71,7 +71,7 @@ describe('#getCookieOptions', () => {
 
   describe('validate function', () => {
     test('Should return isValid false when userSession is null', async () => {
-      getUserSession.mockResolvedValue(null)
+      vi.mocked(getUserSession).mockResolvedValue(null)
 
       const result = getCookieOptions()
       const mockRequest = {}
@@ -83,7 +83,7 @@ describe('#getCookieOptions', () => {
     })
 
     test('Should return isValid false when userSession is undefined', async () => {
-      getUserSession.mockResolvedValue(undefined)
+      vi.mocked(getUserSession).mockResolvedValue(undefined)
 
       const result = getCookieOptions()
       const mockRequest = {}
@@ -101,8 +101,8 @@ describe('#getCookieOptions', () => {
         email: 'test@example-user.test'
       }
 
-      getUserSession.mockResolvedValue(mockUserSession)
-      validateAndRefreshSession.mockResolvedValue(mockUserSession)
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+      vi.mocked(validateAndRefreshSession).mockResolvedValue(mockUserSession)
 
       const result = getCookieOptions()
       const mockRequest = {}
@@ -121,7 +121,7 @@ describe('#getCookieOptions', () => {
     })
 
     test('Should call getUserSession with request', async () => {
-      getUserSession.mockResolvedValue(mockUserSession)
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
 
       const result = getCookieOptions()
       const mockRequest = { id: 'request-123' }
@@ -133,7 +133,9 @@ describe('#getCookieOptions', () => {
     })
 
     test('Should handle getUserSession errors gracefully', async () => {
-      getUserSession.mockRejectedValue(new Error('Session retrieval failed'))
+      vi.mocked(getUserSession).mockRejectedValue(
+        new Error('Session retrieval failed')
+      )
 
       const result = getCookieOptions()
       const mockRequest = {}
@@ -144,8 +146,8 @@ describe('#getCookieOptions', () => {
     })
 
     test('Should return isValid false when validateAndRefreshSession throws error', async () => {
-      getUserSession.mockResolvedValue({ sessionId: 'test' })
-      validateAndRefreshSession.mockRejectedValue(
+      vi.mocked(getUserSession).mockResolvedValue({ sessionId: 'test' })
+      vi.mocked(validateAndRefreshSession).mockRejectedValue(
         new Error('Session expired and no refresh token available')
       )
 
@@ -169,8 +171,8 @@ describe('#getCookieOptions', () => {
         }
       }
 
-      getUserSession.mockResolvedValue(complexUserSession)
-      validateAndRefreshSession.mockResolvedValue(complexUserSession)
+      vi.mocked(getUserSession).mockResolvedValue(complexUserSession)
+      vi.mocked(validateAndRefreshSession).mockResolvedValue(complexUserSession)
 
       const result = getCookieOptions()
       const mockRequest = {}
@@ -191,7 +193,7 @@ describe('#getCookieOptions', () => {
       const falsyValues = [null, undefined, false, 0, '', NaN]
 
       for (const value of falsyValues) {
-        getUserSession.mockResolvedValue(value)
+        vi.mocked(getUserSession).mockResolvedValue(value)
 
         const result = getCookieOptions()
         const validation = await result.validate({})
@@ -212,8 +214,8 @@ describe('#getCookieOptions', () => {
       ]
 
       for (const value of truthyValues) {
-        getUserSession.mockResolvedValue(value)
-        validateAndRefreshSession.mockResolvedValue(value)
+        vi.mocked(getUserSession).mockResolvedValue(value)
+        vi.mocked(validateAndRefreshSession).mockResolvedValue(value)
 
         const result = getCookieOptions()
         const validation = await result.validate({})

--- a/src/server/common/helpers/errors.test.js
+++ b/src/server/common/helpers/errors.test.js
@@ -5,6 +5,16 @@ import { createServer } from '#server/server.js'
 import { statusCodes } from '../constants/status-codes.js'
 import { createMockOidcServer } from '#server/common/test-helpers/mock-oidc.js'
 
+/** @import { HapiRequest } from '#server/common/hapi-types.js' */
+/** @import { Mock } from 'vitest' */
+
+/**
+ * Cast a partial mock request to the full `HapiRequest` shape `catchAll` reads.
+ * @param {unknown} req
+ * @returns {HapiRequest}
+ */
+const asRequest = (req) => /** @type {HapiRequest} */ (req)
+
 describe('#errors integration', () => {
   let server
 
@@ -41,10 +51,10 @@ describe('#catchAll unit tests', () => {
       data: { stack: mockStack },
       output: { statusCode, headers }
     }
-    return {
+    return asRequest({
       response,
       logger: { error: mockLoggerError }
-    }
+    })
   }
 
   const mockToolkitView = vi.fn()
@@ -68,9 +78,9 @@ describe('#catchAll unit tests', () => {
   })
 
   test('Should return early if response does not have isBoom property', () => {
-    const nonBoomRequest = {
+    const nonBoomRequest = asRequest({
       response: {}
-    }
+    })
 
     const result = catchAll(nonBoomRequest, mockToolkit)
 
@@ -171,7 +181,7 @@ describe('#catchAll unit tests', () => {
   })
 
   test('Should handle missing headers gracefully', () => {
-    const request = {
+    const request = asRequest({
       response: {
         isBoom: true,
         message: mockMessage,
@@ -179,7 +189,7 @@ describe('#catchAll unit tests', () => {
         output: { statusCode: statusCodes.notFound }
       },
       logger: { error: mockLoggerError }
-    }
+    })
 
     catchAll(request, mockToolkit)
 
@@ -190,7 +200,7 @@ describe('#catchAll unit tests', () => {
   })
 
   test('Should pass pageTitle from route settings to view context', () => {
-    const request = {
+    const request = asRequest({
       response: {
         isBoom: true,
         message: mockMessage,
@@ -203,7 +213,7 @@ describe('#catchAll unit tests', () => {
         }
       },
       logger: { error: mockLoggerError }
-    }
+    })
 
     catchAll(request, mockToolkit)
 
@@ -214,16 +224,25 @@ describe('#catchAll unit tests', () => {
   })
 
   describe('Redirect after sign-in', () => {
+    /**
+     * @param {{
+     *   statusCode?: number,
+     *   path?: string,
+     *   url?: { search: string },
+     *   yar?: { flash: Mock }
+     * }} [overrides]
+     */
     const mockRedirectRequest = ({
       statusCode = statusCodes.unauthorised,
       ...overrides
-    } = {}) => ({
-      ...mockRequest(statusCode),
-      path: '/organisations',
-      url: { search: '' },
-      yar: { flash: vi.fn() },
-      ...overrides
-    })
+    } = {}) =>
+      asRequest({
+        ...mockRequest(statusCode),
+        path: '/organisations',
+        url: { search: '' },
+        yar: { flash: vi.fn() },
+        ...overrides
+      })
 
     test('Should store request path in referrer flash on 401 error', () => {
       const request = mockRedirectRequest()

--- a/src/server/common/helpers/errors.test.js
+++ b/src/server/common/helpers/errors.test.js
@@ -4,16 +4,9 @@ import { catchAll } from './errors.js'
 import { createServer } from '#server/server.js'
 import { statusCodes } from '../constants/status-codes.js'
 import { createMockOidcServer } from '#server/common/test-helpers/mock-oidc.js'
+import { asRequest } from '#server/common/test-helpers/fixtures.js'
 
-/** @import { HapiRequest } from '#server/common/hapi-types.js' */
 /** @import { Mock } from 'vitest' */
-
-/**
- * Cast a partial mock request to the full `HapiRequest` shape `catchAll` reads.
- * @param {unknown} req
- * @returns {HapiRequest}
- */
-const asRequest = (req) => /** @type {HapiRequest} */ (req)
 
 describe('#errors integration', () => {
   let server

--- a/src/server/common/helpers/fetch-organisation-overview.test.js
+++ b/src/server/common/helpers/fetch-organisation-overview.test.js
@@ -20,13 +20,15 @@ const mockOverview = {
   registrations: []
 }
 
+const mockFetchJsonFromBackend = vi.mocked(fetchJsonFromBackend)
+
 describe('fetchOrganisationOverview', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
   test('calls fetchJsonFromBackend with the correct overview URL', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue(mockOverview)
+    mockFetchJsonFromBackend.mockResolvedValue(mockOverview)
 
     await fetchOrganisationOverview(mockRequest, '69c3b4f0abda9efa68dd6697')
 
@@ -38,7 +40,7 @@ describe('fetchOrganisationOverview', () => {
   })
 
   test('returns the overview response from the backend', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue(mockOverview)
+    mockFetchJsonFromBackend.mockResolvedValue(mockOverview)
 
     const result = await fetchOrganisationOverview(
       mockRequest,
@@ -50,7 +52,7 @@ describe('fetchOrganisationOverview', () => {
 
   test('propagates errors thrown by fetchJsonFromBackend', async () => {
     const error = new Error('backend unavailable')
-    vi.mocked(fetchJsonFromBackend).mockRejectedValue(error)
+    mockFetchJsonFromBackend.mockRejectedValue(error)
 
     await expect(
       fetchOrganisationOverview(mockRequest, '69c3b4f0abda9efa68dd6697')

--- a/src/server/common/helpers/fetch-organisation-overview.test.js
+++ b/src/server/common/helpers/fetch-organisation-overview.test.js
@@ -5,11 +5,14 @@ import {
 } from './fetch-organisation-overview.js'
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
 
+/** @import { Request } from '@hapi/hapi' */
+/** @import { OrganisationOverview, Registration } from './fetch-organisation-overview.js' */
+
 vi.mock('#server/common/helpers/fetch-json-from-backend.js', () => ({
   fetchJsonFromBackend: vi.fn()
 }))
 
-const mockRequest = {}
+const mockRequest = /** @type {Request} */ ({})
 
 const mockOverview = {
   id: '69c3b4f0abda9efa68dd6697',
@@ -23,7 +26,7 @@ describe('fetchOrganisationOverview', () => {
   })
 
   test('calls fetchJsonFromBackend with the correct overview URL', async () => {
-    fetchJsonFromBackend.mockResolvedValue(mockOverview)
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue(mockOverview)
 
     await fetchOrganisationOverview(mockRequest, '69c3b4f0abda9efa68dd6697')
 
@@ -35,7 +38,7 @@ describe('fetchOrganisationOverview', () => {
   })
 
   test('returns the overview response from the backend', async () => {
-    fetchJsonFromBackend.mockResolvedValue(mockOverview)
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue(mockOverview)
 
     const result = await fetchOrganisationOverview(
       mockRequest,
@@ -47,7 +50,7 @@ describe('fetchOrganisationOverview', () => {
 
   test('propagates errors thrown by fetchJsonFromBackend', async () => {
     const error = new Error('backend unavailable')
-    fetchJsonFromBackend.mockRejectedValue(error)
+    vi.mocked(fetchJsonFromBackend).mockRejectedValue(error)
 
     await expect(
       fetchOrganisationOverview(mockRequest, '69c3b4f0abda9efa68dd6697')
@@ -61,7 +64,9 @@ describe(findRegistration, () => {
 
   test('returns the matching registration when present', () => {
     const registration = { id: registrationId, registrationNumber: 'REG-001' }
-    const overview = { registrations: [registration] }
+    const overview = /** @type {OrganisationOverview} */ ({
+      registrations: [registration]
+    })
 
     expect(findRegistration(overview, organisationId, registrationId)).toBe(
       registration
@@ -69,7 +74,9 @@ describe(findRegistration, () => {
   })
 
   test('throws notFound enriched with code and event when missing', () => {
-    const overview = { registrations: [] }
+    const overview = /** @type {OrganisationOverview} */ ({
+      registrations: /** @type {Registration[]} */ ([])
+    })
 
     expect(() =>
       findRegistration(overview, organisationId, registrationId)

--- a/src/server/common/helpers/fetch-redirect-from-backend.test.js
+++ b/src/server/common/helpers/fetch-redirect-from-backend.test.js
@@ -3,17 +3,22 @@ import Boom from '@hapi/boom'
 import { fetchRedirectFromBackend } from './fetch-redirect-from-backend.js'
 import { getUserSession } from './auth/get-user-session.js'
 
+/** @import { Request } from '@hapi/hapi' */
+/** @import { UserSession } from '#server/common/hapi-types.js' */
+
 vi.mock('./auth/get-user-session.js', () => ({
   getUserSession: vi.fn()
 }))
 
 describe('fetchRedirectFromBackend', () => {
   const mockToken = 'test-token'
-  const mockRequest = {}
+  const mockRequest = /** @type {Request} */ ({})
 
   beforeEach(() => {
     vi.clearAllMocks()
-    getUserSession.mockResolvedValue({ token: mockToken })
+    vi.mocked(getUserSession).mockResolvedValue(
+      /** @type {UserSession} */ ({ token: mockToken })
+    )
   })
 
   test('returns the Location header from a redirect response', async () => {
@@ -45,7 +50,8 @@ describe('fetchRedirectFromBackend', () => {
     await fetchRedirectFromBackend(mockRequest, '/v1/test/download')
 
     const [, options] = fetchSpy.mock.calls[0]
-    expect(options.headers.Authorization).toBe(`Bearer ${mockToken}`)
+    const headers = /** @type {Record<string, string>} */ (options?.headers)
+    expect(headers.Authorization).toBe(`Bearer ${mockToken}`)
   })
 
   test('uses redirect manual to prevent following the redirect', async () => {
@@ -59,7 +65,7 @@ describe('fetchRedirectFromBackend', () => {
     await fetchRedirectFromBackend(mockRequest, '/v1/test/download')
 
     const [, options] = fetchSpy.mock.calls[0]
-    expect(options.redirect).toBe('manual')
+    expect(options?.redirect).toBe('manual')
   })
 
   test('throws a bad gateway error when no Location header is returned', async () => {

--- a/src/server/common/helpers/formatters.test.js
+++ b/src/server/common/helpers/formatters.test.js
@@ -24,7 +24,9 @@ describe('formatters', () => {
     })
 
     test('returns empty string when given null', () => {
-      const result = formatDateTime(null)
+      const result = formatDateTime(
+        /** @type {string} */ (/** @type {unknown} */ (null))
+      )
       expect(result).toBe('')
     })
   })

--- a/src/server/common/helpers/logging/request-logger.integration.test.js
+++ b/src/server/common/helpers/logging/request-logger.integration.test.js
@@ -55,7 +55,7 @@ describe('request-logger integration (hapi-pino + pino + ecs format)', () => {
       http: { request: { method: 'GET' } },
       url: { path: '/test' }
     })
-    expect(out.http.request.id).toStrictEqual(expect.any(String))
+    expect(out?.http?.request?.id).toStrictEqual(expect.any(String))
     expect(out).not.toHaveProperty('req')
   })
 
@@ -69,7 +69,9 @@ describe('request-logger integration (hapi-pino + pino + ecs format)', () => {
     })
 
     await server.inject('/test')
-    const out = findLine((l) => l.url?.path === '/test' && l.http?.response)
+    const out = findLine(
+      (l) => l.url?.path === '/test' && Boolean(l.http?.response)
+    )
 
     expect(out).toMatchObject({
       http: { response: { status_code: 200 } },
@@ -162,7 +164,7 @@ describe('request-logger integration (hapi-pino + pino + ecs format)', () => {
     const out = findLine(
       (l) =>
         l.url?.path === '/public/stylesheets/application.css' &&
-        l.http?.response
+        Boolean(l.http?.response)
     )
 
     expect(out).toBeUndefined()
@@ -208,7 +210,9 @@ describe('request-logger integration (hapi-pino + pino + ecs format)', () => {
     })
 
     await server.inject('/visible')
-    const out = findLine((l) => l.url?.path === '/visible' && l.http?.response)
+    const out = findLine(
+      (l) => l.url?.path === '/visible' && Boolean(l.http?.response)
+    )
 
     expect(out?.http?.response?.status_code).toBe(200)
   })

--- a/src/server/common/helpers/metrics/index.test.js
+++ b/src/server/common/helpers/metrics/index.test.js
@@ -14,10 +14,14 @@ vi.mock(import('aws-embedded-metrics'), async (importOriginal) => {
 
   return {
     ...original,
-    createMetricsLogger: () => ({
-      putMetric: mockPutMetric,
-      flush: mockFlush
-    })
+    createMetricsLogger: /** @type {typeof original.createMetricsLogger} */ (
+      /** @type {unknown} */ (
+        () => ({
+          putMetric: mockPutMetric,
+          flush: mockFlush
+        })
+      )
+    )
   }
 })
 

--- a/src/server/common/helpers/redis-client.test.js
+++ b/src/server/common/helpers/redis-client.test.js
@@ -55,8 +55,8 @@ describe('#buildRedisClient', () => {
     })
 
     test('Should log info message when connect event fires', () => {
-      const connectCall = mockOn.mock.calls.find(
-        (call) => call[0] === 'connect'
+      const connectCall = /** @type {[string, () => void]} */ (
+        mockOn.mock.calls.find((call) => call[0] === 'connect')
       )
       const connectHandler = connectCall[1]
       connectHandler()
@@ -67,7 +67,9 @@ describe('#buildRedisClient', () => {
     })
 
     test('Should log error message when error event fires', () => {
-      const errorCall = mockOn.mock.calls.find((call) => call[0] === 'error')
+      const errorCall = /** @type {[string, (error: Error) => void]} */ (
+        mockOn.mock.calls.find((call) => call[0] === 'error')
+      )
       const errorHandler = errorCall[1]
       const mockError = new Error('Connection failed')
       errorHandler(mockError)
@@ -103,7 +105,10 @@ describe('#buildRedisClient', () => {
     })
 
     test('Should configure dnsLookup to pass through address', () => {
-      const clusterCall = Cluster.mock.calls[0]
+      const clusterCall =
+        /** @type {[unknown, { dnsLookup: (address: string, callback: (error: null, address: string) => void) => void }]} */ (
+          vi.mocked(Cluster).mock.calls[0]
+        )
       const config = clusterCall[1]
       const dnsLookup = config.dnsLookup
       const mockCallback = vi.fn()
@@ -114,8 +119,8 @@ describe('#buildRedisClient', () => {
     })
 
     test('Should log info message when connect event fires', () => {
-      const connectCall = mockOn.mock.calls.find(
-        (call) => call[0] === 'connect'
+      const connectCall = /** @type {[string, () => void]} */ (
+        mockOn.mock.calls.find((call) => call[0] === 'connect')
       )
       const connectHandler = connectCall[1]
       connectHandler()
@@ -126,7 +131,9 @@ describe('#buildRedisClient', () => {
     })
 
     test('Should log error message when error event fires', () => {
-      const errorCall = mockOn.mock.calls.find((call) => call[0] === 'error')
+      const errorCall = /** @type {[string, (error: Error) => void]} */ (
+        mockOn.mock.calls.find((call) => call[0] === 'error')
+      )
       const errorHandler = errorCall[1]
       const mockError = new Error('Cluster connection failed')
       errorHandler(mockError)

--- a/src/server/common/helpers/redis-client.test.js
+++ b/src/server/common/helpers/redis-client.test.js
@@ -9,6 +9,17 @@ const mockLoggerInfo = vi.fn()
 const mockLoggerError = vi.fn()
 const mockOn = vi.fn()
 
+/**
+ * @param {string} event
+ * @returns {(arg?: unknown) => void}
+ */
+const findHandler = (event) => {
+  const call = /** @type {[string, (arg?: unknown) => void]} */ (
+    mockOn.mock.calls.find((c) => c[0] === event)
+  )
+  return call[1]
+}
+
 vi.mock('./logging/logger.js', () => ({
   createLogger: () => ({
     info: (...args) => mockLoggerInfo(...args),
@@ -55,10 +66,7 @@ describe('#buildRedisClient', () => {
     })
 
     test('Should log info message when connect event fires', () => {
-      const connectCall = /** @type {[string, () => void]} */ (
-        mockOn.mock.calls.find((call) => call[0] === 'connect')
-      )
-      const connectHandler = connectCall[1]
+      const connectHandler = findHandler('connect')
       connectHandler()
 
       expect(mockLoggerInfo).toHaveBeenCalledWith({
@@ -67,10 +75,7 @@ describe('#buildRedisClient', () => {
     })
 
     test('Should log error message when error event fires', () => {
-      const errorCall = /** @type {[string, (error: Error) => void]} */ (
-        mockOn.mock.calls.find((call) => call[0] === 'error')
-      )
-      const errorHandler = errorCall[1]
+      const errorHandler = findHandler('error')
       const mockError = new Error('Connection failed')
       errorHandler(mockError)
 
@@ -119,10 +124,7 @@ describe('#buildRedisClient', () => {
     })
 
     test('Should log info message when connect event fires', () => {
-      const connectCall = /** @type {[string, () => void]} */ (
-        mockOn.mock.calls.find((call) => call[0] === 'connect')
-      )
-      const connectHandler = connectCall[1]
+      const connectHandler = findHandler('connect')
       connectHandler()
 
       expect(mockLoggerInfo).toHaveBeenCalledWith({
@@ -131,10 +133,7 @@ describe('#buildRedisClient', () => {
     })
 
     test('Should log error message when error event fires', () => {
-      const errorCall = /** @type {[string, (error: Error) => void]} */ (
-        mockOn.mock.calls.find((call) => call[0] === 'error')
-      )
-      const errorHandler = errorCall[1]
+      const errorHandler = findHandler('error')
       const mockError = new Error('Cluster connection failed')
       errorHandler(mockError)
 

--- a/src/server/common/helpers/request-tracing.integration.test.js
+++ b/src/server/common/helpers/request-tracing.integration.test.js
@@ -90,7 +90,9 @@ describe('#request-tracing', () => {
         url: '/test',
         headers: { 'x-cdp-request-id': 'incoming-trace-resp' }
       })
-      const out = findLine((l) => l.url?.path === '/test' && l.http?.response)
+      const out = findLine(
+        (l) => l.url?.path === '/test' && Boolean(l.http?.response)
+      )
 
       expect(out?.trace?.id).toBe('incoming-trace-resp')
     })
@@ -102,7 +104,7 @@ describe('#request-tracing', () => {
       await server.inject('/test')
       const handler = findLine((l) => l.message === 'inside handler')
       const response = findLine(
-        (l) => l.url?.path === '/test' && l.http?.response
+        (l) => l.url?.path === '/test' && Boolean(l.http?.response)
       )
 
       expect(handler?.trace?.id).toMatch(UUID_V4)

--- a/src/server/common/helpers/stream-from-backend.test.js
+++ b/src/server/common/helpers/stream-from-backend.test.js
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 import { streamFromBackend } from './stream-from-backend.js'
+import { asRequest } from '#server/common/test-helpers/fixtures.js'
 
-/** @import { HapiRequest } from '#server/common/hapi-types.js' */
+const mockRequest = asRequest({ yar: {} })
 
 const { mockUserSession, mockConfigGet } = vi.hoisted(() => ({
   mockUserSession: vi.fn(),
@@ -47,10 +48,7 @@ describe('streamFromBackend', () => {
       body
     })
 
-    const result = await streamFromBackend(
-      /** @type {HapiRequest} */ ({ yar: {} }),
-      '/x'
-    )
+    const result = await streamFromBackend(mockRequest, '/x')
     expect(result.status).toBe(200)
     expect(result.headers.get('content-type')).toBe('text/csv')
     expect(result.body).toBe(body)
@@ -71,9 +69,7 @@ describe('streamFromBackend', () => {
       body: null
     })
 
-    await expect(
-      streamFromBackend(/** @type {HapiRequest} */ ({ yar: {} }), '/x')
-    ).rejects.toMatchObject({
+    await expect(streamFromBackend(mockRequest, '/x')).rejects.toMatchObject({
       isBoom: true,
       output: { statusCode: 503 }
     })
@@ -81,9 +77,7 @@ describe('streamFromBackend', () => {
 
   it('throws an internal error if fetch itself rejects', async () => {
     fetchSpy.mockRejectedValue(new Error('network down'))
-    await expect(
-      streamFromBackend(/** @type {HapiRequest} */ ({ yar: {} }), '/x')
-    ).rejects.toMatchObject({
+    await expect(streamFromBackend(mockRequest, '/x')).rejects.toMatchObject({
       isBoom: true
     })
   })

--- a/src/server/common/helpers/stream-from-backend.test.js
+++ b/src/server/common/helpers/stream-from-backend.test.js
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 import { streamFromBackend } from './stream-from-backend.js'
 
+/** @import { HapiRequest } from '#server/common/hapi-types.js' */
+
 const { mockUserSession, mockConfigGet } = vi.hoisted(() => ({
   mockUserSession: vi.fn(),
   mockConfigGet: vi.fn()
@@ -45,7 +47,10 @@ describe('streamFromBackend', () => {
       body
     })
 
-    const result = await streamFromBackend({ yar: {} }, '/x')
+    const result = await streamFromBackend(
+      /** @type {HapiRequest} */ ({ yar: {} }),
+      '/x'
+    )
     expect(result.status).toBe(200)
     expect(result.headers.get('content-type')).toBe('text/csv')
     expect(result.body).toBe(body)
@@ -66,7 +71,9 @@ describe('streamFromBackend', () => {
       body: null
     })
 
-    await expect(streamFromBackend({ yar: {} }, '/x')).rejects.toMatchObject({
+    await expect(
+      streamFromBackend(/** @type {HapiRequest} */ ({ yar: {} }), '/x')
+    ).rejects.toMatchObject({
       isBoom: true,
       output: { statusCode: 503 }
     })
@@ -74,7 +81,9 @@ describe('streamFromBackend', () => {
 
   it('throws an internal error if fetch itself rejects', async () => {
     fetchSpy.mockRejectedValue(new Error('network down'))
-    await expect(streamFromBackend({ yar: {} }, '/x')).rejects.toMatchObject({
+    await expect(
+      streamFromBackend(/** @type {HapiRequest} */ ({ yar: {} }), '/x')
+    ).rejects.toMatchObject({
       isBoom: true
     })
   })

--- a/src/server/common/helpers/useragent-protection.test.js
+++ b/src/server/common/helpers/useragent-protection.test.js
@@ -46,7 +46,7 @@ describe('user-agent protection', () => {
   test('should verify actual header truncation by inspecting processed request', async () => {
     const originalUserAgent =
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 EdgeCustomLongName/SuperLongVersionString'
-    let capturedUserAgent = null
+    let capturedUserAgent = /** @type {string | null} */ (null)
 
     server.route({
       method: 'GET',
@@ -74,13 +74,15 @@ describe('user-agent protection', () => {
     expect(capturedUserAgent).toBe(
       originalUserAgent.substring(0, MAX_USER_AGENT_LENGTH)
     )
-    expect(originalUserAgent.startsWith(capturedUserAgent)).toBe(true)
+    expect(
+      originalUserAgent.startsWith(/** @type {string} */ (capturedUserAgent))
+    ).toBe(true)
   })
 
   test('should not modify User-Agent headers that are already within limit', async () => {
     const normalUserAgent =
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
-    let capturedUserAgent = null
+    let capturedUserAgent = /** @type {string | null} */ (null)
 
     server.route({
       method: 'GET',

--- a/src/server/common/test-helpers/csrf-helper.js
+++ b/src/server/common/test-helpers/csrf-helper.js
@@ -12,7 +12,11 @@ export async function getCsrfToken(server, getUrl, auth) {
   }
   const response = await server.inject(requestOptions)
   const setCookie = response.headers['set-cookie']
-  const cookies = Array.isArray(setCookie) ? setCookie : [setCookie]
+  const cookies = Array.isArray(setCookie)
+    ? setCookie
+    : setCookie
+      ? [setCookie]
+      : []
   const crumbCookie = cookies.find(
     (cookie) => cookie && cookie.startsWith('crumb=')
   )

--- a/src/server/common/test-helpers/fixtures.js
+++ b/src/server/common/test-helpers/fixtures.js
@@ -1,5 +1,7 @@
 import { makeToken } from './test-constants.js'
 
+/** @import { HapiRequest } from '#server/common/hapi-types.js' */
+
 export const mockUserSession = {
   userId: 'user-id',
   email: 'user@email.com',
@@ -9,4 +11,33 @@ export const mockUserSession = {
   scopes: ['admin.read', 'admin.write', 'admin.dlq.purge'],
   token: makeToken('user-token'),
   refreshToken: makeToken('refresh-token')
+}
+
+/**
+ * @param {unknown} req
+ * @returns {HapiRequest}
+ */
+export const asRequest = (req) => /** @type {HapiRequest} */ (req)
+
+/**
+ * @param {{ message?: string, statusCode?: number, payloadMessage?: string }} [options]
+ * @returns {Error & { output: { statusCode?: number, payload?: { message?: string } } }}
+ */
+export const boomError = ({
+  message = 'error',
+  statusCode,
+  payloadMessage
+} = {}) => {
+  const error =
+    /** @type {Error & { output: { statusCode?: number, payload?: { message?: string } } }} */ (
+      new Error(message)
+    )
+  error.output = {}
+  if (statusCode !== undefined) {
+    error.output.statusCode = statusCode
+  }
+  if (payloadMessage !== undefined) {
+    error.output.payload = { message: payloadMessage }
+  }
+  return error
 }

--- a/src/server/plugins/auth-plugin.test.js
+++ b/src/server/plugins/auth-plugin.test.js
@@ -17,7 +17,7 @@ describe('#authPlugin', () => {
     end_session_endpoint: 'https://example-auth.test/oauth/logout'
   }
 
-  const mockBellOptions = {
+  const mockBellOptions = /** @type {ReturnType<typeof getBellOptions>} */ ({
     provider: {
       name: 'entra-id',
       protocol: 'oauth2',
@@ -26,17 +26,18 @@ describe('#authPlugin', () => {
     },
     clientId: 'test-client-id',
     clientSecret: 'test-client-secret'
-  }
+  })
 
-  const mockCookieOptions = {
-    cookie: {
-      password: TEST_COOKIE_PASSWORD,
-      path: '/',
-      isSecure: false,
-      isSameSite: 'Lax'
-    },
-    redirectTo: false
-  }
+  const mockCookieOptions =
+    /** @type {ReturnType<typeof getCookieOptions>} */ ({
+      cookie: {
+        password: TEST_COOKIE_PASSWORD,
+        path: '/',
+        isSecure: false,
+        isSameSite: 'Lax'
+      },
+      redirectTo: false
+    })
 
   const mockServer = {
     auth: {
@@ -48,9 +49,9 @@ describe('#authPlugin', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    getOidcConfig.mockResolvedValue(mockOidcConfig)
-    getBellOptions.mockReturnValue(mockBellOptions)
-    getCookieOptions.mockReturnValue(mockCookieOptions)
+    vi.mocked(getOidcConfig).mockResolvedValue(mockOidcConfig)
+    vi.mocked(getBellOptions).mockReturnValue(mockBellOptions)
+    vi.mocked(getCookieOptions).mockReturnValue(mockCookieOptions)
   })
 
   afterEach(() => {
@@ -84,17 +85,17 @@ describe('#authPlugin', () => {
   test('Should call functions in correct order', async () => {
     const callOrder = []
 
-    getOidcConfig.mockImplementation(async () => {
+    vi.mocked(getOidcConfig).mockImplementation(async () => {
       callOrder.push('getOidcConfig')
       return mockOidcConfig
     })
 
-    getBellOptions.mockImplementation(() => {
+    vi.mocked(getBellOptions).mockImplementation(() => {
       callOrder.push('getBellOptions')
       return mockBellOptions
     })
 
-    getCookieOptions.mockImplementation(() => {
+    vi.mocked(getCookieOptions).mockImplementation(() => {
       callOrder.push('getCookieOptions')
       return mockCookieOptions
     })
@@ -153,7 +154,7 @@ describe('#authPlugin', () => {
 
   test('Should handle getOidcConfig errors', async () => {
     const error = new Error('Failed to fetch OIDC config')
-    getOidcConfig.mockRejectedValue(error)
+    vi.mocked(getOidcConfig).mockRejectedValue(error)
 
     await expect(authPlugin.plugin.register(mockServer)).rejects.toThrow(
       'Failed to fetch OIDC config'
@@ -167,7 +168,7 @@ describe('#authPlugin', () => {
 
   test('Should handle getBellOptions errors', async () => {
     const error = new Error('Failed to get Bell options')
-    getBellOptions.mockImplementation(() => {
+    vi.mocked(getBellOptions).mockImplementation(() => {
       throw error
     })
 
@@ -182,7 +183,7 @@ describe('#authPlugin', () => {
 
   test('Should handle getCookieOptions errors', async () => {
     const error = new Error('Failed to get Cookie options')
-    getCookieOptions.mockImplementation(() => {
+    vi.mocked(getCookieOptions).mockImplementation(() => {
       throw error
     })
 
@@ -234,7 +235,7 @@ describe('#authPlugin', () => {
       end_session_endpoint: 'https://example-provider-2.test/logout'
     }
 
-    getOidcConfig.mockResolvedValue(differentOidcConfig)
+    vi.mocked(getOidcConfig).mockResolvedValue(differentOidcConfig)
 
     await authPlugin.plugin.register(mockServer)
 

--- a/src/server/routes/auth/callback/index.test.js
+++ b/src/server/routes/auth/callback/index.test.js
@@ -5,22 +5,12 @@ import { createUserSession } from '#server/common/helpers/auth/create-user-sessi
 import { fetchAdminMe } from '#server/common/helpers/auth/fetch-admin-me.js'
 import { randomUUID } from 'node:crypto'
 import { auditSignIn } from '#server/common/helpers/auditing/index.js'
+import { asRequest } from '#server/common/test-helpers/fixtures.js'
 
 vi.mock('#server/common/helpers/auth/create-user-session.js')
 vi.mock('#server/common/helpers/auth/fetch-admin-me.js')
 vi.mock('#server/common/helpers/auditing/index.js')
 vi.mock('node:crypto')
-
-/** @typedef {import('#server/common/hapi-types.js').HapiRequest} HapiRequest */
-
-/**
- * Cast a partial mock request to the full `HapiRequest` shape the handler
- * signature requires. The handler only reads a narrow slice (auth.credentials,
- * logger, yar) so the runtime mock is sufficient — the cast satisfies tsc.
- * @param {unknown} obj
- * @returns {HapiRequest}
- */
-const asRequest = (obj) => /** @type {HapiRequest} */ (obj)
 
 /**
  * Cast a partial mock toolkit to the full `ResponseToolkit` shape.

--- a/src/server/routes/auth/sign-in/get.integration.test.js
+++ b/src/server/routes/auth/sign-in/get.integration.test.js
@@ -10,7 +10,9 @@ const mockSignInAttemptedMetric = vi.fn()
 
 vi.mock('#server/common/helpers/metrics/index.js', async (importOriginal) => ({
   metrics: {
-    ...(await importOriginal()).metrics,
+    .../** @type {{ metrics: Record<string, unknown> }} */ (
+      await importOriginal()
+    ).metrics,
     signInAttempted: () => mockSignInAttemptedMetric()
   }
 }))

--- a/src/server/routes/auth/sign-out/get.integration.test.js
+++ b/src/server/routes/auth/sign-out/get.integration.test.js
@@ -14,7 +14,9 @@ const mockCdpAuditing = vi.fn()
 
 vi.mock('#server/common/helpers/metrics/index.js', async (importOriginal) => ({
   metrics: {
-    ...(await importOriginal()).metrics,
+    .../** @type {{ metrics: Record<string, unknown> }} */ (
+      await importOriginal()
+    ).metrics,
     signOutSuccess: () => mockSignOutSuccessMetric()
   }
 }))
@@ -45,7 +47,7 @@ describe('GET /auth/sign-out', () => {
     let response
 
     beforeEach(async () => {
-      getUserSession.mockReturnValue(mockUserSession)
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
 
       response = await server.inject({
         method: 'GET',

--- a/src/server/routes/auth/sign-out/index.test.js
+++ b/src/server/routes/auth/sign-out/index.test.js
@@ -6,16 +6,10 @@ import { clearUserSession } from '#server/common/helpers/auth/clear-user-session
 import { getUserSession } from '#server/common/helpers/auth/get-user-session.js'
 import { getOidcConfig } from '#server/common/helpers/auth/get-oidc-config.js'
 import { auditSignOut } from '#server/common/helpers/auditing/index.js'
-import { mockUserSession } from '#server/common/test-helpers/fixtures.js'
-
-/** @import { HapiRequest } from '#server/common/hapi-types.js' */
-
-/**
- * Cast a partial mock request to the `HapiRequest` shape the handler reads.
- * @param {unknown} req
- * @returns {HapiRequest}
- */
-const asRequest = (req) => /** @type {HapiRequest} */ (req)
+import {
+  mockUserSession,
+  asRequest
+} from '#server/common/test-helpers/fixtures.js'
 
 vi.mock('#server/common/helpers/auth/clear-user-session.js')
 vi.mock('#server/common/helpers/auth/get-user-session.js')

--- a/src/server/routes/auth/sign-out/index.test.js
+++ b/src/server/routes/auth/sign-out/index.test.js
@@ -8,6 +8,15 @@ import { getOidcConfig } from '#server/common/helpers/auth/get-oidc-config.js'
 import { auditSignOut } from '#server/common/helpers/auditing/index.js'
 import { mockUserSession } from '#server/common/test-helpers/fixtures.js'
 
+/** @import { HapiRequest } from '#server/common/hapi-types.js' */
+
+/**
+ * Cast a partial mock request to the `HapiRequest` shape the handler reads.
+ * @param {unknown} req
+ * @returns {HapiRequest}
+ */
+const asRequest = (req) => /** @type {HapiRequest} */ (req)
+
 vi.mock('#server/common/helpers/auth/clear-user-session.js')
 vi.mock('#server/common/helpers/auth/get-user-session.js')
 vi.mock('#server/common/helpers/auth/get-oidc-config.js')
@@ -32,9 +41,9 @@ describe('#signOut route', () => {
 
     mockToolkit.redirect.mockReturnValue('redirect-result')
     mockToolkit.view.mockReturnValue('view-result')
-    getOidcConfig.mockResolvedValue(mockOidcConfig)
-    clearUserSession.mockResolvedValue()
-    getUserSession.mockResolvedValue(mockUserSession)
+    vi.mocked(getOidcConfig).mockResolvedValue(mockOidcConfig)
+    vi.mocked(clearUserSession).mockResolvedValue()
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
   })
 
   afterEach(() => {
@@ -55,9 +64,9 @@ describe('#signOut route', () => {
   })
 
   test('Should redirect to home if there is no user session', async () => {
-    getUserSession.mockResolvedValue(null)
+    vi.mocked(getUserSession).mockResolvedValue(null)
 
-    const result = await signOutRoute.handler({}, mockToolkit)
+    const result = await signOutRoute.handler(asRequest({}), mockToolkit)
 
     expect(mockToolkit.redirect).toHaveBeenCalledWith('/')
     expect(result).toBe('redirect-result')
@@ -73,7 +82,10 @@ describe('#signOut route', () => {
       }
     }
 
-    const result = await signOutRoute.handler(mockRequest, mockToolkit)
+    const result = await signOutRoute.handler(
+      asRequest(mockRequest),
+      mockToolkit
+    )
 
     expect(clearUserSession).toHaveBeenCalledWith(mockRequest)
     expect(getOidcConfig).toHaveBeenCalledTimes(1)
@@ -103,7 +115,7 @@ describe('#signOut route', () => {
       }
     }
 
-    await signOutRoute.handler(mockRequest, mockToolkit)
+    await signOutRoute.handler(asRequest(mockRequest), mockToolkit)
 
     const expectedParams = new URLSearchParams()
     expectedParams.set('logout_hint', mockUserSession.email)
@@ -122,7 +134,7 @@ describe('#signOut route', () => {
   })
 
   test('Should prefer loginHint over email for logout_hint', async () => {
-    getUserSession.mockResolvedValue({
+    vi.mocked(getUserSession).mockResolvedValue({
       ...mockUserSession,
       loginHint: 'hint@example.test'
     })
@@ -132,7 +144,7 @@ describe('#signOut route', () => {
       auth: { isAuthenticated: true }
     }
 
-    await signOutRoute.handler(mockRequest, mockToolkit)
+    await signOutRoute.handler(asRequest(mockRequest), mockToolkit)
 
     expect(mockToolkit.view).toHaveBeenCalledWith(
       'routes/auth/sign-out/index',
@@ -143,7 +155,7 @@ describe('#signOut route', () => {
   })
 
   test('Should omit logout_hint when neither loginHint nor email available', async () => {
-    getUserSession.mockResolvedValue({
+    vi.mocked(getUserSession).mockResolvedValue({
       ...mockUserSession,
       loginHint: undefined,
       email: undefined
@@ -154,7 +166,7 @@ describe('#signOut route', () => {
       auth: { isAuthenticated: true }
     }
 
-    await signOutRoute.handler(mockRequest, mockToolkit)
+    await signOutRoute.handler(asRequest(mockRequest), mockToolkit)
 
     expect(mockToolkit.view).toHaveBeenCalledWith(
       'routes/auth/sign-out/index',
@@ -173,8 +185,10 @@ describe('#signOut route', () => {
 
     for (const endpoint of testEndpoints) {
       vi.clearAllMocks()
-      getOidcConfig.mockResolvedValue({ end_session_endpoint: endpoint })
-      clearUserSession.mockResolvedValue()
+      vi.mocked(getOidcConfig).mockResolvedValue({
+        end_session_endpoint: endpoint
+      })
+      vi.mocked(clearUserSession).mockResolvedValue()
       mockToolkit.view.mockReturnValue('view-result')
 
       const mockRequest = {
@@ -184,7 +198,7 @@ describe('#signOut route', () => {
         }
       }
 
-      await signOutRoute.handler(mockRequest, mockToolkit)
+      await signOutRoute.handler(asRequest(mockRequest), mockToolkit)
 
       const expectedParams = new URLSearchParams()
       expectedParams.set('logout_hint', mockUserSession.email)
@@ -205,11 +219,11 @@ describe('#signOut route', () => {
 
   test('Should handle getOidcConfig errors', async () => {
     const error = new Error('Failed to get OIDC config')
-    getOidcConfig.mockRejectedValue(error)
+    vi.mocked(getOidcConfig).mockRejectedValue(error)
 
-    await expect(signOutRoute.handler({}, mockToolkit)).rejects.toThrow(
-      'Failed to get OIDC config'
-    )
+    await expect(
+      signOutRoute.handler(asRequest({}), mockToolkit)
+    ).rejects.toThrow('Failed to get OIDC config')
 
     expect(clearUserSession).not.toHaveBeenCalledWith()
     expect(mockToolkit.view).not.toHaveBeenCalled()
@@ -217,7 +231,7 @@ describe('#signOut route', () => {
 
   test('Should handle clearUserSession errors', async () => {
     const error = new Error('Failed to clear session')
-    clearUserSession.mockImplementation(() => {
+    vi.mocked(clearUserSession).mockImplementation(() => {
       throw error
     })
 
@@ -229,7 +243,7 @@ describe('#signOut route', () => {
     }
 
     await expect(
-      signOutRoute.handler(mockRequest, mockToolkit)
+      signOutRoute.handler(asRequest(mockRequest), mockToolkit)
     ).rejects.toThrow('Failed to clear session')
 
     expect(mockToolkit.view).not.toHaveBeenCalled()
@@ -238,11 +252,11 @@ describe('#signOut route', () => {
   test('Should call functions in correct order for authenticated user', async () => {
     const callOrder = []
 
-    clearUserSession.mockImplementation(async () => {
+    vi.mocked(clearUserSession).mockImplementation(async () => {
       callOrder.push('clearUserSession')
     })
 
-    getOidcConfig.mockImplementation(async () => {
+    vi.mocked(getOidcConfig).mockImplementation(async () => {
       callOrder.push('getOidcConfig')
       return mockOidcConfig
     })
@@ -259,13 +273,13 @@ describe('#signOut route', () => {
       }
     }
 
-    await signOutRoute.handler(mockRequest, mockToolkit)
+    await signOutRoute.handler(asRequest(mockRequest), mockToolkit)
 
     expect(callOrder).toEqual(['getOidcConfig', 'clearUserSession', 'view'])
   })
 
   test('Should handle missing end_session_endpoint in OIDC config', async () => {
-    getOidcConfig.mockResolvedValue({})
+    vi.mocked(getOidcConfig).mockResolvedValue({})
 
     const mockRequest = {
       logger: mockLogger,
@@ -274,7 +288,7 @@ describe('#signOut route', () => {
       }
     }
 
-    await signOutRoute.handler(mockRequest, mockToolkit)
+    await signOutRoute.handler(asRequest(mockRequest), mockToolkit)
 
     const expectedParams = new URLSearchParams()
     expectedParams.set('logout_hint', mockUserSession.email)
@@ -300,15 +314,15 @@ describe('#signOut route', () => {
       }
     }
 
-    await signOutRoute.handler(mockRequest, mockToolkit)
+    await signOutRoute.handler(asRequest(mockRequest), mockToolkit)
 
     expect(auditSignOut).toHaveBeenCalledWith(mockUserSession)
   })
 
   test('Should not call auditSignOut when no user session', async () => {
-    getUserSession.mockResolvedValue(null)
+    vi.mocked(getUserSession).mockResolvedValue(null)
 
-    await signOutRoute.handler({}, mockToolkit)
+    await signOutRoute.handler(asRequest({}), mockToolkit)
 
     expect(auditSignOut).not.toHaveBeenCalled()
   })
@@ -321,7 +335,7 @@ describe('#signOut route', () => {
       }
     }
 
-    await signOutRoute.handler(mockRequest, mockToolkit)
+    await signOutRoute.handler(asRequest(mockRequest), mockToolkit)
 
     expect(mockLogger.info).toHaveBeenCalledWith({
       message: 'User signed out',

--- a/src/server/routes/defra-forms-submission/get.integration.test.js
+++ b/src/server/routes/defra-forms-submission/get.integration.test.js
@@ -45,7 +45,7 @@ describe('GET /defra-forms-submission/{documentId}', () => {
     const documentId = '000000-0000-1234'
 
     beforeEach(() => {
-      getUserSession.mockReturnValue(mockUserSession)
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
     })
 
     test('Should return OK and render defra forms submission details', async () => {
@@ -81,17 +81,26 @@ describe('GET /defra-forms-submission/{documentId}', () => {
       const quotesEscaped = (s) => s.replaceAll('"', '&quot;')
 
       expect(statusCode).toBe(statusCodes.ok)
-      expect(result)
-        .toContain('<textarea class="govuk-textarea" id="organisation"')
-        .toContain(quotesEscaped('"id": "org-1"'))
-        .toContain('<textarea class="govuk-textarea" id="registration-1"')
-        .toContain(quotesEscaped('"id": "reg-1"'))
-        .toContain('<textarea class="govuk-textarea" id="registration-2"')
-        .toContain(quotesEscaped('"id": "reg-2"'))
-        .toContain('<textarea class="govuk-textarea" id="accreditation-1"')
-        .toContain(quotesEscaped('"id": "acc-1"'))
-        .toContain('<textarea class="govuk-textarea" id="accreditation-2"')
-        .toContain(quotesEscaped('"id": "acc-2"'))
+      expect(result).toContain(
+        '<textarea class="govuk-textarea" id="organisation"'
+      )
+      expect(result).toContain(quotesEscaped('"id": "org-1"'))
+      expect(result).toContain(
+        '<textarea class="govuk-textarea" id="registration-1"'
+      )
+      expect(result).toContain(quotesEscaped('"id": "reg-1"'))
+      expect(result).toContain(
+        '<textarea class="govuk-textarea" id="registration-2"'
+      )
+      expect(result).toContain(quotesEscaped('"id": "reg-2"'))
+      expect(result).toContain(
+        '<textarea class="govuk-textarea" id="accreditation-1"'
+      )
+      expect(result).toContain(quotesEscaped('"id": "acc-1"'))
+      expect(result).toContain(
+        '<textarea class="govuk-textarea" id="accreditation-2"'
+      )
+      expect(result).toContain(quotesEscaped('"id": "acc-2"'))
     })
 
     test('Should render page with no data when backend returns 404', async () => {
@@ -114,13 +123,14 @@ describe('GET /defra-forms-submission/{documentId}', () => {
       })
 
       expect(statusCode).toBe(statusCodes.ok)
-      expect(result)
-        .toContain('<h3 class="govuk-heading-m">Organisation</h3>')
-        .toContain('No organisations submission data found.')
-        .toContain('<h3 class="govuk-heading-m">Registrations</h3>')
-        .toContain('No registrations submission data found.')
-        .toContain('<h3 class="govuk-heading-m">Accreditations</h3>')
-        .toContain('No accreditations submission data found.')
+      expect(result).toContain('<h3 class="govuk-heading-m">Organisation</h3>')
+      expect(result).toContain('No organisations submission data found.')
+      expect(result).toContain('<h3 class="govuk-heading-m">Registrations</h3>')
+      expect(result).toContain('No registrations submission data found.')
+      expect(result).toContain(
+        '<h3 class="govuk-heading-m">Accreditations</h3>'
+      )
+      expect(result).toContain('No accreditations submission data found.')
     })
 
     test('Should render not authorised page when backend request is not authorised', async () => {

--- a/src/server/routes/linked-organisations/controller.download.test.js
+++ b/src/server/routes/linked-organisations/controller.download.test.js
@@ -8,6 +8,8 @@ vi.mock('#server/common/helpers/fetch-json-from-backend.js', () => ({
   fetchJsonFromBackend: vi.fn()
 }))
 
+const mockFetchJsonFromBackend = vi.mocked(fetchJsonFromBackend)
+
 describe('linked-organisations download controller', () => {
   let mockRequest
   let mockH
@@ -34,7 +36,7 @@ describe('linked-organisations download controller', () => {
   })
 
   test('Should generate CSV with correct headers and data', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue([mockLinkedOrg])
+    mockFetchJsonFromBackend.mockResolvedValue([mockLinkedOrg])
 
     await linkedOrganisationsDownloadController.handler(mockRequest, mockH)
 
@@ -55,7 +57,7 @@ describe('linked-organisations download controller', () => {
   })
 
   test('Should set correct Content-Type and Content-Disposition headers', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue([mockLinkedOrg])
+    mockFetchJsonFromBackend.mockResolvedValue([mockLinkedOrg])
 
     await linkedOrganisationsDownloadController.handler(mockRequest, mockH)
 
@@ -67,7 +69,7 @@ describe('linked-organisations download controller', () => {
   })
 
   test('Should handle empty linked organisations', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue([])
+    mockFetchJsonFromBackend.mockResolvedValue([])
 
     await linkedOrganisationsDownloadController.handler(mockRequest, mockH)
 
@@ -78,7 +80,7 @@ describe('linked-organisations download controller', () => {
   })
 
   test('Should handle backend returning non-array data', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({})
+    mockFetchJsonFromBackend.mockResolvedValue({})
 
     await linkedOrganisationsDownloadController.handler(mockRequest, mockH)
 
@@ -93,7 +95,7 @@ describe('linked-organisations download controller', () => {
       ...mockLinkedOrg,
       orgId: null
     }
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue([orgWithNullField])
+    mockFetchJsonFromBackend.mockResolvedValue([orgWithNullField])
 
     await linkedOrganisationsDownloadController.handler(mockRequest, mockH)
 
@@ -106,7 +108,7 @@ describe('linked-organisations download controller', () => {
       ...mockLinkedOrg,
       companyDetails: { name: 'Acme, Ltd' }
     }
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue([orgWithComma])
+    mockFetchJsonFromBackend.mockResolvedValue([orgWithComma])
 
     await linkedOrganisationsDownloadController.handler(mockRequest, mockH)
 
@@ -121,7 +123,7 @@ describe('linked-organisations download controller', () => {
         name: 'Acme "Best" Ltd'
       }
     }
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue([orgWithQuote])
+    mockFetchJsonFromBackend.mockResolvedValue([orgWithQuote])
 
     await linkedOrganisationsDownloadController.handler(mockRequest, mockH)
 
@@ -134,7 +136,7 @@ describe('linked-organisations download controller', () => {
       ...mockLinkedOrg,
       companyDetails: { name: '=SUM(A1)' }
     }
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue([orgWithFormulaValue])
+    mockFetchJsonFromBackend.mockResolvedValue([orgWithFormulaValue])
 
     await linkedOrganisationsDownloadController.handler(mockRequest, mockH)
 
@@ -143,9 +145,7 @@ describe('linked-organisations download controller', () => {
   })
 
   test('Should redirect with error message on fetch failure', async () => {
-    vi.mocked(fetchJsonFromBackend).mockRejectedValue(
-      new Error('Network error')
-    )
+    mockFetchJsonFromBackend.mockRejectedValue(new Error('Network error'))
 
     const result = await linkedOrganisationsDownloadController.handler(
       mockRequest,
@@ -162,7 +162,7 @@ describe('linked-organisations download controller', () => {
 
   test('Should use error message from backend when available', async () => {
     const error = Boom.badRequest('Custom backend error message')
-    vi.mocked(fetchJsonFromBackend).mockRejectedValue(error)
+    mockFetchJsonFromBackend.mockRejectedValue(error)
 
     await linkedOrganisationsDownloadController.handler(mockRequest, mockH)
 
@@ -173,7 +173,7 @@ describe('linked-organisations download controller', () => {
   })
 
   test('Should format linked date in CSV', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue([mockLinkedOrg])
+    mockFetchJsonFromBackend.mockResolvedValue([mockLinkedOrg])
 
     await linkedOrganisationsDownloadController.handler(mockRequest, mockH)
 
@@ -183,7 +183,7 @@ describe('linked-organisations download controller', () => {
 
   test('Should pass search term as query param to backend', async () => {
     mockRequest.payload = { search: ' acme ' }
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue([mockLinkedOrg])
+    mockFetchJsonFromBackend.mockResolvedValue([mockLinkedOrg])
 
     await linkedOrganisationsDownloadController.handler(mockRequest, mockH)
 
@@ -195,7 +195,7 @@ describe('linked-organisations download controller', () => {
 
   test('Should fetch all when no search term in payload', async () => {
     mockRequest.payload = {}
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue([mockLinkedOrg])
+    mockFetchJsonFromBackend.mockResolvedValue([mockLinkedOrg])
 
     await linkedOrganisationsDownloadController.handler(mockRequest, mockH)
 

--- a/src/server/routes/linked-organisations/controller.test.js
+++ b/src/server/routes/linked-organisations/controller.test.js
@@ -33,7 +33,7 @@ describe('linked-organisations controller', () => {
   })
 
   test('Should fetch all linked organisations on GET', async () => {
-    fetchJsonFromBackend.mockResolvedValue([mockLinkedOrg])
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue([mockLinkedOrg])
 
     await linkedOrganisationsController.handler(mockRequest, mockH)
 
@@ -62,7 +62,7 @@ describe('linked-organisations controller', () => {
 
   test('Should pass search term as query param to backend', async () => {
     mockRequest.query = { search: ' acme ' }
-    fetchJsonFromBackend.mockResolvedValue([mockLinkedOrg])
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue([mockLinkedOrg])
 
     await linkedOrganisationsController.handler(mockRequest, mockH)
 
@@ -81,7 +81,7 @@ describe('linked-organisations controller', () => {
 
   test('Should fetch all when search term is empty', async () => {
     mockRequest.query = { search: '  ' }
-    fetchJsonFromBackend.mockResolvedValue([])
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue([])
 
     await linkedOrganisationsController.handler(mockRequest, mockH)
 
@@ -92,7 +92,7 @@ describe('linked-organisations controller', () => {
   })
 
   test('Should handle backend returning non-array', async () => {
-    fetchJsonFromBackend.mockResolvedValue({})
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({})
 
     await linkedOrganisationsController.handler(mockRequest, mockH)
 
@@ -106,7 +106,7 @@ describe('linked-organisations controller', () => {
 
   test('Should display error message from session and clear it', async () => {
     mockRequest.yar.get.mockReturnValue('Download failed')
-    fetchJsonFromBackend.mockResolvedValue([])
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue([])
 
     await linkedOrganisationsController.handler(mockRequest, mockH)
 
@@ -122,7 +122,7 @@ describe('linked-organisations controller', () => {
   })
 
   test('Should pass pageTitle from route settings', async () => {
-    fetchJsonFromBackend.mockResolvedValue([])
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue([])
 
     await linkedOrganisationsController.handler(mockRequest, mockH)
 
@@ -136,7 +136,7 @@ describe('linked-organisations controller', () => {
 
   test('Should encode special characters in search term', async () => {
     mockRequest.query = { search: 'Acme & Co' }
-    fetchJsonFromBackend.mockResolvedValue([])
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue([])
 
     await linkedOrganisationsController.handler(mockRequest, mockH)
 

--- a/src/server/routes/linked-organisations/controller.test.js
+++ b/src/server/routes/linked-organisations/controller.test.js
@@ -7,6 +7,8 @@ vi.mock('#server/common/helpers/fetch-json-from-backend.js', () => ({
   fetchJsonFromBackend: vi.fn()
 }))
 
+const mockFetchJsonFromBackend = vi.mocked(fetchJsonFromBackend)
+
 describe('linked-organisations controller', () => {
   let mockRequest
   let mockH
@@ -33,7 +35,7 @@ describe('linked-organisations controller', () => {
   })
 
   test('Should fetch all linked organisations on GET', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue([mockLinkedOrg])
+    mockFetchJsonFromBackend.mockResolvedValue([mockLinkedOrg])
 
     await linkedOrganisationsController.handler(mockRequest, mockH)
 
@@ -62,7 +64,7 @@ describe('linked-organisations controller', () => {
 
   test('Should pass search term as query param to backend', async () => {
     mockRequest.query = { search: ' acme ' }
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue([mockLinkedOrg])
+    mockFetchJsonFromBackend.mockResolvedValue([mockLinkedOrg])
 
     await linkedOrganisationsController.handler(mockRequest, mockH)
 
@@ -81,7 +83,7 @@ describe('linked-organisations controller', () => {
 
   test('Should fetch all when search term is empty', async () => {
     mockRequest.query = { search: '  ' }
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue([])
+    mockFetchJsonFromBackend.mockResolvedValue([])
 
     await linkedOrganisationsController.handler(mockRequest, mockH)
 
@@ -92,7 +94,7 @@ describe('linked-organisations controller', () => {
   })
 
   test('Should handle backend returning non-array', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({})
+    mockFetchJsonFromBackend.mockResolvedValue({})
 
     await linkedOrganisationsController.handler(mockRequest, mockH)
 
@@ -106,7 +108,7 @@ describe('linked-organisations controller', () => {
 
   test('Should display error message from session and clear it', async () => {
     mockRequest.yar.get.mockReturnValue('Download failed')
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue([])
+    mockFetchJsonFromBackend.mockResolvedValue([])
 
     await linkedOrganisationsController.handler(mockRequest, mockH)
 
@@ -122,7 +124,7 @@ describe('linked-organisations controller', () => {
   })
 
   test('Should pass pageTitle from route settings', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue([])
+    mockFetchJsonFromBackend.mockResolvedValue([])
 
     await linkedOrganisationsController.handler(mockRequest, mockH)
 
@@ -136,7 +138,7 @@ describe('linked-organisations controller', () => {
 
   test('Should encode special characters in search term', async () => {
     mockRequest.query = { search: 'Acme & Co' }
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue([])
+    mockFetchJsonFromBackend.mockResolvedValue([])
 
     await linkedOrganisationsController.handler(mockRequest, mockH)
 

--- a/src/server/routes/organisation/controller.get.integration.test.js
+++ b/src/server/routes/organisation/controller.get.integration.test.js
@@ -50,7 +50,7 @@ describe('organisation GET controller', () => {
 
   describe('When user is authenticated', () => {
     beforeEach(() => {
-      getUserSession.mockReturnValue(mockUserSession)
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
     })
 
     test('Should return OK and render organisation details', async () => {

--- a/src/server/routes/organisation/controller.post.test.js
+++ b/src/server/routes/organisation/controller.post.test.js
@@ -53,7 +53,7 @@ describe('organisation POST controller', () => {
 
   describe('When user is authenticated', () => {
     beforeEach(() => {
-      getUserSession.mockReturnValue(mockUserSession)
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
       mswServer.use(
         http.get(`${backendUrl}/v1/organisations/:id`, () =>
           HttpResponse.json({ id: 'stub', companyDetails: { name: 'Stub' } })

--- a/src/server/routes/organisations/get.integration.test.js
+++ b/src/server/routes/organisations/get.integration.test.js
@@ -80,7 +80,7 @@ describe('GET /organisations', () => {
 
   describe('When user is authenticated', () => {
     beforeEach(() => {
-      getUserSession.mockReturnValue(mockUserSession)
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
     })
 
     const loadPage = async (queryParams = new URLSearchParams()) => {

--- a/src/server/routes/organisations/post.integration.test.js
+++ b/src/server/routes/organisations/post.integration.test.js
@@ -67,7 +67,7 @@ describe('POST /organisations', () => {
   }
 
   const getCrumb = async () => {
-    getUserSession.mockReturnValue(mockUserSession)
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
     mswServer.use(
       http.get(`${config.get('eprBackendUrl')}/v1/organisations`, () =>
         HttpResponse.json(envelope([]))
@@ -101,7 +101,7 @@ describe('POST /organisations', () => {
     let crumb
 
     beforeEach(async () => {
-      getUserSession.mockReturnValue(mockUserSession)
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
       crumb = await getCrumb()
     })
 

--- a/src/server/routes/ors-upload/controller.download.test.js
+++ b/src/server/routes/ors-upload/controller.download.test.js
@@ -8,6 +8,8 @@ vi.mock('#server/common/helpers/fetch-json-from-backend.js', () => ({
   fetchJsonFromBackend: vi.fn()
 }))
 
+const mockFetchJsonFromBackend = vi.mocked(fetchJsonFromBackend)
+
 describe('orsDownloadController', () => {
   let mockRequest
   let mockH
@@ -33,7 +35,7 @@ describe('orsDownloadController', () => {
   })
 
   test('Should fetch all ORS rows from the backend', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({ rows: [] })
+    mockFetchJsonFromBackend.mockResolvedValue({ rows: [] })
 
     await orsDownloadController.handler(mockRequest, mockH)
 
@@ -44,7 +46,7 @@ describe('orsDownloadController', () => {
   })
 
   test('Should generate CSV with correct headers and row data', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       rows: [
         {
           orgId: 500001,
@@ -79,7 +81,7 @@ describe('orsDownloadController', () => {
   })
 
   test('Should preserve UTF-8 coordinate symbols in the CSV payload', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       rows: [
         {
           orgId: 500001,
@@ -99,7 +101,7 @@ describe('orsDownloadController', () => {
   })
 
   test('Should handle legacy array payloads', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue([
+    mockFetchJsonFromBackend.mockResolvedValue([
       {
         orgId: 500001,
         orsId: '001'
@@ -114,7 +116,7 @@ describe('orsDownloadController', () => {
   })
 
   test('Should handle empty backend rows', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({ rows: [] })
+    mockFetchJsonFromBackend.mockResolvedValue({ rows: [] })
 
     await orsDownloadController.handler(mockRequest, mockH)
 
@@ -125,7 +127,7 @@ describe('orsDownloadController', () => {
   })
 
   test('Should handle missing rows payload', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({})
+    mockFetchJsonFromBackend.mockResolvedValue({})
 
     await orsDownloadController.handler(mockRequest, mockH)
 
@@ -134,7 +136,7 @@ describe('orsDownloadController', () => {
   })
 
   test('Should return blank values for null and invalid dates', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       rows: [
         {
           orgId: null,
@@ -163,7 +165,7 @@ describe('orsDownloadController', () => {
   })
 
   test('Should prefix formula-like string values', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       rows: [
         {
           orgId: '=SUM(A1)',
@@ -185,7 +187,7 @@ describe('orsDownloadController', () => {
   })
 
   test('Should set correct Content-Type and Content-Disposition headers', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({ rows: [] })
+    mockFetchJsonFromBackend.mockResolvedValue({ rows: [] })
 
     await orsDownloadController.handler(mockRequest, mockH)
 
@@ -200,9 +202,7 @@ describe('orsDownloadController', () => {
   })
 
   test('Should redirect with default error message on fetch failure', async () => {
-    vi.mocked(fetchJsonFromBackend).mockRejectedValue(
-      new Error('Network error')
-    )
+    mockFetchJsonFromBackend.mockRejectedValue(new Error('Network error'))
 
     const result = await orsDownloadController.handler(mockRequest, mockH)
 
@@ -216,7 +216,7 @@ describe('orsDownloadController', () => {
 
   test('Should use backend error message when available', async () => {
     const error = Boom.badRequest('Custom backend error message')
-    vi.mocked(fetchJsonFromBackend).mockRejectedValue(error)
+    mockFetchJsonFromBackend.mockRejectedValue(error)
 
     await orsDownloadController.handler(mockRequest, mockH)
 

--- a/src/server/routes/ors-upload/controller.get.test.js
+++ b/src/server/routes/ors-upload/controller.get.test.js
@@ -15,6 +15,8 @@ vi.mock('#server/common/helpers/logging/logger.js', () => ({
   }))
 }))
 
+const mockFetchJsonFromBackend = vi.mocked(fetchJsonFromBackend)
+
 describe('orsUploadGetController', () => {
   let mockRequest
   let mockH
@@ -38,7 +40,7 @@ describe('orsUploadGetController', () => {
   })
 
   test('initiates ORS upload and renders upload page', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       uploadUrl: 'http://cdp-uploader/upload-123'
     })
 
@@ -64,7 +66,7 @@ describe('orsUploadGetController', () => {
 
   test('handles upload initiation failure and renders error message', async () => {
     const error = new Error('Backend unavailable')
-    vi.mocked(fetchJsonFromBackend).mockRejectedValue(error)
+    mockFetchJsonFromBackend.mockRejectedValue(error)
 
     await orsUploadGetController.handler(mockRequest, mockH)
 
@@ -110,7 +112,7 @@ describe('orsUploadGetController', () => {
       }
     }
 
-    vi.mocked(fetchJsonFromBackend).mockRejectedValue(error)
+    mockFetchJsonFromBackend.mockRejectedValue(error)
 
     await orsUploadGetController.handler(mockRequest, mockH)
 

--- a/src/server/routes/ors-upload/controller.list.get.test.js
+++ b/src/server/routes/ors-upload/controller.list.get.test.js
@@ -15,6 +15,8 @@ vi.mock('#server/common/helpers/logging/logger.js', () => ({
   }))
 }))
 
+const mockFetchJsonFromBackend = vi.mocked(fetchJsonFromBackend)
+
 describe('orsListGetController', () => {
   let mockRequest
   let mockH
@@ -39,7 +41,7 @@ describe('orsListGetController', () => {
   })
 
   test('loads ORS data and maps null values for display', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       rows: [
         {
           orsId: '001',
@@ -165,7 +167,7 @@ describe('orsListGetController', () => {
       registrationNumber: ' REG-123 '
     }
 
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       rows: [{ orsId: '003', registrationNumber: 'REG-123' }],
       pagination: {
         page: 2,
@@ -210,7 +212,7 @@ describe('orsListGetController', () => {
   })
 
   test('returns empty rows when backend returns no values', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue(undefined)
+    mockFetchJsonFromBackend.mockResolvedValue(undefined)
 
     await orsListGetController.handler(mockRequest, mockH)
 
@@ -226,7 +228,7 @@ describe('orsListGetController', () => {
   })
 
   test('returns empty rows when backend returns non-array payload', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue(null)
+    mockFetchJsonFromBackend.mockResolvedValue(null)
 
     await orsListGetController.handler(mockRequest, mockH)
 
@@ -247,7 +249,7 @@ describe('orsListGetController', () => {
       pageSize: 'invalid'
     }
 
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue([
+    mockFetchJsonFromBackend.mockResolvedValue([
       {
         orsId: '010'
       }
@@ -289,7 +291,7 @@ describe('orsListGetController', () => {
   })
 
   test('returns empty rows for non-array rows payload in object response', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       rows: {},
       pagination: {
         page: 1,
@@ -315,7 +317,7 @@ describe('orsListGetController', () => {
   })
 
   test('supports legacy empty array payloads with zero total pages', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue([])
+    mockFetchJsonFromBackend.mockResolvedValue([])
 
     await orsListGetController.handler(mockRequest, mockH)
 
@@ -336,7 +338,7 @@ describe('orsListGetController', () => {
       pageSize: '2'
     }
 
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       rows: [{ orsId: '002' }],
       pagination: {
         page: 2,
@@ -408,7 +410,7 @@ describe('orsListGetController', () => {
   })
 
   test('builds numbered pagination items for each page', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       rows: [{ orsId: '001' }],
       pagination: {
         page: 1,
@@ -477,7 +479,7 @@ describe('orsListGetController', () => {
       pageSize: '10'
     }
 
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       rows: [{ orsId: '006' }],
       pagination: {
         page: 6,
@@ -565,7 +567,7 @@ describe('orsListGetController', () => {
       pageSize: '2'
     }
 
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       rows: [{ orsId: '003' }],
       pagination: {
         page: 3,
@@ -630,7 +632,7 @@ describe('orsListGetController', () => {
 
   test('handles backend failure and renders error message', async () => {
     const error = new Error('Backend unavailable')
-    vi.mocked(fetchJsonFromBackend).mockRejectedValue(error)
+    mockFetchJsonFromBackend.mockRejectedValue(error)
 
     await orsListGetController.handler(mockRequest, mockH)
 

--- a/src/server/routes/ors-upload/controller.list.get.test.js
+++ b/src/server/routes/ors-upload/controller.list.get.test.js
@@ -39,7 +39,7 @@ describe('orsListGetController', () => {
   })
 
   test('loads ORS data and maps null values for display', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       rows: [
         {
           orsId: '001',
@@ -165,7 +165,7 @@ describe('orsListGetController', () => {
       registrationNumber: ' REG-123 '
     }
 
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       rows: [{ orsId: '003', registrationNumber: 'REG-123' }],
       pagination: {
         page: 2,
@@ -210,7 +210,7 @@ describe('orsListGetController', () => {
   })
 
   test('returns empty rows when backend returns no values', async () => {
-    fetchJsonFromBackend.mockResolvedValue(undefined)
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue(undefined)
 
     await orsListGetController.handler(mockRequest, mockH)
 
@@ -226,7 +226,7 @@ describe('orsListGetController', () => {
   })
 
   test('returns empty rows when backend returns non-array payload', async () => {
-    fetchJsonFromBackend.mockResolvedValue(null)
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue(null)
 
     await orsListGetController.handler(mockRequest, mockH)
 
@@ -247,7 +247,7 @@ describe('orsListGetController', () => {
       pageSize: 'invalid'
     }
 
-    fetchJsonFromBackend.mockResolvedValue([
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue([
       {
         orsId: '010'
       }
@@ -289,7 +289,7 @@ describe('orsListGetController', () => {
   })
 
   test('returns empty rows for non-array rows payload in object response', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       rows: {},
       pagination: {
         page: 1,
@@ -315,7 +315,7 @@ describe('orsListGetController', () => {
   })
 
   test('supports legacy empty array payloads with zero total pages', async () => {
-    fetchJsonFromBackend.mockResolvedValue([])
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue([])
 
     await orsListGetController.handler(mockRequest, mockH)
 
@@ -336,7 +336,7 @@ describe('orsListGetController', () => {
       pageSize: '2'
     }
 
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       rows: [{ orsId: '002' }],
       pagination: {
         page: 2,
@@ -408,7 +408,7 @@ describe('orsListGetController', () => {
   })
 
   test('builds numbered pagination items for each page', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       rows: [{ orsId: '001' }],
       pagination: {
         page: 1,
@@ -477,7 +477,7 @@ describe('orsListGetController', () => {
       pageSize: '10'
     }
 
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       rows: [{ orsId: '006' }],
       pagination: {
         page: 6,
@@ -565,7 +565,7 @@ describe('orsListGetController', () => {
       pageSize: '2'
     }
 
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       rows: [{ orsId: '003' }],
       pagination: {
         page: 3,
@@ -630,7 +630,7 @@ describe('orsListGetController', () => {
 
   test('handles backend failure and renders error message', async () => {
     const error = new Error('Backend unavailable')
-    fetchJsonFromBackend.mockRejectedValue(error)
+    vi.mocked(fetchJsonFromBackend).mockRejectedValue(error)
 
     await orsListGetController.handler(mockRequest, mockH)
 

--- a/src/server/routes/ors-upload/controller.status.get.test.js
+++ b/src/server/routes/ors-upload/controller.status.get.test.js
@@ -43,7 +43,7 @@ describe('orsUploadStatusGetController', () => {
   })
 
   test('renders processing state with polling', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       status: 'processing',
       files: []
     })
@@ -85,7 +85,7 @@ describe('orsUploadStatusGetController', () => {
   })
 
   test('renders completed state with file summary', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       status: 'completed',
       files: [
         {
@@ -141,7 +141,7 @@ describe('orsUploadStatusGetController', () => {
   })
 
   test('renders status with empty files when backend response has no files array', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       status: 'completed'
     })
 
@@ -162,11 +162,13 @@ describe('orsUploadStatusGetController', () => {
   })
 
   test('handles status fetch failure and renders failed view model', async () => {
-    const error = new Error('Request failed')
+    const error = /** @type {Error & { output: { statusCode: number } }} */ (
+      new Error('Request failed')
+    )
     error.output = {
       statusCode: 500
     }
-    fetchJsonFromBackend.mockRejectedValue(error)
+    vi.mocked(fetchJsonFromBackend).mockRejectedValue(error)
 
     await orsUploadStatusGetController.handler(mockRequest, mockH)
 
@@ -203,7 +205,7 @@ describe('orsUploadStatusGetController', () => {
 
   test('handles status fetch failure with missing message and status code', async () => {
     const error = {}
-    fetchJsonFromBackend.mockRejectedValue(error)
+    vi.mocked(fetchJsonFromBackend).mockRejectedValue(error)
 
     await orsUploadStatusGetController.handler(mockRequest, mockH)
 

--- a/src/server/routes/ors-upload/controller.status.get.test.js
+++ b/src/server/routes/ors-upload/controller.status.get.test.js
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
 import { orsUploadStatusGetController } from './controller.status.get.js'
+import { boomError } from '#server/common/test-helpers/fixtures.js'
 
 vi.mock('#server/common/helpers/fetch-json-from-backend.js', () => ({
   fetchJsonFromBackend: vi.fn()
@@ -162,12 +163,7 @@ describe('orsUploadStatusGetController', () => {
   })
 
   test('handles status fetch failure and renders failed view model', async () => {
-    const error = /** @type {Error & { output: { statusCode: number } }} */ (
-      new Error('Request failed')
-    )
-    error.output = {
-      statusCode: 500
-    }
+    const error = boomError({ message: 'Request failed', statusCode: 500 })
     vi.mocked(fetchJsonFromBackend).mockRejectedValue(error)
 
     await orsUploadStatusGetController.handler(mockRequest, mockH)

--- a/src/server/routes/ors-upload/controller.status.get.test.js
+++ b/src/server/routes/ors-upload/controller.status.get.test.js
@@ -18,6 +18,8 @@ vi.mock('#server/common/helpers/logging/logger.js', () => ({
   }))
 }))
 
+const mockFetchJsonFromBackend = vi.mocked(fetchJsonFromBackend)
+
 describe('orsUploadStatusGetController', () => {
   let mockRequest
   let mockH
@@ -44,7 +46,7 @@ describe('orsUploadStatusGetController', () => {
   })
 
   test('renders processing state with polling', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       status: 'processing',
       files: []
     })
@@ -86,7 +88,7 @@ describe('orsUploadStatusGetController', () => {
   })
 
   test('renders completed state with file summary', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       status: 'completed',
       files: [
         {
@@ -142,7 +144,7 @@ describe('orsUploadStatusGetController', () => {
   })
 
   test('renders status with empty files when backend response has no files array', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       status: 'completed'
     })
 
@@ -164,7 +166,7 @@ describe('orsUploadStatusGetController', () => {
 
   test('handles status fetch failure and renders failed view model', async () => {
     const error = boomError({ message: 'Request failed', statusCode: 500 })
-    vi.mocked(fetchJsonFromBackend).mockRejectedValue(error)
+    mockFetchJsonFromBackend.mockRejectedValue(error)
 
     await orsUploadStatusGetController.handler(mockRequest, mockH)
 
@@ -201,7 +203,7 @@ describe('orsUploadStatusGetController', () => {
 
   test('handles status fetch failure with missing message and status code', async () => {
     const error = {}
-    vi.mocked(fetchJsonFromBackend).mockRejectedValue(error)
+    mockFetchJsonFromBackend.mockRejectedValue(error)
 
     await orsUploadStatusGetController.handler(mockRequest, mockH)
 

--- a/src/server/routes/prn-activity/controller.download.test.js
+++ b/src/server/routes/prn-activity/controller.download.test.js
@@ -26,6 +26,8 @@ const mockPrn = {
   wasteProcessingType: 'reprocessor'
 }
 
+const mockFetchJsonFromBackend = vi.mocked(fetchJsonFromBackend)
+
 describe('prn-activity download controller', () => {
   let mockRequest
   let mockH
@@ -51,7 +53,7 @@ describe('prn-activity download controller', () => {
   })
 
   test('Should fetch PRNs with correct statuses', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [],
       hasMore: false
     })
@@ -65,7 +67,7 @@ describe('prn-activity download controller', () => {
   })
 
   test('Should generate CSV with correct headers and data', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [mockPrn],
       hasMore: false
     })
@@ -86,7 +88,7 @@ describe('prn-activity download controller', () => {
   })
 
   test('Should set correct Content-Type and Content-Disposition headers', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [mockPrn],
       hasMore: false
     })
@@ -101,7 +103,7 @@ describe('prn-activity download controller', () => {
   })
 
   test('Should handle empty items', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [],
       hasMore: false
     })
@@ -115,7 +117,7 @@ describe('prn-activity download controller', () => {
   })
 
   test('Should handle null data from backend', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue(null)
+    mockFetchJsonFromBackend.mockResolvedValue(null)
 
     await prnActivityDownloadController.handler(mockRequest, mockH)
 
@@ -125,7 +127,7 @@ describe('prn-activity download controller', () => {
   })
 
   test('Should map isDecemberWaste to Yes/No', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [
         { ...mockPrn, isDecemberWaste: true },
         { ...mockPrn, prnNumber: 'PRN-002', isDecemberWaste: false }
@@ -142,7 +144,7 @@ describe('prn-activity download controller', () => {
   })
 
   test('Should use tradingName over name for issuedToOrganisation', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [
         {
           ...mockPrn,
@@ -163,7 +165,7 @@ describe('prn-activity download controller', () => {
   })
 
   test('Should handle null/undefined optional fields in CSV', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [
         {
           status: 'awaiting_authorisation',
@@ -194,7 +196,7 @@ describe('prn-activity download controller', () => {
   })
 
   test('Should return empty string when org has no name or tradingName', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [
         {
           ...mockPrn,
@@ -212,7 +214,7 @@ describe('prn-activity download controller', () => {
   })
 
   test('Should use name when tradingName is empty string', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [
         {
           ...mockPrn,
@@ -229,7 +231,7 @@ describe('prn-activity download controller', () => {
   })
 
   test('Should prefix fields starting with formula-injection characters', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [{ ...mockPrn, accreditationNumber: '=SUM(A1)' }],
       hasMore: false
     })
@@ -241,9 +243,7 @@ describe('prn-activity download controller', () => {
   })
 
   test('Should redirect with error message on fetch failure', async () => {
-    vi.mocked(fetchJsonFromBackend).mockRejectedValue(
-      new Error('Network error')
-    )
+    mockFetchJsonFromBackend.mockRejectedValue(new Error('Network error'))
 
     const result = await prnActivityDownloadController.handler(
       mockRequest,
@@ -260,7 +260,7 @@ describe('prn-activity download controller', () => {
 
   test('Should use error message from backend when available', async () => {
     const error = Boom.badRequest('Custom backend error message')
-    vi.mocked(fetchJsonFromBackend).mockRejectedValue(error)
+    mockFetchJsonFromBackend.mockRejectedValue(error)
 
     await prnActivityDownloadController.handler(mockRequest, mockH)
 
@@ -271,7 +271,7 @@ describe('prn-activity download controller', () => {
   })
 
   test('Should fetch all pages when hasMore is true', async () => {
-    vi.mocked(fetchJsonFromBackend)
+    mockFetchJsonFromBackend
       .mockResolvedValueOnce({
         items: [{ ...mockPrn, prnNumber: 'PRN-001' }],
         hasMore: true,

--- a/src/server/routes/prn-activity/controller.scoped-download.test.js
+++ b/src/server/routes/prn-activity/controller.scoped-download.test.js
@@ -24,6 +24,8 @@ const mockPrn = {
   wasteProcessingType: 'reprocessor'
 }
 
+const mockFetchJsonFromBackend = vi.mocked(fetchJsonFromBackend)
+
 describe('prn-activity scoped download controller', () => {
   let request
   let h
@@ -49,7 +51,7 @@ describe('prn-activity scoped download controller', () => {
   })
 
   test('Should fetch PRNs filtered by the accreditation id', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [],
       hasMore: false
     })
@@ -63,7 +65,7 @@ describe('prn-activity scoped download controller', () => {
   })
 
   test('Should generate CSV and set an accreditation-scoped filename', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [mockPrn],
       hasMore: false
     })
@@ -83,9 +85,7 @@ describe('prn-activity scoped download controller', () => {
   })
 
   test('Should redirect to the registration overview with a flash error on failure', async () => {
-    vi.mocked(fetchJsonFromBackend).mockRejectedValue(
-      new Error('Network error')
-    )
+    mockFetchJsonFromBackend.mockRejectedValue(new Error('Network error'))
 
     const result = await prnActivityScopedDownloadController.handler(request, h)
 
@@ -100,7 +100,7 @@ describe('prn-activity scoped download controller', () => {
   })
 
   test('Should use the backend error message when available', async () => {
-    vi.mocked(fetchJsonFromBackend).mockRejectedValue(
+    mockFetchJsonFromBackend.mockRejectedValue(
       Boom.badRequest('Custom backend error message')
     )
 

--- a/src/server/routes/prn-activity/controller.test.js
+++ b/src/server/routes/prn-activity/controller.test.js
@@ -35,7 +35,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should fetch PRNs with correct statuses', async () => {
-    fetchJsonFromBackend.mockResolvedValue({ items: [] })
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({ items: [] })
 
     await prnActivityController.handler(mockRequest, mockH)
 
@@ -46,7 +46,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should render view with pageTitle and mapped PRNs', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       items: [
         {
           prnNumber: 'PRN-001',
@@ -89,7 +89,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should map isDecemberWaste false to No', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       items: [
         {
           prnNumber: 'PRN-001',
@@ -107,7 +107,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should handle null/undefined optional fields', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       items: [
         {
           status: 'awaiting_authorisation',
@@ -132,7 +132,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should handle empty items array', async () => {
-    fetchJsonFromBackend.mockResolvedValue({ items: [] })
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({ items: [] })
 
     await prnActivityController.handler(mockRequest, mockH)
 
@@ -146,7 +146,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should handle null data from backend', async () => {
-    fetchJsonFromBackend.mockResolvedValue(null)
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue(null)
 
     await prnActivityController.handler(mockRequest, mockH)
 
@@ -155,7 +155,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should use tradingName over name for issuedToOrganisation', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       items: [
         {
           status: 'accepted',
@@ -175,7 +175,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should use name when tradingName is empty string', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       items: [
         {
           status: 'accepted',
@@ -192,7 +192,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should use name when tradingName is not present', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       items: [
         {
           status: 'accepted',
@@ -209,7 +209,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should return empty string when org has no name or tradingName', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       items: [
         {
           status: 'accepted',
@@ -227,7 +227,7 @@ describe('prn-activity controller', () => {
 
   test('Should display error message from session and clear it', async () => {
     mockRequest.yar.get.mockReturnValue('Download failed')
-    fetchJsonFromBackend.mockResolvedValue({ items: [] })
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({ items: [] })
 
     await prnActivityController.handler(mockRequest, mockH)
 
@@ -243,7 +243,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should return empty string when issuedToOrganisation is null', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       items: [
         {
           status: 'accepted',
@@ -261,7 +261,7 @@ describe('prn-activity controller', () => {
 
   test('Should pass cursor to backend when provided in query', async () => {
     mockRequest.query.cursor = 'abc123'
-    fetchJsonFromBackend.mockResolvedValue({ items: [] })
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({ items: [] })
 
     await prnActivityController.handler(mockRequest, mockH)
 
@@ -272,7 +272,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should include next pagination link when hasMore is true', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       items: [{ status: 'accepted', tonnage: 10 }],
       hasMore: true,
       nextCursor: 'cursor-xyz'
@@ -289,7 +289,7 @@ describe('prn-activity controller', () => {
   test('Should include previous pagination link when cursor is provided', async () => {
     mockRequest.query.cursor = 'abc123'
     mockRequest.query.page = '2'
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       items: [{ status: 'accepted', tonnage: 10 }],
       hasMore: false
     })
@@ -304,7 +304,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should not include pagination links on first page with no more results', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       items: [{ status: 'accepted', tonnage: 10 }],
       hasMore: false
     })

--- a/src/server/routes/prn-activity/controller.test.js
+++ b/src/server/routes/prn-activity/controller.test.js
@@ -9,6 +9,8 @@ vi.mock('#server/common/helpers/fetch-json-from-backend.js', () => ({
 const expectedStatuses =
   'awaiting_authorisation,awaiting_acceptance,accepted,awaiting_cancellation,cancelled,deleted'
 
+const mockFetchJsonFromBackend = vi.mocked(fetchJsonFromBackend)
+
 describe('prn-activity controller', () => {
   let mockRequest
   let mockH
@@ -35,7 +37,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should fetch PRNs with correct statuses', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({ items: [] })
+    mockFetchJsonFromBackend.mockResolvedValue({ items: [] })
 
     await prnActivityController.handler(mockRequest, mockH)
 
@@ -46,7 +48,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should render view with pageTitle and mapped PRNs', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [
         {
           prnNumber: 'PRN-001',
@@ -89,7 +91,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should map isDecemberWaste false to No', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [
         {
           prnNumber: 'PRN-001',
@@ -107,7 +109,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should handle null/undefined optional fields', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [
         {
           status: 'awaiting_authorisation',
@@ -132,7 +134,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should handle empty items array', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({ items: [] })
+    mockFetchJsonFromBackend.mockResolvedValue({ items: [] })
 
     await prnActivityController.handler(mockRequest, mockH)
 
@@ -146,7 +148,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should handle null data from backend', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue(null)
+    mockFetchJsonFromBackend.mockResolvedValue(null)
 
     await prnActivityController.handler(mockRequest, mockH)
 
@@ -155,7 +157,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should use tradingName over name for issuedToOrganisation', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [
         {
           status: 'accepted',
@@ -175,7 +177,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should use name when tradingName is empty string', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [
         {
           status: 'accepted',
@@ -192,7 +194,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should use name when tradingName is not present', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [
         {
           status: 'accepted',
@@ -209,7 +211,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should return empty string when org has no name or tradingName', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [
         {
           status: 'accepted',
@@ -227,7 +229,7 @@ describe('prn-activity controller', () => {
 
   test('Should display error message from session and clear it', async () => {
     mockRequest.yar.get.mockReturnValue('Download failed')
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({ items: [] })
+    mockFetchJsonFromBackend.mockResolvedValue({ items: [] })
 
     await prnActivityController.handler(mockRequest, mockH)
 
@@ -243,7 +245,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should return empty string when issuedToOrganisation is null', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [
         {
           status: 'accepted',
@@ -261,7 +263,7 @@ describe('prn-activity controller', () => {
 
   test('Should pass cursor to backend when provided in query', async () => {
     mockRequest.query.cursor = 'abc123'
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({ items: [] })
+    mockFetchJsonFromBackend.mockResolvedValue({ items: [] })
 
     await prnActivityController.handler(mockRequest, mockH)
 
@@ -272,7 +274,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should include next pagination link when hasMore is true', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [{ status: 'accepted', tonnage: 10 }],
       hasMore: true,
       nextCursor: 'cursor-xyz'
@@ -289,7 +291,7 @@ describe('prn-activity controller', () => {
   test('Should include previous pagination link when cursor is provided', async () => {
     mockRequest.query.cursor = 'abc123'
     mockRequest.query.page = '2'
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [{ status: 'accepted', tonnage: 10 }],
       hasMore: false
     })
@@ -304,7 +306,7 @@ describe('prn-activity controller', () => {
   })
 
   test('Should not include pagination links on first page with no more results', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       items: [{ status: 'accepted', tonnage: 10 }],
       hasMore: false
     })

--- a/src/server/routes/prn-tonnage/controller.post.test.js
+++ b/src/server/routes/prn-tonnage/controller.post.test.js
@@ -7,6 +7,8 @@ vi.mock('#server/common/helpers/fetch-json-from-backend.js', () => ({
   fetchJsonFromBackend: vi.fn()
 }))
 
+const mockFetchJsonFromBackend = vi.mocked(fetchJsonFromBackend)
+
 describe('prn-tonnage POST controller', () => {
   let mockRequest
   let mockH
@@ -32,7 +34,7 @@ describe('prn-tonnage POST controller', () => {
   })
 
   test('Should generate CSV with correct headers and formatting', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-02-20T14:30:00.000Z',
       rows: [
         {
@@ -77,7 +79,7 @@ describe('prn-tonnage POST controller', () => {
   })
 
   test('Should handle empty data rows', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-02-20T12:00:00.000Z',
       rows: []
     })
@@ -93,9 +95,7 @@ describe('prn-tonnage POST controller', () => {
   })
 
   test('Should redirect with default error message on failure', async () => {
-    vi.mocked(fetchJsonFromBackend).mockRejectedValue(
-      new Error('Network error')
-    )
+    mockFetchJsonFromBackend.mockRejectedValue(new Error('Network error'))
 
     const result = await prnTonnagePostController.handler(mockRequest, mockH)
 
@@ -109,7 +109,7 @@ describe('prn-tonnage POST controller', () => {
 
   test('Should use error message from backend when available', async () => {
     const error = Boom.badRequest('Custom backend error message')
-    vi.mocked(fetchJsonFromBackend).mockRejectedValue(error)
+    mockFetchJsonFromBackend.mockRejectedValue(error)
 
     await prnTonnagePostController.handler(mockRequest, mockH)
 

--- a/src/server/routes/prn-tonnage/controller.results.get.test.js
+++ b/src/server/routes/prn-tonnage/controller.results.get.test.js
@@ -6,6 +6,8 @@ vi.mock('#server/common/helpers/fetch-json-from-backend.js', () => ({
   fetchJsonFromBackend: vi.fn()
 }))
 
+const mockFetchJsonFromBackend = vi.mocked(fetchJsonFromBackend)
+
 describe('prn-tonnage results GET controller', () => {
   let mockRequest
   let mockH
@@ -31,7 +33,7 @@ describe('prn-tonnage results GET controller', () => {
   })
 
   test('Should fetch PRN tonnage data from backend and render results page', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-02-20T12:00:00.000Z',
       rows: [
         {
@@ -79,7 +81,7 @@ describe('prn-tonnage results GET controller', () => {
 
   test('Should display error message from session and clear it', async () => {
     mockRequest.yar.get.mockReturnValue('Download failed')
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-02-20T12:00:00.000Z',
       rows: []
     })
@@ -98,7 +100,7 @@ describe('prn-tonnage results GET controller', () => {
   })
 
   test('Should keep unknown values and blank tonnage band for missing band', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-02-20T12:00:00.000Z',
       rows: [
         {

--- a/src/server/routes/prn-tonnage/controller.results.get.test.js
+++ b/src/server/routes/prn-tonnage/controller.results.get.test.js
@@ -31,7 +31,7 @@ describe('prn-tonnage results GET controller', () => {
   })
 
   test('Should fetch PRN tonnage data from backend and render results page', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       generatedAt: '2026-02-20T12:00:00.000Z',
       rows: [
         {
@@ -79,7 +79,7 @@ describe('prn-tonnage results GET controller', () => {
 
   test('Should display error message from session and clear it', async () => {
     mockRequest.yar.get.mockReturnValue('Download failed')
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       generatedAt: '2026-02-20T12:00:00.000Z',
       rows: []
     })
@@ -98,7 +98,7 @@ describe('prn-tonnage results GET controller', () => {
   })
 
   test('Should keep unknown values and blank tonnage band for missing band', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       generatedAt: '2026-02-20T12:00:00.000Z',
       rows: [
         {

--- a/src/server/routes/report-submissions/controller.post.test.js
+++ b/src/server/routes/report-submissions/controller.post.test.js
@@ -6,10 +6,7 @@ vi.mock('#server/common/helpers/fetch-json-from-backend.js', () => ({
   fetchJsonFromBackend: vi.fn()
 }))
 
-const mockFetchJsonFromBackend =
-  /** @type {import('vitest').MockedFunction<typeof fetchJsonFromBackend>} */ (
-    fetchJsonFromBackend
-  )
+const mockFetchJsonFromBackend = vi.mocked(fetchJsonFromBackend)
 
 const { mockLoggerError } = vi.hoisted(() => ({ mockLoggerError: vi.fn() }))
 vi.mock('#server/common/helpers/logging/logger.js', () => ({

--- a/src/server/routes/summary-log/controller.get.test.js
+++ b/src/server/routes/summary-log/controller.get.test.js
@@ -78,7 +78,7 @@ describe('summaryLogUploadsReportGetController', () => {
       generatedAt: '2026-02-06T14:30:00.000Z'
     }
 
-    fetchJsonFromBackend.mockResolvedValue(mockData)
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue(mockData)
     mockRequest.yar.get.mockReturnValue(null)
 
     await summaryLogUploadsReportGetController.handler(mockRequest, mockH)
@@ -136,7 +136,7 @@ describe('summaryLogUploadsReportGetController', () => {
       generatedAt: '2026-01-15T10:00:00.000Z'
     }
 
-    fetchJsonFromBackend.mockResolvedValue(mockData)
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue(mockData)
     mockRequest.yar.get.mockReturnValue(null)
 
     await summaryLogUploadsReportGetController.handler(mockRequest, mockH)
@@ -155,7 +155,7 @@ describe('summaryLogUploadsReportGetController', () => {
     const fetchError = new Error('Network error')
     fetchError.stack = 'Error stack trace...'
 
-    fetchJsonFromBackend.mockRejectedValue(fetchError)
+    vi.mocked(fetchJsonFromBackend).mockRejectedValue(fetchError)
     mockRequest.yar.get.mockReturnValue(null)
 
     await summaryLogUploadsReportGetController.handler(mockRequest, mockH)

--- a/src/server/routes/summary-log/controller.get.test.js
+++ b/src/server/routes/summary-log/controller.get.test.js
@@ -31,6 +31,8 @@ vi.mock('#server/common/helpers/logging/logger.js', () => ({
   }))
 }))
 
+const mockFetchJsonFromBackend = vi.mocked(fetchJsonFromBackend)
+
 describe('summaryLogUploadsReportGetController', () => {
   let mockRequest
   let mockH
@@ -78,7 +80,7 @@ describe('summaryLogUploadsReportGetController', () => {
       generatedAt: '2026-02-06T14:30:00.000Z'
     }
 
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue(mockData)
+    mockFetchJsonFromBackend.mockResolvedValue(mockData)
     mockRequest.yar.get.mockReturnValue(null)
 
     await summaryLogUploadsReportGetController.handler(mockRequest, mockH)
@@ -136,7 +138,7 @@ describe('summaryLogUploadsReportGetController', () => {
       generatedAt: '2026-01-15T10:00:00.000Z'
     }
 
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue(mockData)
+    mockFetchJsonFromBackend.mockResolvedValue(mockData)
     mockRequest.yar.get.mockReturnValue(null)
 
     await summaryLogUploadsReportGetController.handler(mockRequest, mockH)
@@ -155,7 +157,7 @@ describe('summaryLogUploadsReportGetController', () => {
     const fetchError = new Error('Network error')
     fetchError.stack = 'Error stack trace...'
 
-    vi.mocked(fetchJsonFromBackend).mockRejectedValue(fetchError)
+    mockFetchJsonFromBackend.mockRejectedValue(fetchError)
     mockRequest.yar.get.mockReturnValue(null)
 
     await summaryLogUploadsReportGetController.handler(mockRequest, mockH)

--- a/src/server/routes/summary-log/controller.post.test.js
+++ b/src/server/routes/summary-log/controller.post.test.js
@@ -27,6 +27,8 @@ vi.mock('#server/common/helpers/logging/logger.js', () => ({
   }))
 }))
 
+const mockFetchJsonFromBackend = vi.mocked(fetchJsonFromBackend)
+
 describe('summaryLogUploadsReportPostController', () => {
   let mockRequest
   let mockH
@@ -96,7 +98,7 @@ describe('summaryLogUploadsReportPostController', () => {
       generatedAt: '2026-02-06T14:30:00.000Z'
     }
 
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue(mockData)
+    mockFetchJsonFromBackend.mockResolvedValue(mockData)
 
     await summaryLogUploadsReportPostController.handler(mockRequest, mockH)
 
@@ -133,7 +135,7 @@ describe('summaryLogUploadsReportPostController', () => {
     const fetchError = new Error('Network error')
     fetchError.stack = 'Error stack trace...'
 
-    vi.mocked(fetchJsonFromBackend).mockRejectedValue(fetchError)
+    mockFetchJsonFromBackend.mockRejectedValue(fetchError)
 
     await summaryLogUploadsReportPostController.handler(mockRequest, mockH)
 

--- a/src/server/routes/system-logs/controller.download.test.js
+++ b/src/server/routes/system-logs/controller.download.test.js
@@ -36,7 +36,7 @@ describe('system-log download controller', () => {
     const presignedUrl =
       'https://my-bucket.s3.eu-west-2.amazonaws.com/file.xlsx'
 
-    fetchRedirectFromBackend.mockResolvedValue(presignedUrl)
+    vi.mocked(fetchRedirectFromBackend).mockResolvedValue(presignedUrl)
     mswServer.use(
       http.get(
         presignedUrl,
@@ -59,7 +59,7 @@ describe('system-log download controller', () => {
       0x50, 0x4b, 0x03, 0x04, 0xff, 0xfe, 0x00, 0x80
     ])
 
-    fetchRedirectFromBackend.mockResolvedValue(presignedUrl)
+    vi.mocked(fetchRedirectFromBackend).mockResolvedValue(presignedUrl)
     mswServer.use(http.get(presignedUrl, () => new HttpResponse(binaryContent)))
 
     await systemLogDownloadController.handler(mockRequest, mockH)
@@ -81,7 +81,7 @@ describe('system-log download controller', () => {
     const presignedUrl = 'http://localhost:4566/bucket/file.xlsx'
     const binaryContent = new Uint8Array([0x50, 0x4b, 0x03, 0x04])
 
-    fetchRedirectFromBackend.mockResolvedValue(presignedUrl)
+    vi.mocked(fetchRedirectFromBackend).mockResolvedValue(presignedUrl)
     mswServer.use(http.get(presignedUrl, () => new HttpResponse(binaryContent)))
 
     await systemLogDownloadController.handler(mockRequest, mockH)
@@ -95,7 +95,7 @@ describe('system-log download controller', () => {
     const presignedUrl = 'http://floci:4566/bucket/file.xlsx'
     const binaryContent = new Uint8Array([0x50, 0x4b, 0x03, 0x04])
 
-    fetchRedirectFromBackend.mockResolvedValue(presignedUrl)
+    vi.mocked(fetchRedirectFromBackend).mockResolvedValue(presignedUrl)
     mswServer.use(http.get(presignedUrl, () => new HttpResponse(binaryContent)))
 
     await systemLogDownloadController.handler(mockRequest, mockH)
@@ -106,7 +106,7 @@ describe('system-log download controller', () => {
   })
 
   test('rejects invalid download URLs to prevent SSRF', async () => {
-    fetchRedirectFromBackend.mockResolvedValue(
+    vi.mocked(fetchRedirectFromBackend).mockResolvedValue(
       'https://evil-site.com/steal-data'
     )
 
@@ -119,7 +119,7 @@ describe('system-log download controller', () => {
     const presignedUrl =
       'https://my-bucket.s3.eu-west-2.amazonaws.com/file.xlsx'
 
-    fetchRedirectFromBackend.mockResolvedValue(presignedUrl)
+    vi.mocked(fetchRedirectFromBackend).mockResolvedValue(presignedUrl)
     mswServer.use(
       http.get(presignedUrl, () => new HttpResponse(null, { status: 500 }))
     )

--- a/src/server/routes/system-logs/download.integration.test.js
+++ b/src/server/routes/system-logs/download.integration.test.js
@@ -45,7 +45,7 @@ describe('GET /system-logs/download/{organisationId}/{registrationId}/{summaryLo
 
   describe('when user is authenticated', () => {
     beforeEach(() => {
-      getUserSession.mockReturnValue(mockUserSession)
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
     })
 
     test('streams binary file content from S3 via the backend pre-signed URL', async () => {

--- a/src/server/routes/tonnage-monitoring/controller.get.test.js
+++ b/src/server/routes/tonnage-monitoring/controller.get.test.js
@@ -6,6 +6,8 @@ vi.mock('#server/common/helpers/fetch-json-from-backend.js', () => ({
   fetchJsonFromBackend: vi.fn()
 }))
 
+const mockFetchJsonFromBackend = vi.mocked(fetchJsonFromBackend)
+
 describe('tonnage-monitoring GET controller', () => {
   let mockRequest
   let mockH
@@ -42,7 +44,7 @@ describe('tonnage-monitoring GET controller', () => {
       ]
     }))
 
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: mockMaterials,
       total: 2190
@@ -74,7 +76,7 @@ describe('tonnage-monitoring GET controller', () => {
   })
 
   test('Should format material names and types correctly', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [
         {
@@ -151,7 +153,7 @@ describe('tonnage-monitoring GET controller', () => {
   })
 
   test('Should format tonnage values to 2 decimal places', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [
         {
@@ -190,7 +192,7 @@ describe('tonnage-monitoring GET controller', () => {
   })
 
   test('Should handle empty materials array', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [],
       total: 0
@@ -213,7 +215,7 @@ describe('tonnage-monitoring GET controller', () => {
   test('Should display error message from session and clear it', async () => {
     mockRequest.yar.get.mockReturnValue('Download failed')
 
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [],
       total: 0
@@ -229,7 +231,7 @@ describe('tonnage-monitoring GET controller', () => {
   })
 
   test('Should throw error for unknown material', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [
         {
@@ -248,7 +250,7 @@ describe('tonnage-monitoring GET controller', () => {
   })
 
   test('Should include year column when multiple years are present', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [
         {
@@ -323,7 +325,7 @@ describe('tonnage-monitoring GET controller', () => {
   })
 
   test('Should handle materials with different month counts', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [
         {

--- a/src/server/routes/tonnage-monitoring/controller.post.test.js
+++ b/src/server/routes/tonnage-monitoring/controller.post.test.js
@@ -7,6 +7,8 @@ vi.mock('#server/common/helpers/fetch-json-from-backend.js', () => ({
   fetchJsonFromBackend: vi.fn()
 }))
 
+const mockFetchJsonFromBackend = vi.mocked(fetchJsonFromBackend)
+
 describe('tonnage-monitoring POST controller', () => {
   let mockRequest
   let mockH
@@ -32,7 +34,7 @@ describe('tonnage-monitoring POST controller', () => {
   })
 
   test('Should generate CSV with correct headers and formatting', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T14:30:00.000Z',
       materials: [
         {
@@ -90,7 +92,7 @@ describe('tonnage-monitoring POST controller', () => {
   })
 
   test('Should format material names to display names', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T09:00:00.000Z',
       materials: [
         {
@@ -123,7 +125,7 @@ describe('tonnage-monitoring POST controller', () => {
   })
 
   test('Should emit tonnage values as unquoted numbers', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [
         {
@@ -157,7 +159,7 @@ describe('tonnage-monitoring POST controller', () => {
   })
 
   test('Should format morning times correctly', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-06-15T09:05:00.000Z',
       materials: [],
       total: 0
@@ -170,7 +172,7 @@ describe('tonnage-monitoring POST controller', () => {
   })
 
   test('Should handle empty materials array', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [],
       total: 0
@@ -194,7 +196,7 @@ describe('tonnage-monitoring POST controller', () => {
   })
 
   test('Should include year column when multiple years present', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [
         {
@@ -222,7 +224,7 @@ describe('tonnage-monitoring POST controller', () => {
   })
 
   test('Should handle materials with different month counts', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [
         {
@@ -256,9 +258,7 @@ describe('tonnage-monitoring POST controller', () => {
   })
 
   test('Should redirect with error message on fetch failure', async () => {
-    vi.mocked(fetchJsonFromBackend).mockRejectedValue(
-      new Error('Network error')
-    )
+    mockFetchJsonFromBackend.mockRejectedValue(new Error('Network error'))
 
     const result = await tonnageMonitoringPostController.handler(
       mockRequest,
@@ -275,7 +275,7 @@ describe('tonnage-monitoring POST controller', () => {
 
   test('Should use error message from backend when available', async () => {
     const error = Boom.badRequest('Custom backend error message')
-    vi.mocked(fetchJsonFromBackend).mockRejectedValue(error)
+    mockFetchJsonFromBackend.mockRejectedValue(error)
 
     await tonnageMonitoringPostController.handler(mockRequest, mockH)
 

--- a/src/server/routes/waste-balance-availability/controller.get.test.js
+++ b/src/server/routes/waste-balance-availability/controller.get.test.js
@@ -31,7 +31,7 @@ describe('waste-balance-availability GET controller', () => {
   })
 
   test('Should fetch balance data from backend and render page', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [
         { material: 'aluminium', availableAmount: 1234.56 },
@@ -63,7 +63,7 @@ describe('waste-balance-availability GET controller', () => {
   })
 
   test('Should format material names to display names', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [
         { material: 'plastic', availableAmount: 100 },
@@ -88,7 +88,7 @@ describe('waste-balance-availability GET controller', () => {
   })
 
   test('Should format amount values to 2 decimal places', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [
         { material: 'wood', availableAmount: 1000 },
@@ -112,7 +112,7 @@ describe('waste-balance-availability GET controller', () => {
   })
 
   test('Should treat null availableAmount as zero', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [{ material: 'plastic', availableAmount: null }],
       total: null
@@ -130,7 +130,7 @@ describe('waste-balance-availability GET controller', () => {
   })
 
   test('Should throw for unknown material names', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [{ material: 'unknown_material', availableAmount: 100 }],
       total: 100
@@ -142,7 +142,7 @@ describe('waste-balance-availability GET controller', () => {
   })
 
   test('Should handle empty materials array', async () => {
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [],
       total: 0
@@ -165,7 +165,7 @@ describe('waste-balance-availability GET controller', () => {
   test('Should display error message from session and clear it', async () => {
     mockRequest.yar.get.mockReturnValue('Download failed')
 
-    fetchJsonFromBackend.mockResolvedValue({
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [],
       total: 0

--- a/src/server/routes/waste-balance-availability/controller.get.test.js
+++ b/src/server/routes/waste-balance-availability/controller.get.test.js
@@ -6,6 +6,8 @@ vi.mock('#server/common/helpers/fetch-json-from-backend.js', () => ({
   fetchJsonFromBackend: vi.fn()
 }))
 
+const mockFetchJsonFromBackend = vi.mocked(fetchJsonFromBackend)
+
 describe('waste-balance-availability GET controller', () => {
   let mockRequest
   let mockH
@@ -31,7 +33,7 @@ describe('waste-balance-availability GET controller', () => {
   })
 
   test('Should fetch balance data from backend and render page', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [
         { material: 'aluminium', availableAmount: 1234.56 },
@@ -63,7 +65,7 @@ describe('waste-balance-availability GET controller', () => {
   })
 
   test('Should format material names to display names', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [
         { material: 'plastic', availableAmount: 100 },
@@ -88,7 +90,7 @@ describe('waste-balance-availability GET controller', () => {
   })
 
   test('Should format amount values to 2 decimal places', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [
         { material: 'wood', availableAmount: 1000 },
@@ -112,7 +114,7 @@ describe('waste-balance-availability GET controller', () => {
   })
 
   test('Should treat null availableAmount as zero', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [{ material: 'plastic', availableAmount: null }],
       total: null
@@ -130,7 +132,7 @@ describe('waste-balance-availability GET controller', () => {
   })
 
   test('Should throw for unknown material names', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [{ material: 'unknown_material', availableAmount: 100 }],
       total: 100
@@ -142,7 +144,7 @@ describe('waste-balance-availability GET controller', () => {
   })
 
   test('Should handle empty materials array', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [],
       total: 0
@@ -165,7 +167,7 @@ describe('waste-balance-availability GET controller', () => {
   test('Should display error message from session and clear it', async () => {
     mockRequest.yar.get.mockReturnValue('Download failed')
 
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [],
       total: 0

--- a/src/server/routes/waste-balance-availability/controller.post.test.js
+++ b/src/server/routes/waste-balance-availability/controller.post.test.js
@@ -7,6 +7,8 @@ vi.mock('#server/common/helpers/fetch-json-from-backend.js', () => ({
   fetchJsonFromBackend: vi.fn()
 }))
 
+const mockFetchJsonFromBackend = vi.mocked(fetchJsonFromBackend)
+
 describe('waste-balance-availability POST controller', () => {
   let mockRequest
   let mockH
@@ -32,7 +34,7 @@ describe('waste-balance-availability POST controller', () => {
   })
 
   test('Should generate CSV with correct headers and formatting', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T14:30:00.000Z',
       materials: [
         { material: 'aluminium', availableAmount: 1234.56 },
@@ -70,7 +72,7 @@ describe('waste-balance-availability POST controller', () => {
   })
 
   test('Should format material names to display names', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T09:00:00.000Z',
       materials: [
         { material: 'plastic', availableAmount: 100 },
@@ -87,7 +89,7 @@ describe('waste-balance-availability POST controller', () => {
   })
 
   test('Should emit amount values as unquoted numbers', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [
         { material: 'wood', availableAmount: 1000 },
@@ -105,7 +107,7 @@ describe('waste-balance-availability POST controller', () => {
   })
 
   test('Should format morning times correctly', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-06-15T09:05:00.000Z',
       materials: [],
       total: 0
@@ -118,7 +120,7 @@ describe('waste-balance-availability POST controller', () => {
   })
 
   test('Should handle empty materials array', async () => {
-    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+    mockFetchJsonFromBackend.mockResolvedValue({
       generatedAt: '2026-01-29T12:00:00.000Z',
       materials: [],
       total: 0
@@ -141,9 +143,7 @@ describe('waste-balance-availability POST controller', () => {
   })
 
   test('Should redirect with error message on fetch failure', async () => {
-    vi.mocked(fetchJsonFromBackend).mockRejectedValue(
-      new Error('Network error')
-    )
+    mockFetchJsonFromBackend.mockRejectedValue(new Error('Network error'))
 
     const result = await wasteBalanceAvailabilityPostController.handler(
       mockRequest,
@@ -160,7 +160,7 @@ describe('waste-balance-availability POST controller', () => {
 
   test('Should use error message from backend when available', async () => {
     const error = Boom.badRequest('Custom backend error message')
-    vi.mocked(fetchJsonFromBackend).mockRejectedValue(error)
+    mockFetchJsonFromBackend.mockRejectedValue(error)
 
     await wasteBalanceAvailabilityPostController.handler(mockRequest, mockH)
 

--- a/src/server/routes/waste-records-export/controller.post.test.js
+++ b/src/server/routes/waste-records-export/controller.post.test.js
@@ -36,7 +36,10 @@ describe('wasteRecordsExportPostController', () => {
   beforeEach(() => vi.clearAllMocks())
 
   const buildHapiH = () => {
-    const calls = { type: [], header: [] }
+    const calls = {
+      type: /** @type {unknown[][]} */ ([]),
+      header: /** @type {unknown[][]} */ ([])
+    }
     const responseBuilder = {
       type: vi.fn(function (...args) {
         calls.type.push(args)
@@ -55,14 +58,16 @@ describe('wasteRecordsExportPostController', () => {
   }
 
   it('converts the backend Web ReadableStream to a Node Readable and preserves the CSV chunks', async () => {
-    streamFromBackend.mockResolvedValue({
-      body: buildWebStream(['header1,header2\n', 'a,b\n', 'c,d\n']),
-      headers: new Headers({
-        'content-type': 'text/csv; charset=utf-8',
-        'content-disposition':
-          'attachment; filename="waste-records-2026-05-08T10-00-00Z.csv"'
+    vi.mocked(streamFromBackend).mockResolvedValue(
+      /** @type {Response} */ ({
+        body: buildWebStream(['header1,header2\n', 'a,b\n', 'c,d\n']),
+        headers: new Headers({
+          'content-type': 'text/csv; charset=utf-8',
+          'content-disposition':
+            'attachment; filename="waste-records-2026-05-08T10-00-00Z.csv"'
+        })
       })
-    })
+    )
 
     const { h, calls } = buildHapiH()
     const request = { yar: { set: vi.fn() } }
@@ -74,7 +79,7 @@ describe('wasteRecordsExportPostController', () => {
       '/v1/admin/waste-records/export.csv'
     )
 
-    const passedBody = h.response.mock.calls[0][0]
+    const passedBody = /** @type {unknown[]} */ (h.response.mock.calls[0])[0]
     expect(passedBody).toBeInstanceOf(Readable)
     expect(await collectNodeStream(passedBody)).toBe(
       'header1,header2\na,b\nc,d\n'
@@ -90,10 +95,12 @@ describe('wasteRecordsExportPostController', () => {
   })
 
   it('falls back to default content-type and disposition when backend headers are missing', async () => {
-    streamFromBackend.mockResolvedValue({
-      body: buildWebStream([]),
-      headers: new Headers({})
-    })
+    vi.mocked(streamFromBackend).mockResolvedValue(
+      /** @type {Response} */ ({
+        body: buildWebStream([]),
+        headers: new Headers({})
+      })
+    )
 
     const { h, calls } = buildHapiH()
     const request = { yar: { set: vi.fn() } }
@@ -108,7 +115,7 @@ describe('wasteRecordsExportPostController', () => {
 
   it('redirects with a flash error when the backend call fails', async () => {
     const error = new Error('boom')
-    streamFromBackend.mockRejectedValue(error)
+    vi.mocked(streamFromBackend).mockRejectedValue(error)
 
     const { h } = buildHapiH()
     const yarSet = vi.fn()
@@ -126,9 +133,12 @@ describe('wasteRecordsExportPostController', () => {
   })
 
   it('uses the Boom payload message when available', async () => {
-    const error = new Error('upstream')
+    const error =
+      /** @type {Error & { output: { payload: { message: string } } }} */ (
+        new Error('upstream')
+      )
     error.output = { payload: { message: 'Backend exploded' } }
-    streamFromBackend.mockRejectedValue(error)
+    vi.mocked(streamFromBackend).mockRejectedValue(error)
 
     const { h } = buildHapiH()
     const yarSet = vi.fn()
@@ -140,7 +150,9 @@ describe('wasteRecordsExportPostController', () => {
   })
 
   it('logs and redirects with a flash error when the backend response has no body', async () => {
-    streamFromBackend.mockResolvedValue({ body: null, headers: new Headers() })
+    vi.mocked(streamFromBackend).mockResolvedValue(
+      /** @type {Response} */ ({ body: null, headers: new Headers() })
+    )
 
     const { h } = buildHapiH()
     const yarSet = vi.fn()

--- a/src/server/routes/waste-records-export/controller.post.test.js
+++ b/src/server/routes/waste-records-export/controller.post.test.js
@@ -4,6 +4,7 @@ import { vi, describe, it, expect, beforeEach } from 'vitest'
 
 import { wasteRecordsExportPostController } from './controller.post.js'
 import { streamFromBackend } from '#server/common/helpers/stream-from-backend.js'
+import { boomError } from '#server/common/test-helpers/fixtures.js'
 
 vi.mock('#server/common/helpers/stream-from-backend.js', () => ({
   streamFromBackend: vi.fn()
@@ -133,11 +134,10 @@ describe('wasteRecordsExportPostController', () => {
   })
 
   it('uses the Boom payload message when available', async () => {
-    const error =
-      /** @type {Error & { output: { payload: { message: string } } }} */ (
-        new Error('upstream')
-      )
-    error.output = { payload: { message: 'Backend exploded' } }
+    const error = boomError({
+      message: 'upstream',
+      payloadMessage: 'Backend exploded'
+    })
     vi.mocked(streamFromBackend).mockRejectedValue(error)
 
     const { h } = buildHapiH()


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)
clears every test-surface type error in the admin frontend (195 -> 0), test-side only, no prod changes.

what changed:
- wrap mocked fns in `vi.mocked()` so vitest mock methods type-check (the bulk)
- cast partial mock requests to `HapiRequest`/`Request` (small `asRequest` helpers where repeated)
- cast partial fixtures to their domain/return types (`ReturnType<typeof ...>`, `Response`, `EntraIdTokenPayload`, etc.)
- convert await-tolerant `getUserSession.mockReturnValue(session)` to `mockResolvedValue`
- fix latent test bugs surfaced by typing: chained `.toContain(...)` split into separate assertions; `Boolean()` on truthy log predicates
- optional-chaining / tuple casts for `.find()` and `mock.calls` indexing

33 test files, 1093 tests still pass at 100% coverage.

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ