### PR TITLE
PAE-1593: Download an accreditation's PRNs by its full path

### DIFF
--- a/src/server/routes/prn-activity/controller.download.js
+++ b/src/server/routes/prn-activity/controller.download.js
@@ -11,12 +11,12 @@ function getDisplayName(org) {
   return org.tradingName || org.name || ''
 }
 
-export async function fetchAllPrns(request, accreditationId) {
+export async function fetchAllPrns(request) {
   const allItems = []
   let cursor = null
 
   do {
-    const url = buildPrnApiUrl(cursor, accreditationId)
+    const url = buildPrnApiUrl(cursor)
     const data = await fetchJsonFromBackend(request, url)
     const items = data?.items || []
     allItems.push(...items)

--- a/src/server/routes/prn-activity/controller.js
+++ b/src/server/routes/prn-activity/controller.js
@@ -31,15 +31,30 @@ function mapPrns(data) {
   }))
 }
 
-export function buildPrnApiUrl(cursor, accreditationId) {
+export function buildPrnApiUrl(cursor) {
   let url = `/v1/admin/packaging-recycling-notes?statuses=${statuses}`
   if (cursor) {
     url += `&cursor=${encodeURIComponent(cursor)}`
   }
-  if (accreditationId) {
-    url += `&accreditationId=${encodeURIComponent(accreditationId)}`
-  }
   return url
+}
+
+export function buildAccreditationPrnApiUrl({
+  organisationId,
+  registrationId,
+  accreditationId
+}) {
+  const path = [
+    '/v1/admin/organisations',
+    encodeURIComponent(organisationId),
+    'registrations',
+    encodeURIComponent(registrationId),
+    'accreditations',
+    encodeURIComponent(accreditationId),
+    'packaging-recycling-notes'
+  ].join('/')
+
+  return `${path}?statuses=${statuses}`
 }
 
 export const prnActivityController = {

--- a/src/server/routes/prn-activity/controller.scoped-download.js
+++ b/src/server/routes/prn-activity/controller.scoped-download.js
@@ -1,4 +1,6 @@
-import { fetchAllPrns, generateCsv } from './controller.download.js'
+import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
+import { generateCsv } from './controller.download.js'
+import { buildAccreditationPrnApiUrl } from './controller.js'
 
 /**
  * Downloads PRN activity for a single accreditation as CSV. Triggered from the
@@ -9,8 +11,15 @@ export const prnActivityScopedDownloadController = {
     const { organisationId, registrationId, accreditationId } = request.params
 
     try {
-      const items = await fetchAllPrns(request, accreditationId)
-      const csv = await generateCsv(items)
+      const data = await fetchJsonFromBackend(
+        request,
+        buildAccreditationPrnApiUrl({
+          organisationId,
+          registrationId,
+          accreditationId
+        })
+      )
+      const csv = await generateCsv(data?.items || [])
 
       return h
         .response(csv)

--- a/src/server/routes/prn-activity/controller.scoped-download.test.js
+++ b/src/server/routes/prn-activity/controller.scoped-download.test.js
@@ -50,7 +50,7 @@ describe('prn-activity scoped download controller', () => {
     }
   })
 
-  test('Should fetch PRNs filtered by the accreditation id', async () => {
+  test('Should fetch the PRNs of the accreditation by its full path', async () => {
     mockFetchJsonFromBackend.mockResolvedValue({
       items: [],
       hasMore: false
@@ -60,8 +60,20 @@ describe('prn-activity scoped download controller', () => {
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
       request,
-      expect.stringContaining('accreditationId=acc-9')
+      expect.stringContaining(
+        '/v1/admin/organisations/org-1/registrations/reg-1/accreditations/acc-9/packaging-recycling-notes'
+      )
     )
+  })
+
+  test('Should generate a headers-only CSV when the backend returns no payload', async () => {
+    mockFetchJsonFromBackend.mockResolvedValue(null)
+
+    await prnActivityScopedDownloadController.handler(request, h)
+
+    const csvContent = h.response.mock.calls[0][0]
+    expect(csvContent).toContain('PRN Number')
+    expect(csvContent).not.toContain('PRN-001')
   })
 
   test('Should generate CSV and set an accreditation-scoped filename', async () => {


### PR DESCRIPTION
Ticket: [PAE-1593](https://eaflood.atlassian.net/browse/PAE-1593)
## PAE-1593

Depends on **[DEFRA/epr-backend#1489](https://github.com/DEFRA/epr-backend/pull/1489)** and must merge after it. Until that PR lands, the path this calls does not exist and the download 404s.

A PRN belongs to an accreditation, which belongs to a registration, which belongs to an organisation. The backend's accreditation-scoped admin PRN list stops being an optional `accreditationId` query filter on the global collection path and becomes its own resource, addressed by the full hierarchy.

The per-registration PRN download already held all three ids in its own route params and dropped two of them when building the backend URL. It now names all three:

```
GET /v1/admin/organisations/{organisationId}/registrations/{registrationId}/accreditations/{accreditationId}/packaging-recycling-notes
```

The scoped list is not paginated, so the download fetches it once rather than driving the global list's cursor loop. `buildPrnApiUrl` goes back to serving only the global PRN activity page and its download, which keep cursor pagination.


[PAE-1593]: https://eaflood.atlassian.net/browse/PAE-1593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ