### PR TITLE
PAE-000: baseline typecheck strictness + hard test-type gate

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -42,12 +42,13 @@ jobs:
     name: Lint Types - Tests
     runs-on: ubuntu-latest
     needs: pr-prep
-    continue-on-error: true
     permissions:
       contents: read
       pull-requests: write
     steps:
       - uses: DEFRA/epr-re-ex-service/.github/actions/lint-types-tests@main
+        with:
+          fail-on: all
 
   test-journey:
     name: Run Journey Tests

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,7 +12,17 @@ export default [
   }),
   {
     rules: {
-      eqeqeq: ['error', 'always']
+      eqeqeq: ['error', 'always'],
+      'no-unused-vars': [
+        'error',
+        {
+          args: 'all',
+          argsIgnorePattern: '^_',
+          caughtErrors: 'none',
+          ignoreRestSiblings: true,
+          varsIgnorePattern: '^_'
+        }
+      ]
     }
   }
 ]

--- a/jsconfig.typecheck.json
+++ b/jsconfig.typecheck.json
@@ -15,7 +15,10 @@
     "noImplicitAny": false,
     "strictNullChecks": true,
     "noUnusedLocals": false,
-    "noUnusedParameters": false,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
     "paths": {
       "#config/*": ["./src/config/*"],
       "#server/*": ["./src/server/*"],

--- a/src/client/javascripts/jsoneditor.helpers.test.js
+++ b/src/client/javascripts/jsoneditor.helpers.test.js
@@ -24,7 +24,7 @@ const { mockSet, mockGet, MockJSONEditorConstructor } = vi.hoisted(() => {
     findNodeByPath: vi.fn()
   }
 
-  const MockJSONEditorConstructor = vi.fn(function (container, options) {
+  const MockJSONEditorConstructor = vi.fn(function (_container, options) {
     this.options = options
     this.node = mockNode
   })

--- a/src/server/routes/auth/callback/get.integration.test.js
+++ b/src/server/routes/auth/callback/get.integration.test.js
@@ -59,7 +59,7 @@ describe('GET /auth/callback', () => {
       .split(';')[0]
 
     mswServer.use(
-      http.post(mockOidcResponse.token_endpoint, ({ request }) => {
+      http.post(mockOidcResponse.token_endpoint, () => {
         return HttpResponse.json({
           access_token: Jwt.token.generate(
             accessToken,


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
baseline typecheck strictness plus a real gate on the test typecheck.

- enable zero-cost tsc flags: noImplicitReturns, noFallthroughCasesInSwitch, noImplicitOverride, noUnusedParameters
- make the Lint Types - Tests job a hard gate (drop continue-on-error) and set fail-on: all so any test type error fails, not just changed files
- align eslint no-unused-vars to args: all (matches tsc noUnusedParameters; neostandard defaults to args: none)

part of a wider push to raise typecheck strictness now the test suite is green. depends on the epr-re-ex-service PR adding the fail-on input.