### PR TITLE
PAE-1676: waste balance report page (month view, tables, CSV download)

### DIFF
--- a/src/config/nunjucks/context/build-navigation.js
+++ b/src/config/nunjucks/context/build-navigation.js
@@ -10,6 +10,7 @@ const navItems = [
   { text: 'PRN activity', href: '/prn-activity' },
   { text: 'PRN tonnage', href: '/prn-tonnage' },
   { text: 'Report submissions', href: '/report-submissions' },
+  { text: 'Waste balance report', href: '/waste-balance-report' },
   { text: 'Waste records export', href: '/waste-records-export' },
   { text: 'System logs', href: '/system-logs' },
   { text: 'Queue management', href: '/queue-management', matchSubPaths: true }

--- a/src/config/nunjucks/context/build-navigation.test.js
+++ b/src/config/nunjucks/context/build-navigation.test.js
@@ -66,6 +66,11 @@ describe('#buildNavigation', () => {
       },
       {
         current: false,
+        text: 'Waste balance report',
+        href: '/waste-balance-report'
+      },
+      {
+        current: false,
         text: 'Waste records export',
         href: '/waste-records-export'
       },
@@ -141,6 +146,11 @@ describe('#buildNavigation', () => {
       },
       {
         current: false,
+        text: 'Waste balance report',
+        href: '/waste-balance-report'
+      },
+      {
+        current: false,
         text: 'Waste records export',
         href: '/waste-records-export'
       },
@@ -173,12 +183,15 @@ describe('#buildNavigation', () => {
     )
   })
 
-  test('Should place report submissions before waste records export before system logs', () => {
+  test('Should place report submissions before waste balance report before waste records export before system logs', () => {
     const navigation = buildNavigation(
       mockRequest({ path: '/non-existent-path' })
     )
     const reportSubmissionsIndex = navigation.findIndex(
       (item) => item.text === 'Report submissions'
+    )
+    const wasteBalanceReportIndex = navigation.findIndex(
+      (item) => item.text === 'Waste balance report'
     )
     const wasteRecordsExportIndex = navigation.findIndex(
       (item) => item.text === 'Waste records export'
@@ -187,7 +200,8 @@ describe('#buildNavigation', () => {
       (item) => item.text === 'System logs'
     )
 
-    expect(wasteRecordsExportIndex).toBe(reportSubmissionsIndex + 1)
+    expect(wasteBalanceReportIndex).toBe(reportSubmissionsIndex + 1)
+    expect(wasteRecordsExportIndex).toBe(wasteBalanceReportIndex + 1)
     expect(systemLogsIndex).toBe(wasteRecordsExportIndex + 1)
   })
 

--- a/src/config/nunjucks/context/context.test.js
+++ b/src/config/nunjucks/context/context.test.js
@@ -115,6 +115,11 @@ describe('context and cache', () => {
             },
             {
               current: false,
+              text: 'Waste balance report',
+              href: '/waste-balance-report'
+            },
+            {
+              current: false,
               text: 'Waste records export',
               href: '/waste-records-export'
             },
@@ -309,6 +314,11 @@ describe('context and cache', () => {
               current: false,
               text: 'Report submissions',
               href: '/report-submissions'
+            },
+            {
+              current: false,
+              text: 'Waste balance report',
+              href: '/waste-balance-report'
             },
             {
               current: false,

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -19,6 +19,7 @@ import { prnActivity } from './routes/prn-activity/index.js'
 import { summaryLogUploadsReport } from './routes/summary-log/index.js'
 import { orsUpload } from './routes/ors-upload/index.js'
 import { reportSubmissions } from './routes/report-submissions/index.js'
+import { wasteBalanceReport } from './routes/waste-balance-report/index.js'
 import { wasteRecordsExport } from './routes/waste-records-export/index.js'
 import { queueManagement } from './routes/queue-management/index.js'
 import { reportUnsubmit } from './routes/report-unsubmit/index.js'
@@ -57,6 +58,7 @@ export const router = {
         summaryLogUploadsReport,
         orsUpload,
         reportSubmissions,
+        wasteBalanceReport,
         wasteRecordsExport,
         queueManagement,
         reportUnsubmit,

--- a/src/server/routes/waste-balance-report/controller.get.js
+++ b/src/server/routes/waste-balance-report/controller.get.js
@@ -1,0 +1,124 @@
+import { statusCodes } from '#server/common/constants/status-codes.js'
+import { createLogger } from '#server/common/helpers/logging/logger.js'
+import { fetchWasteBalanceReport } from './fetch-report.js'
+import { isValidReportMonth, reportMonthItems } from './months.js'
+
+/**
+ * @import { WasteBalanceReport } from './types.js'
+ */
+
+const logger = createLogger()
+
+const VIEW = 'routes/waste-balance-report/index'
+const PAGE_TITLE = 'Waste balance report'
+
+/**
+ * en-GB thousand separators for the on-page tables; the CSV download keeps
+ * raw numbers. The fraction-digit ceiling stops toLocaleString's default
+ * 3-decimal rounding from hiding precision the CSV would show.
+ * @param {number} value
+ */
+const formatTonnage = (value) =>
+  value.toLocaleString('en-GB', { maximumFractionDigits: 10 })
+
+/**
+ * govukTable rows for the per-material totals, in the report's canonical
+ * order.
+ * @param {WasteBalanceReport} report
+ */
+const totalsRows = (report) =>
+  report.totals.map((total) => [
+    { text: total.material },
+    { text: total.wasteProcessingType },
+    { text: formatTonnage(total.amount), format: 'numeric' },
+    { text: formatTonnage(total.availableAmount), format: 'numeric' }
+  ])
+
+/**
+ * govukTable rows for the per-accreditation balances, in the report's
+ * canonical order.
+ * @param {WasteBalanceReport} report
+ */
+const accreditationRows = (report) =>
+  report.accreditations.map((accreditation) => [
+    { text: accreditation.orgId },
+    { text: accreditation.registrationNumber },
+    { text: accreditation.accreditationNumber },
+    { text: accreditation.material },
+    { text: accreditation.wasteProcessingType },
+    { text: formatTonnage(accreditation.amount), format: 'numeric' },
+    { text: formatTonnage(accreditation.availableAmount), format: 'numeric' }
+  ])
+
+/**
+ * The month select items, with the chosen month selected when the page is
+ * re-rendering an existing report (page state lives in the URL).
+ * @param {Date} now
+ * @param {string} [selectedMonth]
+ */
+const monthItems = (now, selectedMonth) => {
+  const items = reportMonthItems(now)
+  if (!selectedMonth) {
+    return items
+  }
+  return items.map((item) => ({
+    ...item,
+    selected: item.value === selectedMonth
+  }))
+}
+
+export const wasteBalanceReportGetController = {
+  async handler(request, h) {
+    const flashError = request.yar.get('error')
+    await request.yar.clear('error')
+
+    const now = new Date()
+    const { month } = request.query
+
+    if (month === undefined) {
+      return h.view(VIEW, {
+        pageTitle: PAGE_TITLE,
+        error: flashError,
+        months: monthItems(now)
+      })
+    }
+
+    if (!isValidReportMonth(month, now)) {
+      return h
+        .view(VIEW, {
+          pageTitle: PAGE_TITLE,
+          error: 'Select a month from the list',
+          months: monthItems(now)
+        })
+        .code(statusCodes.badRequest)
+    }
+
+    try {
+      const report = await fetchWasteBalanceReport(request, month)
+
+      return h.view(VIEW, {
+        pageTitle: PAGE_TITLE,
+        error: flashError,
+        months: monthItems(now, month),
+        month,
+        totalsRows: totalsRows(report),
+        accreditationRows: accreditationRows(report)
+      })
+    } catch (error) {
+      logger.error({
+        message: 'Failed to fetch the waste balance report',
+        err: error
+      })
+
+      // Rendering the error directly (rather than flash-and-redirect, as the
+      // download POST does) keeps the month in the URL without redirecting a
+      // failing GET back to itself.
+      return h.view(VIEW, {
+        pageTitle: PAGE_TITLE,
+        error:
+          'There was a problem retrieving the waste balance report. Please try again.',
+        months: monthItems(now, month)
+      })
+    }
+  }
+}

--- a/src/server/routes/waste-balance-report/controller.get.test.js
+++ b/src/server/routes/waste-balance-report/controller.get.test.js
@@ -1,0 +1,217 @@
+import { statusCodes } from '#server/common/constants/status-codes.js'
+import { fetchWasteBalanceReport } from './fetch-report.js'
+import { wasteBalanceReportGetController } from './controller.get.js'
+
+vi.mock('./fetch-report.js', () => ({
+  fetchWasteBalanceReport: vi.fn()
+}))
+
+const VIEW = 'routes/waste-balance-report/index'
+
+const report = {
+  cutoff: '2026-06-30T23:00:00Z',
+  totals: [
+    {
+      material: 'glass',
+      wasteProcessingType: 'reprocessor',
+      amount: 800,
+      availableAmount: 700
+    },
+    {
+      material: 'plastic',
+      wasteProcessingType: 'reprocessor',
+      amount: 1200.5,
+      availableAmount: 900
+    }
+  ],
+  accreditations: [
+    {
+      orgId: '500001',
+      registrationNumber: 'REG-123',
+      accreditationNumber: 'ACC-456',
+      material: 'glass',
+      wasteProcessingType: 'reprocessor',
+      amount: 800,
+      availableAmount: 700
+    },
+    {
+      orgId: '500002',
+      registrationNumber: 'REG-124',
+      accreditationNumber: 'ACC-457',
+      material: 'plastic',
+      wasteProcessingType: 'reprocessor',
+      amount: 1200.5,
+      availableAmount: 0
+    }
+  ]
+}
+
+describe('wasteBalanceReportGetController', () => {
+  let mockRequest
+  let mockH
+  let renderedWithCode
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-14T12:00:00.000Z'))
+
+    mockRequest = {
+      query: {},
+      yar: {
+        get: vi.fn().mockReturnValue(null),
+        clear: vi.fn()
+      }
+    }
+
+    renderedWithCode = { code: vi.fn().mockReturnValue('rendered-with-code') }
+    mockH = {
+      view: vi.fn().mockReturnValue(renderedWithCode)
+    }
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders only the month form when no month is selected', async () => {
+    await wasteBalanceReportGetController.handler(mockRequest, mockH)
+
+    expect(mockH.view).toHaveBeenCalledWith(
+      VIEW,
+      expect.objectContaining({
+        pageTitle: 'Waste balance report',
+        months: expect.arrayContaining([
+          expect.objectContaining({ value: '2026-06', selected: true })
+        ])
+      })
+    )
+    const context = mockH.view.mock.calls[0][1]
+    expect(context.totalsRows).toBeUndefined()
+    expect(context.accreditationRows).toBeUndefined()
+    expect(fetchWasteBalanceReport).not.toHaveBeenCalled()
+  })
+
+  it('renders both tables and the download month for a valid month', async () => {
+    mockRequest.query = { month: '2026-05' }
+    vi.mocked(fetchWasteBalanceReport).mockResolvedValue(report)
+
+    await wasteBalanceReportGetController.handler(mockRequest, mockH)
+
+    expect(fetchWasteBalanceReport).toHaveBeenCalledWith(mockRequest, '2026-05')
+    const context = mockH.view.mock.calls[0][1]
+    expect(context.month).toBe('2026-05')
+    expect(context.totalsRows).toEqual([
+      [
+        { text: 'glass' },
+        { text: 'reprocessor' },
+        { text: '800', format: 'numeric' },
+        { text: '700', format: 'numeric' }
+      ],
+      [
+        { text: 'plastic' },
+        { text: 'reprocessor' },
+        { text: '1,200.5', format: 'numeric' },
+        { text: '900', format: 'numeric' }
+      ]
+    ])
+    expect(context.accreditationRows).toEqual([
+      [
+        { text: '500001' },
+        { text: 'REG-123' },
+        { text: 'ACC-456' },
+        { text: 'glass' },
+        { text: 'reprocessor' },
+        { text: '800', format: 'numeric' },
+        { text: '700', format: 'numeric' }
+      ],
+      [
+        { text: '500002' },
+        { text: 'REG-124' },
+        { text: 'ACC-457' },
+        { text: 'plastic' },
+        { text: 'reprocessor' },
+        { text: '1,200.5', format: 'numeric' },
+        { text: '0', format: 'numeric' }
+      ]
+    ])
+  })
+
+  it('marks the chosen month as selected when re-rendering a report', async () => {
+    mockRequest.query = { month: '2026-03' }
+    vi.mocked(fetchWasteBalanceReport).mockResolvedValue(report)
+
+    await wasteBalanceReportGetController.handler(mockRequest, mockH)
+
+    const context = mockH.view.mock.calls[0][1]
+    const selected = context.months.filter((item) => item.selected)
+    expect(selected).toEqual([
+      expect.objectContaining({ value: '2026-03', selected: true })
+    ])
+  })
+
+  it('renders empty tables for an empty report', async () => {
+    mockRequest.query = { month: '2026-05' }
+    vi.mocked(fetchWasteBalanceReport).mockResolvedValue({
+      cutoff: '2026-05-31T23:00:00Z',
+      totals: [],
+      accreditations: []
+    })
+
+    await wasteBalanceReportGetController.handler(mockRequest, mockH)
+
+    const context = mockH.view.mock.calls[0][1]
+    expect(context.totalsRows).toEqual([])
+    expect(context.accreditationRows).toEqual([])
+  })
+
+  it('rejects an invalid month with a 400 and an error message', async () => {
+    mockRequest.query = { month: '2031-99' }
+
+    const result = await wasteBalanceReportGetController.handler(
+      mockRequest,
+      mockH
+    )
+
+    expect(fetchWasteBalanceReport).not.toHaveBeenCalled()
+    expect(mockH.view).toHaveBeenCalledWith(
+      VIEW,
+      expect.objectContaining({ error: 'Select a month from the list' })
+    )
+    expect(renderedWithCode.code).toHaveBeenCalledWith(statusCodes.badRequest)
+    expect(result).toBe('rendered-with-code')
+  })
+
+  it('renders an error, keeping the month selected, when the backend fetch fails', async () => {
+    mockRequest.query = { month: '2026-05' }
+    vi.mocked(fetchWasteBalanceReport).mockRejectedValue(
+      new Error('backend down')
+    )
+
+    await wasteBalanceReportGetController.handler(mockRequest, mockH)
+
+    const context = mockH.view.mock.calls[0][1]
+    expect(context.error).toBe(
+      'There was a problem retrieving the waste balance report. Please try again.'
+    )
+    expect(context.totalsRows).toBeUndefined()
+    expect(context.months).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ value: '2026-05', selected: true })
+      ])
+    )
+  })
+
+  it('shows and clears a flash error from the download controller', async () => {
+    mockRequest.yar.get.mockReturnValue('Download failed')
+
+    await wasteBalanceReportGetController.handler(mockRequest, mockH)
+
+    expect(mockRequest.yar.get).toHaveBeenCalledWith('error')
+    expect(mockRequest.yar.clear).toHaveBeenCalledWith('error')
+    expect(mockH.view).toHaveBeenCalledWith(
+      VIEW,
+      expect.objectContaining({ error: 'Download failed' })
+    )
+  })
+})

--- a/src/server/routes/waste-balance-report/controller.post.js
+++ b/src/server/routes/waste-balance-report/controller.post.js
@@ -1,0 +1,107 @@
+import { writeToString } from '@fast-csv/format'
+
+import { createLogger } from '#server/common/helpers/logging/logger.js'
+import { sanitizeFormulaInjection } from '#server/common/helpers/sanitize-formula-injection.js'
+import { fetchWasteBalanceReport } from './fetch-report.js'
+import { isValidReportMonth } from './months.js'
+
+/**
+ * @import { WasteBalanceReport } from './types.js'
+ */
+
+const logger = createLogger()
+
+const TOTALS_HEADER = [
+  'material',
+  'type',
+  'total_balance',
+  'total_available_balance'
+]
+
+const ACCREDITATIONS_HEADER = [
+  'org_id',
+  'registration_number',
+  'accreditation_number',
+  'material',
+  'type',
+  'balance',
+  'available_balance'
+]
+
+/**
+ * The two-section CSV: per-material totals, a blank line, then
+ * per-accreditation rows — each section with its own header, both in the
+ * report's canonical order, with raw (unformatted) numbers. Identifier cells
+ * pass through formula-injection sanitisation.
+ * @param {WasteBalanceReport} report
+ * @returns {Promise<string>}
+ */
+const generateCsv = async (report) => {
+  const totalsSection = await writeToString(
+    [
+      TOTALS_HEADER,
+      ...report.totals.map((total) => [
+        total.material,
+        total.wasteProcessingType,
+        total.amount,
+        total.availableAmount
+      ])
+    ],
+    { headers: false }
+  )
+
+  const accreditationsSection = await writeToString(
+    [
+      ACCREDITATIONS_HEADER,
+      ...report.accreditations.map((accreditation) => [
+        sanitizeFormulaInjection(accreditation.orgId),
+        sanitizeFormulaInjection(accreditation.registrationNumber),
+        sanitizeFormulaInjection(accreditation.accreditationNumber),
+        accreditation.material,
+        accreditation.wasteProcessingType,
+        accreditation.amount,
+        accreditation.availableAmount
+      ])
+    ],
+    { headers: false }
+  )
+
+  return `${totalsSection}\n\n${accreditationsSection}`
+}
+
+export const wasteBalanceReportPostController = {
+  async handler(request, h) {
+    const { month } = request.payload ?? {}
+    const now = new Date()
+
+    if (!isValidReportMonth(month, now)) {
+      request.yar.set('error', 'Select a month from the list')
+      return h.redirect('/waste-balance-report')
+    }
+
+    try {
+      const report = await fetchWasteBalanceReport(request, month)
+      const csv = await generateCsv(report)
+
+      return h
+        .response(csv)
+        .header('Content-Type', 'text/csv')
+        .header(
+          'Content-Disposition',
+          `attachment; filename="waste-balance-report-${month}.csv"`
+        )
+    } catch (error) {
+      logger.error({
+        message: 'Failed to generate the waste balance report CSV',
+        err: error
+      })
+
+      request.yar.set(
+        'error',
+        'There was a problem downloading the waste balance report. Please try again.'
+      )
+
+      return h.redirect(`/waste-balance-report?month=${month}`)
+    }
+  }
+}

--- a/src/server/routes/waste-balance-report/controller.post.test.js
+++ b/src/server/routes/waste-balance-report/controller.post.test.js
@@ -1,0 +1,189 @@
+import { fetchWasteBalanceReport } from './fetch-report.js'
+import { wasteBalanceReportPostController } from './controller.post.js'
+
+vi.mock('./fetch-report.js', () => ({
+  fetchWasteBalanceReport: vi.fn()
+}))
+
+const report = {
+  cutoff: '2026-05-31T23:00:00Z',
+  totals: [
+    {
+      material: 'glass',
+      wasteProcessingType: 'reprocessor',
+      amount: 800,
+      availableAmount: 700
+    },
+    {
+      material: 'plastic',
+      wasteProcessingType: 'exporter',
+      amount: 1200.005,
+      availableAmount: 900
+    }
+  ],
+  accreditations: [
+    {
+      orgId: '500001',
+      registrationNumber: 'REG-123',
+      accreditationNumber: 'ACC-456',
+      material: 'glass',
+      wasteProcessingType: 'reprocessor',
+      amount: 800,
+      availableAmount: 700
+    },
+    {
+      orgId: '500002',
+      registrationNumber: '=SUM(A1)',
+      accreditationNumber: 'ACC-457',
+      material: 'plastic',
+      wasteProcessingType: 'exporter',
+      amount: 1200.005,
+      availableAmount: 0
+    }
+  ]
+}
+
+describe('wasteBalanceReportPostController', () => {
+  let mockRequest
+  let mockH
+  let response
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-14T12:00:00.000Z'))
+
+    mockRequest = {
+      payload: { month: '2026-05' },
+      yar: {
+        set: vi.fn()
+      }
+    }
+
+    response = {
+      header: vi.fn()
+    }
+    response.header.mockReturnValue(response)
+    mockH = {
+      response: vi.fn().mockReturnValue(response),
+      redirect: vi.fn().mockReturnValue('redirected')
+    }
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('downloads the two-section CSV with its own header per section and raw numbers', async () => {
+    vi.mocked(fetchWasteBalanceReport).mockResolvedValue(report)
+
+    const result = await wasteBalanceReportPostController.handler(
+      mockRequest,
+      mockH
+    )
+
+    expect(result).toBe(response)
+
+    expect(fetchWasteBalanceReport).toHaveBeenCalledWith(mockRequest, '2026-05')
+    const csv = mockH.response.mock.calls[0][0]
+    expect(csv).toBe(
+      [
+        'material,type,total_balance,total_available_balance',
+        'glass,reprocessor,800,700',
+        'plastic,exporter,1200.005,900',
+        '',
+        'org_id,registration_number,accreditation_number,material,type,balance,available_balance',
+        '500001,REG-123,ACC-456,glass,reprocessor,800,700',
+        "500002,'=SUM(A1),ACC-457,plastic,exporter,1200.005,0"
+      ].join('\n')
+    )
+  })
+
+  it('names the file after the selected month and serves it as an attachment', async () => {
+    vi.mocked(fetchWasteBalanceReport).mockResolvedValue(report)
+
+    await wasteBalanceReportPostController.handler(mockRequest, mockH)
+
+    expect(response.header).toHaveBeenCalledWith('Content-Type', 'text/csv')
+    expect(response.header).toHaveBeenCalledWith(
+      'Content-Disposition',
+      'attachment; filename="waste-balance-report-2026-05.csv"'
+    )
+  })
+
+  it('downloads a headers-only CSV for an empty report', async () => {
+    vi.mocked(fetchWasteBalanceReport).mockResolvedValue({
+      cutoff: '2026-05-31T23:00:00Z',
+      totals: [],
+      accreditations: []
+    })
+
+    await wasteBalanceReportPostController.handler(mockRequest, mockH)
+
+    const csv = mockH.response.mock.calls[0][0]
+    expect(csv).toBe(
+      [
+        'material,type,total_balance,total_available_balance',
+        '',
+        'org_id,registration_number,accreditation_number,material,type,balance,available_balance'
+      ].join('\n')
+    )
+  })
+
+  it('rejects the current, incomplete month', async () => {
+    // Well-formed but out of range: July 2026 is the current month under the
+    // pinned clock, so it has no closing balance yet.
+    mockRequest.payload = { month: '2026-07' }
+
+    await wasteBalanceReportPostController.handler(mockRequest, mockH)
+
+    expect(fetchWasteBalanceReport).not.toHaveBeenCalled()
+    expect(mockH.redirect).toHaveBeenCalledWith('/waste-balance-report')
+  })
+
+  it('rejects an invalid month with a flash error and a redirect', async () => {
+    mockRequest.payload = { month: '2031-99' }
+
+    const result = await wasteBalanceReportPostController.handler(
+      mockRequest,
+      mockH
+    )
+
+    expect(fetchWasteBalanceReport).not.toHaveBeenCalled()
+    expect(mockRequest.yar.set).toHaveBeenCalledWith(
+      'error',
+      'Select a month from the list'
+    )
+    expect(mockH.redirect).toHaveBeenCalledWith('/waste-balance-report')
+    expect(result).toBe('redirected')
+  })
+
+  it('rejects a missing payload', async () => {
+    mockRequest.payload = undefined
+
+    await wasteBalanceReportPostController.handler(mockRequest, mockH)
+
+    expect(fetchWasteBalanceReport).not.toHaveBeenCalled()
+    expect(mockH.redirect).toHaveBeenCalledWith('/waste-balance-report')
+  })
+
+  it('flashes an error and redirects back preserving the month when the backend fails', async () => {
+    vi.mocked(fetchWasteBalanceReport).mockRejectedValue(
+      new Error('backend down')
+    )
+
+    const result = await wasteBalanceReportPostController.handler(
+      mockRequest,
+      mockH
+    )
+
+    expect(mockRequest.yar.set).toHaveBeenCalledWith(
+      'error',
+      'There was a problem downloading the waste balance report. Please try again.'
+    )
+    expect(mockH.redirect).toHaveBeenCalledWith(
+      '/waste-balance-report?month=2026-05'
+    )
+    expect(result).toBe('redirected')
+  })
+})

--- a/src/server/routes/waste-balance-report/fetch-report.js
+++ b/src/server/routes/waste-balance-report/fetch-report.js
@@ -1,0 +1,24 @@
+import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
+import { cutoffForReportMonth } from './months.js'
+
+/**
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { WasteBalanceReport } from './types.js'
+ */
+
+/**
+ * Fetch the waste balance report for a report month. Maps the month to its
+ * Europe/London closing cutoff and calls the backend. The view and download
+ * controllers both go through this one helper so the on-page tables and the
+ * CSV cannot drift apart.
+ * @param {HapiRequest} request
+ * @param {string} monthValue - A validated `YYYY-MM` report month.
+ * @returns {Promise<WasteBalanceReport>}
+ */
+export const fetchWasteBalanceReport = (request, monthValue) => {
+  const cutoff = cutoffForReportMonth(monthValue).toISOString()
+  return fetchJsonFromBackend(
+    request,
+    `/v1/admin/waste-balances/report?cutoff=${encodeURIComponent(cutoff)}`
+  )
+}

--- a/src/server/routes/waste-balance-report/fetch-report.js
+++ b/src/server/routes/waste-balance-report/fetch-report.js
@@ -3,22 +3,60 @@ import { cutoffForReportMonth } from './months.js'
 
 /**
  * @import { HapiRequest } from '#server/common/hapi-types.js'
- * @import { WasteBalanceReport } from './types.js'
+ * @import { WasteBalanceReport, WasteBalanceReportAccreditation, WasteBalanceReportTotal } from './types.js'
  */
+
+// Pinned locale and numeric collation so the canonical order is identical in
+// every environment and ACC-10 sorts after ACC-9.
+const collator = new Intl.Collator('en', { numeric: true })
+
+/**
+ * @param {string} a
+ * @param {string} b
+ */
+const compareStrings = (a, b) => collator.compare(a, b)
+
+/**
+ * @param {WasteBalanceReportTotal} a
+ * @param {WasteBalanceReportTotal} b
+ */
+const byMaterialThenType = (a, b) =>
+  compareStrings(a.material, b.material) ||
+  compareStrings(a.wasteProcessingType, b.wasteProcessingType)
+
+/**
+ * @param {WasteBalanceReportAccreditation} a
+ * @param {WasteBalanceReportAccreditation} b
+ */
+const byMaterialTypeThenAccreditation = (a, b) =>
+  byMaterialThenType(a, b) ||
+  compareStrings(a.accreditationNumber, b.accreditationNumber)
 
 /**
  * Fetch the waste balance report for a report month. Maps the month to its
- * Europe/London closing cutoff and calls the backend. The view and download
+ * Europe/London closing cutoff, calls the backend, and returns the report in
+ * its canonical order — totals by material then type, accreditations by
+ * material, type, then accreditation number. The view and download
  * controllers both go through this one helper so the on-page tables and the
- * CSV cannot drift apart.
+ * CSV cannot drift apart, in content or in order.
  * @param {HapiRequest} request
  * @param {string} monthValue - A validated `YYYY-MM` report month.
  * @returns {Promise<WasteBalanceReport>}
  */
-export const fetchWasteBalanceReport = (request, monthValue) => {
+export const fetchWasteBalanceReport = async (request, monthValue) => {
   const cutoff = cutoffForReportMonth(monthValue).toISOString()
-  return fetchJsonFromBackend(
+
+  /** @type {WasteBalanceReport} */
+  const report = await fetchJsonFromBackend(
     request,
     `/v1/admin/waste-balances/report?cutoff=${encodeURIComponent(cutoff)}`
   )
+
+  return {
+    ...report,
+    totals: [...report.totals].sort(byMaterialThenType),
+    accreditations: [...report.accreditations].sort(
+      byMaterialTypeThenAccreditation
+    )
+  }
 }

--- a/src/server/routes/waste-balance-report/fetch-report.test.js
+++ b/src/server/routes/waste-balance-report/fetch-report.test.js
@@ -1,0 +1,48 @@
+import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
+import { fetchWasteBalanceReport } from './fetch-report.js'
+
+vi.mock('#server/common/helpers/fetch-json-from-backend.js', () => ({
+  fetchJsonFromBackend: vi.fn()
+}))
+
+/**
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ */
+
+const request = /** @type {HapiRequest} */ (
+  /** @type {unknown} */ ({ fake: 'request' })
+)
+
+describe('fetchWasteBalanceReport', () => {
+  it('requests the report at the London closing cutoff of the month', async () => {
+    const report = {
+      cutoff: '2026-06-30T23:00:00Z',
+      totals: [],
+      accreditations: []
+    }
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue(report)
+
+    const result = await fetchWasteBalanceReport(request, '2026-06')
+
+    expect(fetchJsonFromBackend).toHaveBeenCalledWith(
+      request,
+      '/v1/admin/waste-balances/report?cutoff=2026-06-30T23%3A00%3A00.000Z'
+    )
+    expect(result).toBe(report)
+  })
+
+  it('maps a GMT month to a midnight UTC cutoff', async () => {
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+      cutoff: '2027-01-01T00:00:00Z',
+      totals: [],
+      accreditations: []
+    })
+
+    await fetchWasteBalanceReport(request, '2026-12')
+
+    expect(fetchJsonFromBackend).toHaveBeenCalledWith(
+      request,
+      '/v1/admin/waste-balances/report?cutoff=2027-01-01T00%3A00%3A00.000Z'
+    )
+  })
+})

--- a/src/server/routes/waste-balance-report/fetch-report.test.js
+++ b/src/server/routes/waste-balance-report/fetch-report.test.js
@@ -28,7 +28,55 @@ describe('fetchWasteBalanceReport', () => {
       request,
       '/v1/admin/waste-balances/report?cutoff=2026-06-30T23%3A00%3A00.000Z'
     )
-    expect(result).toBe(report)
+    expect(result).toEqual(report)
+  })
+
+  it('returns the report in canonical order: totals by material then type, accreditations by material, type, then accreditation number', async () => {
+    const total = (material, wasteProcessingType) => ({
+      material,
+      wasteProcessingType,
+      amount: 1,
+      availableAmount: 1
+    })
+    const accreditation = (
+      material,
+      wasteProcessingType,
+      accreditationNumber
+    ) => ({
+      orgId: '500001',
+      registrationNumber: 'REG-1',
+      accreditationNumber,
+      material,
+      wasteProcessingType,
+      amount: 1,
+      availableAmount: 1
+    })
+    vi.mocked(fetchJsonFromBackend).mockResolvedValue({
+      cutoff: '2026-06-30T23:00:00Z',
+      totals: [
+        total('plastic', 'reprocessor'),
+        total('glass', 'reprocessor'),
+        total('plastic', 'exporter')
+      ],
+      accreditations: [
+        accreditation('plastic', 'reprocessor', 'ACC-9'),
+        accreditation('glass', 'reprocessor', 'ACC-5'),
+        accreditation('plastic', 'reprocessor', 'ACC-1'),
+        accreditation('plastic', 'exporter', 'ACC-7')
+      ]
+    })
+
+    const result = await fetchWasteBalanceReport(request, '2026-06')
+
+    expect(
+      result.totals.map((t) => `${t.material}|${t.wasteProcessingType}`)
+    ).toEqual(['glass|reprocessor', 'plastic|exporter', 'plastic|reprocessor'])
+    expect(result.accreditations.map((a) => a.accreditationNumber)).toEqual([
+      'ACC-5',
+      'ACC-7',
+      'ACC-1',
+      'ACC-9'
+    ])
   })
 
   it('maps a GMT month to a midnight UTC cutoff', async () => {

--- a/src/server/routes/waste-balance-report/index.js
+++ b/src/server/routes/waste-balance-report/index.js
@@ -1,4 +1,5 @@
 import { wasteBalanceReportGetController } from './controller.get.js'
+import { wasteBalanceReportPostController } from './controller.post.js'
 
 export const wasteBalanceReport = {
   plugin: {
@@ -9,6 +10,11 @@ export const wasteBalanceReport = {
           method: 'GET',
           path: '/waste-balance-report',
           ...wasteBalanceReportGetController
+        },
+        {
+          method: 'POST',
+          path: '/waste-balance-report',
+          ...wasteBalanceReportPostController
         }
       ])
     }

--- a/src/server/routes/waste-balance-report/index.js
+++ b/src/server/routes/waste-balance-report/index.js
@@ -1,0 +1,16 @@
+import { wasteBalanceReportGetController } from './controller.get.js'
+
+export const wasteBalanceReport = {
+  plugin: {
+    name: 'waste-balance-report',
+    register(server) {
+      server.route([
+        {
+          method: 'GET',
+          path: '/waste-balance-report',
+          ...wasteBalanceReportGetController
+        }
+      ])
+    }
+  }
+}

--- a/src/server/routes/waste-balance-report/index.njk
+++ b/src/server/routes/waste-balance-report/index.njk
@@ -1,0 +1,85 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+
+      {% if error %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: [
+            {
+              text: error
+            }
+          ]
+        }) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
+
+      <p class="govuk-body">
+        View and download each accreditation's waste balance as it stood at the
+        end of a month, with totals per material across all reprocessors and
+        all exporters.
+      </p>
+
+      <form method="GET" action="/waste-balance-report">
+        {{ govukSelect({
+          id: "month",
+          name: "month",
+          label: {
+            text: "Month",
+            classes: "govuk-label--s"
+          },
+          items: months
+        }) }}
+        {{ govukButton({
+          text: "View report"
+        }) }}
+      </form>
+
+      {% if totalsRows %}
+        <form method="POST" action="/waste-balance-report">
+          <input type="hidden" name="crumb" value="{{ crumb }}" />
+          <input type="hidden" name="month" value="{{ month }}" />
+          {{ govukButton({
+            text: "Download CSV",
+            classes: "govuk-button--secondary"
+          }) }}
+        </form>
+
+        {{ govukTable({
+          caption: "Totals by material",
+          captionClasses: "govuk-table__caption--m",
+          head: [
+            { text: "Material" },
+            { text: "Type" },
+            { text: "Balance (tonnes)", format: "numeric" },
+            { text: "Available balance (tonnes)", format: "numeric" }
+          ],
+          rows: totalsRows
+        }) }}
+
+        {{ govukTable({
+          caption: "Accreditations",
+          captionClasses: "govuk-table__caption--m",
+          head: [
+            { text: "Organisation ID" },
+            { text: "Registration number" },
+            { text: "Accreditation number" },
+            { text: "Material" },
+            { text: "Type" },
+            { text: "Balance (tonnes)", format: "numeric" },
+            { text: "Available balance (tonnes)", format: "numeric" }
+          ],
+          rows: accreditationRows
+        }) }}
+      {% endif %}
+
+    </div>
+  </div>
+{% endblock %}

--- a/src/server/routes/waste-balance-report/index.test.js
+++ b/src/server/routes/waste-balance-report/index.test.js
@@ -17,11 +17,22 @@ describe('#waste-balance-report routes plugin', () => {
     wasteBalanceReport.plugin.register(mockServer)
 
     const routes = mockServer.route.mock.calls[0][0]
-    expect(routes).toHaveLength(1)
+    expect(routes).toHaveLength(2)
     expect(routes[0]).toMatchObject({
       method: 'GET',
       path: '/waste-balance-report'
     })
     expect(routes[0]).toHaveProperty('handler')
+  })
+
+  it('registers POST /waste-balance-report with a handler', () => {
+    wasteBalanceReport.plugin.register(mockServer)
+
+    const routes = mockServer.route.mock.calls[0][0]
+    expect(routes[1]).toMatchObject({
+      method: 'POST',
+      path: '/waste-balance-report'
+    })
+    expect(routes[1]).toHaveProperty('handler')
   })
 })

--- a/src/server/routes/waste-balance-report/index.test.js
+++ b/src/server/routes/waste-balance-report/index.test.js
@@ -1,0 +1,27 @@
+import { wasteBalanceReport } from './index.js'
+
+describe('#waste-balance-report routes plugin', () => {
+  const mockServer = {
+    route: vi.fn()
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('has the correct plugin name', () => {
+    expect(wasteBalanceReport.plugin.name).toBe('waste-balance-report')
+  })
+
+  it('registers GET /waste-balance-report with a handler', () => {
+    wasteBalanceReport.plugin.register(mockServer)
+
+    const routes = mockServer.route.mock.calls[0][0]
+    expect(routes).toHaveLength(1)
+    expect(routes[0]).toMatchObject({
+      method: 'GET',
+      path: '/waste-balance-report'
+    })
+    expect(routes[0]).toHaveProperty('handler')
+  })
+})

--- a/src/server/routes/waste-balance-report/months.js
+++ b/src/server/routes/waste-balance-report/months.js
@@ -1,0 +1,137 @@
+/**
+ * Month helpers for the waste balance report.
+ *
+ * The report is Europe/London based throughout: "the previous month" and the
+ * validation bounds are evaluated on the London calendar, and a month's
+ * cutoff is midnight London time on the 1st of the following month. Near a
+ * month boundary London and UTC can disagree on what the current month is,
+ * so every helper that needs a clock takes `now` as a parameter.
+ */
+
+const LONDON_TIME_ZONE = 'Europe/London'
+const MONTH_PATTERN = /^\d{4}-(0[1-9]|1[0-2])$/
+const MILLISECONDS_PER_HOUR = 60 * 60 * 1000
+
+/**
+ * The earliest selectable report month — service start. There is no ledger
+ * data before it.
+ */
+const EARLIEST_REPORT_MONTH = '2026-01'
+
+/**
+ * `YYYY-MM` of the given UTC month-start date.
+ * @param {Date} monthStart
+ */
+const toMonthValue = (monthStart) => monthStart.toISOString().slice(0, 7)
+
+/**
+ * UTC month-start date for a `YYYY-MM` value. `Date.UTC` rolls months over,
+ * so callers can pass an out-of-range month index to step across years.
+ * @param {string} monthValue
+ */
+const toMonthStart = (monthValue) => {
+  const [year, month] = monthValue.split('-').map(Number)
+  return new Date(Date.UTC(year, month - 1, 1))
+}
+
+/**
+ * The UTC month-start one month before the given one.
+ * @param {Date} monthStart
+ */
+const monthBefore = (monthStart) =>
+  new Date(
+    Date.UTC(monthStart.getUTCFullYear(), monthStart.getUTCMonth() - 1, 1)
+  )
+
+/**
+ * The London calendar month containing the instant, as `YYYY-MM`. The en-CA
+ * locale formats dates ISO-style, so it yields the value directly.
+ * @param {Date} instant
+ */
+const londonMonthValue = (instant) =>
+  new Intl.DateTimeFormat('en-CA', {
+    timeZone: LONDON_TIME_ZONE,
+    year: 'numeric',
+    month: '2-digit'
+  }).format(instant)
+
+/**
+ * The most recent complete month on the London calendar, as `YYYY-MM`.
+ * @param {Date} now
+ * @returns {string}
+ */
+const previousReportMonth = (now) =>
+  toMonthValue(monthBefore(toMonthStart(londonMonthValue(now))))
+
+/**
+ * "June 2026"-style label for a `YYYY-MM` month value.
+ * @param {string} monthValue
+ */
+const monthLabel = (monthValue) =>
+  new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'UTC',
+    month: 'long',
+    year: 'numeric'
+  }).format(toMonthStart(monthValue))
+
+/**
+ * govukSelect items for every selectable report month: all complete months
+ * from January 2026 to the previous month, newest first, with the previous
+ * month selected as the default.
+ * @param {Date} now
+ * @returns {{ value: string, text: string, selected: boolean }[]}
+ */
+export const reportMonthItems = (now) => {
+  const latest = previousReportMonth(now)
+  const items = []
+
+  for (
+    let cursor = toMonthStart(latest);
+    toMonthValue(cursor) >= EARLIEST_REPORT_MONTH;
+    cursor = monthBefore(cursor)
+  ) {
+    const value = toMonthValue(cursor)
+    items.push({ value, text: monthLabel(value), selected: value === latest })
+  }
+
+  return items
+}
+
+/**
+ * Whether the value names a selectable report month: a string of well-formed
+ * `YYYY-MM`, no earlier than January 2026 and no later than the previous
+ * London month. Takes raw query-param input, which need not be a string
+ * (Hapi parses a repeated param as an array). Zero-padded `YYYY-MM` values
+ * order lexicographically, so the range check is plain string comparison.
+ * @param {unknown} monthValue
+ * @param {Date} now
+ * @returns {monthValue is string}
+ */
+export const isValidReportMonth = (monthValue, now) =>
+  typeof monthValue === 'string' &&
+  MONTH_PATTERN.test(monthValue) &&
+  monthValue >= EARLIEST_REPORT_MONTH &&
+  monthValue <= previousReportMonth(now)
+
+/**
+ * The report cutoff for a month: midnight Europe/London on the 1st of the
+ * following month, as a UTC instant. At that naive UTC midnight the London
+ * clock reads 00:00 (GMT) or 01:00 (BST); subtracting that hour gives the
+ * instant London midnight actually happened. UK DST never changes within an
+ * hour of a month boundary, so the single adjustment is exact.
+ * @param {string} monthValue - A validated `YYYY-MM` report month.
+ * @returns {Date}
+ */
+export const cutoffForReportMonth = (monthValue) => {
+  const [year, month] = monthValue.split('-').map(Number)
+  // The 1-based month used as a 0-based month index is the following month.
+  const naiveUtcMidnight = Date.UTC(year, month, 1)
+  const londonHour = Number(
+    new Intl.DateTimeFormat('en-GB', {
+      timeZone: LONDON_TIME_ZONE,
+      hour: 'numeric',
+      hourCycle: 'h23'
+    }).format(naiveUtcMidnight)
+  )
+  return new Date(naiveUtcMidnight - londonHour * MILLISECONDS_PER_HOUR)
+}

--- a/src/server/routes/waste-balance-report/months.test.js
+++ b/src/server/routes/waste-balance-report/months.test.js
@@ -1,0 +1,144 @@
+import {
+  cutoffForReportMonth,
+  isValidReportMonth,
+  reportMonthItems
+} from './months.js'
+
+describe('reportMonthItems', () => {
+  it('lists all complete months from January 2026 to the previous month, newest first', () => {
+    const now = new Date('2026-07-14T12:00:00.000Z')
+
+    const items = reportMonthItems(now)
+
+    expect(items.map((item) => item.value)).toEqual([
+      '2026-06',
+      '2026-05',
+      '2026-04',
+      '2026-03',
+      '2026-02',
+      '2026-01'
+    ])
+    expect(items.map((item) => item.text)).toEqual([
+      'June 2026',
+      'May 2026',
+      'April 2026',
+      'March 2026',
+      'February 2026',
+      'January 2026'
+    ])
+  })
+
+  it('selects only the previous month as the default', () => {
+    const now = new Date('2026-07-14T12:00:00.000Z')
+
+    const items = reportMonthItems(now)
+
+    expect(items.map((item) => item.selected)).toEqual([
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ])
+  })
+
+  it('uses the London calendar when UTC has not yet reached the new month', () => {
+    // 23:30 UTC on 30 June is already 00:30 BST on 1 July in London,
+    // so June is complete and becomes the latest selectable month.
+    const now = new Date('2026-06-30T23:30:00.000Z')
+
+    const items = reportMonthItems(now)
+
+    expect(items[0].value).toBe('2026-06')
+    expect(items[0].selected).toBe(true)
+  })
+
+  it('lists no months before the service start', () => {
+    const now = new Date('2026-01-15T12:00:00.000Z')
+
+    const items = reportMonthItems(now)
+
+    expect(items).toEqual([])
+  })
+})
+
+describe('isValidReportMonth', () => {
+  const now = new Date('2026-07-14T12:00:00.000Z')
+
+  it('accepts every month from January 2026 to the previous month', () => {
+    expect(isValidReportMonth('2026-01', now)).toBe(true)
+    expect(isValidReportMonth('2026-06', now)).toBe(true)
+  })
+
+  it.each(['June 2026', '2026-6', '2026-13', '2026-00', 'garbage', ''])(
+    'rejects the malformed value %j',
+    (value) => {
+      expect(isValidReportMonth(value, now)).toBe(false)
+    }
+  )
+
+  it('rejects a non-string value, as Hapi yields for a repeated query param', () => {
+    // A single-element array coerces to a passing string in the regex and
+    // range checks, so only the string type guard rejects it.
+    expect(isValidReportMonth(['2026-06'], now)).toBe(false)
+    expect(isValidReportMonth(undefined, now)).toBe(false)
+  })
+
+  it('rejects months before the January 2026 service start', () => {
+    expect(isValidReportMonth('2025-12', now)).toBe(false)
+  })
+
+  it('rejects the current month', () => {
+    expect(isValidReportMonth('2026-07', now)).toBe(false)
+  })
+
+  it('rejects future months', () => {
+    expect(isValidReportMonth('2027-01', now)).toBe(false)
+  })
+
+  it('accepts the month that has just completed on the London calendar', () => {
+    // 23:30 UTC on 30 June is 00:30 BST on 1 July in London.
+    const justAfterLondonMonthEnd = new Date('2026-06-30T23:30:00.000Z')
+
+    expect(isValidReportMonth('2026-06', justAfterLondonMonthEnd)).toBe(true)
+  })
+})
+
+describe('cutoffForReportMonth', () => {
+  it('maps a BST month to 23:00 UTC on its last day', () => {
+    expect(cutoffForReportMonth('2026-06').toISOString()).toBe(
+      '2026-06-30T23:00:00.000Z'
+    )
+  })
+
+  it('maps a GMT month to midnight UTC on the 1st of the following month', () => {
+    expect(cutoffForReportMonth('2026-12').toISOString()).toBe(
+      '2027-01-01T00:00:00.000Z'
+    )
+  })
+
+  it('stays on GMT for the month ending before the spring clock change', () => {
+    expect(cutoffForReportMonth('2026-02').toISOString()).toBe(
+      '2026-03-01T00:00:00.000Z'
+    )
+  })
+
+  it('uses BST for the month containing the spring clock change', () => {
+    expect(cutoffForReportMonth('2026-03').toISOString()).toBe(
+      '2026-03-31T23:00:00.000Z'
+    )
+  })
+
+  it('uses BST for the month ending before the autumn clock change', () => {
+    expect(cutoffForReportMonth('2026-09').toISOString()).toBe(
+      '2026-09-30T23:00:00.000Z'
+    )
+  })
+
+  it('returns to GMT for the month containing the autumn clock change', () => {
+    expect(cutoffForReportMonth('2026-10').toISOString()).toBe(
+      '2026-11-01T00:00:00.000Z'
+    )
+  })
+})

--- a/src/server/routes/waste-balance-report/types.js
+++ b/src/server/routes/waste-balance-report/types.js
@@ -1,0 +1,36 @@
+/**
+ * Per-material total in the waste balance report. Mirrors the shape returned
+ * by `GET /v1/admin/waste-balances/report` on epr-backend.
+ * @typedef {{
+ *   material: string
+ *   wasteProcessingType: string
+ *   amount: number
+ *   availableAmount: number
+ * }} WasteBalanceReportTotal
+ */
+
+/**
+ * Per-accreditation row in the waste balance report. `orgId` is the
+ * organisation's external reference, not its internal id.
+ * @typedef {{
+ *   orgId: string
+ *   registrationNumber: string
+ *   accreditationNumber: string
+ *   material: string
+ *   wasteProcessingType: string
+ *   amount: number
+ *   availableAmount: number
+ * }} WasteBalanceReportAccreditation
+ */
+
+/**
+ * Waste balance report as at a cutoff instant: per-material totals across
+ * reprocessors and exporters, then per-accreditation balances.
+ * @typedef {{
+ *   cutoff: string
+ *   totals: WasteBalanceReportTotal[]
+ *   accreditations: WasteBalanceReportAccreditation[]
+ * }} WasteBalanceReport
+ */
+
+export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import


### PR DESCRIPTION
## Summary

Admin frontend for the monthly waste balance report (PAE-1676, PRN market supply): a back-office page at `/waste-balance-report` where a user picks a month, views each accreditation's end-of-month waste balance as two on-page tables with per-material totals, and downloads the same data as a two-section CSV. The EA runs this on the 21st of each month, selecting the previous month.

- **Month select** lists every complete month from January 2026 (service start) to the previous month, newest first, defaulting to the previous month. The form submits via GET (`?month=YYYY-MM`), so page state lives in the URL — refresh and shared links re-render the same report.
- **Month → cutoff mapping is Europe/London**: the selected month maps to midnight London time on the 1st of the following month (June 2026 → `2026-06-30T23:00:00Z` BST; December 2026 → `2027-01-01T00:00:00Z` GMT), computed with `Intl` — no new dependency. "The previous month" is evaluated on the London calendar with an injectable clock, tested either side of both BST/GMT transitions.
- **View**: month form, then (for a valid month) a Download CSV button at the top of the results, then two unpaginated `govukTable`s — "Totals by material" and "Accreditations" — with numeric right-aligned cells and en-GB thousand separators. An empty report renders both tables with headers only.
- **Download**: two-section CSV (`material,type,total_balance,total_available_balance`, blank line, `org_id,registration_number,accreditation_number,material,type,balance,available_balance`), raw numbers, formula-injection sanitisation on identifier cells, filename `waste-balance-report-<YYYY-MM>.csv`.
- **Tables and CSV cannot drift**: both controllers go through one shared fetch helper that maps the month to its cutoff, calls `GET /v1/admin/waste-balances/report` on epr-backend (DEFRA/epr-backend#1506), and returns the report in canonical order (pinned `en` numeric collation: totals by material then type; accreditations by material, type, accreditation number).
- **Errors**: backend failure on download → flash + redirect preserving the month; on view → the error renders directly (flash-and-redirect on a failing GET back to itself would loop). Invalid or out-of-range months (including the Hapi repeated-param array case) are rejected in both controllers.

Depends on DEFRA/epr-backend#1506 for real data; frontend tests mock the backend against the contract pinned in `types.js`.

## Changes

- `src/server/routes/waste-balance-report/months.js` + tests — month list, validation (string-guarded), Europe/London cutoff mapping with injectable now.
- `src/server/routes/waste-balance-report/fetch-report.js` + tests — shared month→cutoff→backend fetch returning canonically sorted data.
- `src/server/routes/waste-balance-report/types.js` — JSDoc typedefs mirroring the backend contract.
- `src/server/routes/waste-balance-report/controller.get.js` + tests — the view: form-only / tables / invalid-month 400 / direct error render.
- `src/server/routes/waste-balance-report/controller.post.js` + tests — the CSV download.
- `src/server/routes/waste-balance-report/index.js` + tests, `index.njk` — plugin (GET + POST) and page template.
- `src/server/router.js`, `src/config/nunjucks/context/build-navigation.js` + tests — route and "Waste balance report" nav item registration.
