### PR TITLE
PAE-1657: hide Unsubmit link on superseded submissions

### DIFF
--- a/src/server/routes/registration-overview/controller.get.js
+++ b/src/server/routes/registration-overview/controller.get.js
@@ -10,6 +10,41 @@ const RED_TAG = 'govuk-tag--red'
 
 const EXPORTER_PROCESSING_TYPE = 'exporter'
 
+const SUBMITTED_STATUS = 'submitted'
+
+const periodKey = (period) => `${period.year}-${period.period}`
+
+/**
+ * Builds the view model for each calendar reporting period, flagging a
+ * submission as superseded when a later submitted submission exists for the same
+ * period. A superseded submission must not offer the Unsubmit action:
+ * unsubmitting it would silently drop it from the submission history (PAE-1657).
+ * The backend enforces the same rule; ADR-0038 keeps the calendar payload free
+ * of superseded fields, so the flag is derived here.
+ * @param {Array<Record<string, any>>} reportingPeriods
+ * @param {string} cadence
+ */
+const toReportingPeriods = (reportingPeriods, cadence) => {
+  const latestSubmittedSubmission = new Map()
+  for (const period of reportingPeriods) {
+    if (period.report?.status !== SUBMITTED_STATUS) {
+      continue
+    }
+    const key = periodKey(period)
+    latestSubmittedSubmission.set(
+      key,
+      Math.max(latestSubmittedSubmission.get(key) ?? 0, period.submissionNumber)
+    )
+  }
+  return reportingPeriods.map((period) => ({
+    ...period,
+    formattedPeriod: formatPeriod(period.period, cadence),
+    isSuperseded:
+      period.report?.status === SUBMITTED_STATUS &&
+      period.submissionNumber < latestSubmittedSubmission.get(periodKey(period))
+  }))
+}
+
 const STATUS_DISPLAY = {
   submitted: { label: 'Success', className: GREEN_TAG },
   rejected: { label: 'Failed (Rejected)', className: RED_TAG },
@@ -106,10 +141,10 @@ export const registrationOverviewGETController = {
       registrationId,
       registration,
       cadence: calendar.cadence,
-      reportingPeriods: calendar.reportingPeriods.map((rp) => ({
-        ...rp,
-        formattedPeriod: formatPeriod(rp.period, calendar.cadence)
-      })),
+      reportingPeriods: toReportingPeriods(
+        calendar.reportingPeriods,
+        calendar.cadence
+      ),
       summaryLogRows,
       wasteBalance,
       error: errorMessage,

--- a/src/server/routes/registration-overview/get.integration.test.js
+++ b/src/server/routes/registration-overview/get.integration.test.js
@@ -1040,6 +1040,49 @@ describe('#registrationOverviewController', () => {
           })
         ).toBeNull()
       })
+
+      test('Should render the Unsubmit link only on the current submission, not a superseded one', async () => {
+        useMockBackend(mockOverview, mockCalendarWithHistory)
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        const body = renderPage(result)
+        const [supersededRow, currentRow] = getDataRows(getReportsTable(body))
+
+        expect(
+          within(supersededRow).queryByRole('link', { name: 'Unsubmit' })
+        ).toBeNull()
+        expect(
+          within(currentRow).getByRole('link', { name: 'Unsubmit' })
+        ).toHaveAttribute(
+          'href',
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/submissions/2/unsubmit/confirm`
+        )
+      })
+
+      test('Should render the Unsubmit link on the submitted submission while a resubmission is required', async () => {
+        useMockBackend(mockOverview, mockCalendarWithSkeleton)
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        const body = renderPage(result)
+        const [submittedRow] = getDataRows(getReportsTable(body))
+
+        expect(
+          within(submittedRow).getByRole('link', { name: 'Unsubmit' })
+        ).toHaveAttribute(
+          'href',
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/submissions/1/unsubmit/confirm`
+        )
+      })
     })
   })
 })

--- a/src/server/routes/registration-overview/index.njk
+++ b/src/server/routes/registration-overview/index.njk
@@ -69,7 +69,7 @@
               {% if period.report %}
                 <a class="govuk-link govuk-link--no-visited-state" href="{{ reportUrl }}">View</a>
               {% endif %}
-              {% if period.report and period.report.status === 'submitted' and SCOPES.adminWrite in scopes %}
+              {% if period.report and period.report.status === 'submitted' and not period.isSuperseded and SCOPES.adminWrite in scopes %}
                 {% set unsubmitUrl = '/organisations/' ~ organisationId ~ '/registrations/' ~ registrationId ~ '/reports/' ~ period.year ~ '/' ~ cadence ~ '/' ~ period.period ~ '/submissions/' ~ period.submissionNumber ~ '/unsubmit/confirm' %}
                 <br><a class="govuk-link govuk-link--no-visited-state" href="{{ unsubmitUrl }}">Unsubmit</a>
               {% endif %}


### PR DESCRIPTION
Ticket: [PAE-1657](https://eaflood.atlassian.net/browse/PAE-1657)
## What

Frontend follow-up to PAE-1657 (merged in #459). During review, **Tony Bruce** flagged:

> When a period holds two submitted submissions (post-resubmission), the Unsubmit link renders on both rows. Clicking it on the superseded submission 1 succeeds, and the unsubmitted submission then disappears from the history view — silently removing a submission from the exact history this ticket adds.

A sibling epr-backend PR (#1498) rejects the action at the API as defence in depth.

## Change

- `controller.get.js` — derive an `isSuperseded` flag per reporting period: a submission is superseded when a later **submitted** submission exists for the same period. The reporting-period view-model mapping is extracted into a small helper.
- `index.njk` — gate the Unsubmit link on `not period.isSuperseded` (alongside the existing `submitted` + `admin.write` checks).

A resubmission still *in progress* does not supersede the earlier submitted submission, so the live submission keeps its Unsubmit action.

**No backend payload change** — ADR-0038 deliberately keeps the calendar free of `current`/`superseded` fields, so the flag is derived in the frontend from the submission numbers already present.

Jira: https://eaflood.atlassian.net/browse/PAE-1657

[PAE-1657]: https://eaflood.atlassian.net/browse/PAE-1657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ