### PR TITLE
PAE-1593: Name the organisation when reading waste balance events

### DIFF
--- a/src/server/routes/waste-balance-events/controller.get.js
+++ b/src/server/routes/waste-balance-events/controller.get.js
@@ -30,7 +30,7 @@ export const wasteBalanceEventsGETController = {
 
     const events = await fetchJsonFromBackend(
       request,
-      `/v1/admin/registrations/${registrationId}/accreditations/${accreditationId}/waste-balance-events`,
+      `/v1/admin/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/waste-balance-events`,
       {}
     )
 

--- a/src/server/routes/waste-balance-events/get.integration.test.js
+++ b/src/server/routes/waste-balance-events/get.integration.test.js
@@ -126,7 +126,7 @@ describe('#wasteBalanceEventsController', () => {
         () => HttpResponse.json(overviewResponse)
       ),
       http.get(
-        `${backendUrl}/v1/admin/registrations/reg-001/accreditations/${accreditationId}/waste-balance-events`,
+        `${backendUrl}/v1/admin/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/waste-balance-events`,
         () => HttpResponse.json(eventsResponse)
       )
     )


### PR DESCRIPTION
Ticket: [PAE-1593](https://eaflood.atlassian.net/browse/PAE-1593)

## Summary

A waste balance ledger belongs to an accreditation, which belongs to a registration, which belongs to an organisation. All three ids identify the ledger. This page already holds the organisation id — it is in the route params and in the breadcrumbs — but dropped it when calling the backend, asking for a registration's ledger events without saying whose registration.

The backend's admin waste-balance-events endpoint now takes the organisation as a path segment (DEFRA/epr-backend#1486). This passes the organisation the controller already has.

## Changes

- `src/server/routes/waste-balance-events/controller.get.js` — the backend request names the organisation alongside the registration and accreditation.
- `src/server/routes/waste-balance-events/get.integration.test.js` — the stubbed backend route matches the organisation-scoped path.

Merge after the backend PR: until that endpoint exists, the request path this sends is a 404.


[PAE-1593]: https://eaflood.atlassian.net/browse/PAE-1593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
