### PR TITLE
PAE-000: require curly braces around control statements

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,7 @@ export default [
   }),
   {
     rules: {
+      curly: ['error', 'all'],
       eqeqeq: ['error', 'always'],
       'no-unused-vars': [
         'error',

--- a/src/client/javascripts/jsoneditor.helpers.test.js
+++ b/src/client/javascripts/jsoneditor.helpers.test.js
@@ -1099,12 +1099,24 @@ describe('JSONEditor Helpers', () => {
       // Mock document.getElementById
       originalGetElementById = document.getElementById
       document.getElementById = vi.fn((id) => {
-        if (id === 'jsoneditor') return container
-        if (id === 'organisation-json') return payloadEl
-        if (id === 'jsoneditor-organisation-object') return hiddenInput
-        if (id === 'jsoneditor-reset-button') return resetButton
-        if (id === 'jsoneditor-save-button') return saveButton
-        if (id === 'organisation-success-message') return messageEl
+        if (id === 'jsoneditor') {
+          return container
+        }
+        if (id === 'organisation-json') {
+          return payloadEl
+        }
+        if (id === 'jsoneditor-organisation-object') {
+          return hiddenInput
+        }
+        if (id === 'jsoneditor-reset-button') {
+          return resetButton
+        }
+        if (id === 'jsoneditor-save-button') {
+          return saveButton
+        }
+        if (id === 'organisation-success-message') {
+          return messageEl
+        }
         return null
       })
 
@@ -1208,10 +1220,18 @@ describe('JSONEditor Helpers', () => {
       document.getElementById = /** @type {typeof document.getElementById} */ (
         /** @type {unknown} */ (
           vi.fn((id) => {
-            if (id === 'custom-container') return customContainer
-            if (id === 'custom-payload') return customPayload
-            if (id === 'custom-input') return customInput
-            if (id === 'custom-button') return customButton
+            if (id === 'custom-container') {
+              return customContainer
+            }
+            if (id === 'custom-payload') {
+              return customPayload
+            }
+            if (id === 'custom-input') {
+              return customInput
+            }
+            if (id === 'custom-button') {
+              return customButton
+            }
             return null
           })
         )
@@ -1251,8 +1271,12 @@ describe('JSONEditor Helpers', () => {
 
     it('should not initialise when payload element does not exist', () => {
       document.getElementById = vi.fn((id) => {
-        if (id === 'jsoneditor') return container
-        if (id === 'organisation-json') return null
+        if (id === 'jsoneditor') {
+          return container
+        }
+        if (id === 'organisation-json') {
+          return null
+        }
         return null
       })
 
@@ -1283,10 +1307,18 @@ describe('JSONEditor Helpers', () => {
 
     it('should handle missing hidden input', () => {
       document.getElementById = vi.fn((id) => {
-        if (id === 'jsoneditor') return container
-        if (id === 'organisation-json') return payloadEl
-        if (id === 'jsoneditor-organisation-object') return null
-        if (id === 'jsoneditor-reset-button') return resetButton
+        if (id === 'jsoneditor') {
+          return container
+        }
+        if (id === 'organisation-json') {
+          return payloadEl
+        }
+        if (id === 'jsoneditor-organisation-object') {
+          return null
+        }
+        if (id === 'jsoneditor-reset-button') {
+          return resetButton
+        }
         return null
       })
 
@@ -1336,13 +1368,27 @@ describe('JSONEditor Helpers', () => {
       const warningPlaceholder = { innerHTML: '' }
       const originalGetById = document.getElementById
       document.getElementById = vi.fn((id) => {
-        if (id === 'jsoneditor') return container
-        if (id === 'organisation-json') return payloadEl
-        if (id === 'jsoneditor-organisation-object') return hiddenInput
-        if (id === 'jsoneditor-reset-button') return resetButton
-        if (id === 'jsoneditor-save-button') return saveButton
-        if (id === 'organisation-success-message') return messageEl
-        if (id === 'stale-draft-warning-placeholder') return warningPlaceholder
+        if (id === 'jsoneditor') {
+          return container
+        }
+        if (id === 'organisation-json') {
+          return payloadEl
+        }
+        if (id === 'jsoneditor-organisation-object') {
+          return hiddenInput
+        }
+        if (id === 'jsoneditor-reset-button') {
+          return resetButton
+        }
+        if (id === 'jsoneditor-save-button') {
+          return saveButton
+        }
+        if (id === 'organisation-success-message') {
+          return messageEl
+        }
+        if (id === 'stale-draft-warning-placeholder') {
+          return warningPlaceholder
+        }
         return null
       })
 
@@ -1389,12 +1435,24 @@ describe('JSONEditor Helpers', () => {
 
       const originalGetById = document.getElementById
       document.getElementById = vi.fn((id) => {
-        if (id === 'jsoneditor') return container
-        if (id === 'organisation-json') return payloadEl
-        if (id === 'jsoneditor-organisation-object') return hiddenInput
-        if (id === 'jsoneditor-reset-button') return resetButton
-        if (id === 'jsoneditor-save-button') return saveButton
-        if (id === 'organisation-success-message') return messageEl
+        if (id === 'jsoneditor') {
+          return container
+        }
+        if (id === 'organisation-json') {
+          return payloadEl
+        }
+        if (id === 'jsoneditor-organisation-object') {
+          return hiddenInput
+        }
+        if (id === 'jsoneditor-reset-button') {
+          return resetButton
+        }
+        if (id === 'jsoneditor-save-button') {
+          return saveButton
+        }
+        if (id === 'organisation-success-message') {
+          return messageEl
+        }
         return null
       })
 
@@ -1416,11 +1474,21 @@ describe('JSONEditor Helpers', () => {
     it('should not throw when the reset button is missing', () => {
       const originalGetById = document.getElementById
       document.getElementById = vi.fn((id) => {
-        if (id === 'jsoneditor') return container
-        if (id === 'organisation-json') return payloadEl
-        if (id === 'jsoneditor-organisation-object') return hiddenInput
-        if (id === 'jsoneditor-save-button') return saveButton
-        if (id === 'organisation-success-message') return messageEl
+        if (id === 'jsoneditor') {
+          return container
+        }
+        if (id === 'organisation-json') {
+          return payloadEl
+        }
+        if (id === 'jsoneditor-organisation-object') {
+          return hiddenInput
+        }
+        if (id === 'jsoneditor-save-button') {
+          return saveButton
+        }
+        if (id === 'organisation-success-message') {
+          return messageEl
+        }
         return null
       })
 
@@ -1663,11 +1731,21 @@ describe('JSONEditor Helpers', () => {
 
     it('should handle missing save button gracefully', () => {
       document.getElementById = vi.fn((id) => {
-        if (id === 'jsoneditor') return container
-        if (id === 'organisation-json') return payloadEl
-        if (id === 'jsoneditor-organisation-object') return hiddenInput
-        if (id === 'jsoneditor-reset-button') return resetButton
-        if (id === 'jsoneditor-save-button') return null
+        if (id === 'jsoneditor') {
+          return container
+        }
+        if (id === 'organisation-json') {
+          return payloadEl
+        }
+        if (id === 'jsoneditor-organisation-object') {
+          return hiddenInput
+        }
+        if (id === 'jsoneditor-reset-button') {
+          return resetButton
+        }
+        if (id === 'jsoneditor-save-button') {
+          return null
+        }
         return null
       })
 
@@ -1733,8 +1811,12 @@ describe('JSONEditor Helpers', () => {
 
         const originalGetById = document.getElementById
         document.getElementById = vi.fn((id) => {
-          if (id === 'add-registration-button') return addRegistrationButton
-          if (id === 'add-accreditation-button') return addAccreditationButton
+          if (id === 'add-registration-button') {
+            return addRegistrationButton
+          }
+          if (id === 'add-accreditation-button') {
+            return addAccreditationButton
+          }
           return originalGetById(id)
         })
       })
@@ -1875,13 +1957,27 @@ describe('JSONEditor Helpers', () => {
 
       it('should not throw when append button does not exist in DOM', () => {
         document.getElementById = vi.fn((id) => {
-          if (id === 'jsoneditor') return container
-          if (id === 'organisation-json') return payloadEl
-          if (id === 'jsoneditor-organisation-object') return hiddenInput
-          if (id === 'jsoneditor-reset-button') return resetButton
-          if (id === 'jsoneditor-save-button') return saveButton
-          if (id === 'add-registration-button') return null
-          if (id === 'add-accreditation-button') return null
+          if (id === 'jsoneditor') {
+            return container
+          }
+          if (id === 'organisation-json') {
+            return payloadEl
+          }
+          if (id === 'jsoneditor-organisation-object') {
+            return hiddenInput
+          }
+          if (id === 'jsoneditor-reset-button') {
+            return resetButton
+          }
+          if (id === 'jsoneditor-save-button') {
+            return saveButton
+          }
+          if (id === 'add-registration-button') {
+            return null
+          }
+          if (id === 'add-accreditation-button') {
+            return null
+          }
           return null
         })
 

--- a/src/server/common/helpers/auth/get-bell-options.test.js
+++ b/src/server/common/helpers/auth/get-bell-options.test.js
@@ -81,7 +81,9 @@ describe('#getBellOptions', () => {
 
   test('Should set isSecure and forceHttps to true in production', () => {
     config.get = vi.fn().mockImplementation((key) => {
-      if (key === 'isProduction') return true
+      if (key === 'isProduction') {
+        return true
+      }
       return mockConfig[key]
     })
 
@@ -187,7 +189,9 @@ describe('#getBellOptions', () => {
 
     testUrls.forEach((url) => {
       config.get = vi.fn().mockImplementation((key) => {
-        if (key === 'appBaseUrl') return url
+        if (key === 'appBaseUrl') {
+          return url
+        }
         return mockConfig[key]
       })
 

--- a/src/server/common/helpers/auth/get-cookie-options.test.js
+++ b/src/server/common/helpers/auth/get-cookie-options.test.js
@@ -48,7 +48,9 @@ describe('#getCookieOptions', () => {
 
   test('Should set isSecure to true in production', () => {
     config.get = vi.fn().mockImplementation((key) => {
-      if (key === 'isProduction') return true
+      if (key === 'isProduction') {
+        return true
+      }
       return mockConfig[key]
     })
 
@@ -233,7 +235,9 @@ describe('#getCookieOptions', () => {
 
     passwords.forEach((password) => {
       config.get = vi.fn().mockImplementation((key) => {
-        if (key === 'session.cookie.password') return password
+        if (key === 'session.cookie.password') {
+          return password
+        }
         return mockConfig[key]
       })
 

--- a/src/server/common/test-helpers/csrf-helper.js
+++ b/src/server/common/test-helpers/csrf-helper.js
@@ -20,7 +20,9 @@ export async function getCsrfToken(server, getUrl, auth) {
   const crumbCookie = cookies.find(
     (cookie) => cookie && cookie.startsWith('crumb=')
   )
-  if (!crumbCookie) throw new Error('No crumb cookie found')
+  if (!crumbCookie) {
+    throw new Error('No crumb cookie found')
+  }
   const crumbValue = crumbCookie.split(';')[0].split('=')[1]
   // Preserve all cookies from the response (e.g., session + crumb)
   // to accurately represent multi-cookie scenarios in tests

--- a/src/server/routes/organisation/controller.get.test.js
+++ b/src/server/routes/organisation/controller.get.test.js
@@ -81,7 +81,9 @@ describe('organisation GET controller - Unit Tests - Flash message handling', ()
 
     fetchJsonFromBackend.mockResolvedValue(mockOrgData)
     mockRequest.yar.get.mockImplementation((key) => {
-      if (key === 'errorList') return mockErrorList
+      if (key === 'errorList') {
+        return mockErrorList
+      }
       return null
     })
 
@@ -103,7 +105,9 @@ describe('organisation GET controller - Unit Tests - Flash message handling', ()
 
     fetchJsonFromBackend.mockResolvedValue(mockOrgData)
     mockRequest.yar.get.mockImplementation((key) => {
-      if (key === 'success') return true
+      if (key === 'success') {
+        return true
+      }
       return null
     })
 
@@ -127,8 +131,12 @@ describe('organisation GET controller - Unit Tests - Flash message handling', ()
 
     fetchJsonFromBackend.mockResolvedValue(mockOrgData)
     mockRequest.yar.get.mockImplementation((key) => {
-      if (key === 'errorList') return mockErrorList
-      if (key === 'success') return true
+      if (key === 'errorList') {
+        return mockErrorList
+      }
+      if (key === 'success') {
+        return true
+      }
       return null
     })
 

--- a/src/server/routes/prn-activity/controller.download.js
+++ b/src/server/routes/prn-activity/controller.download.js
@@ -7,7 +7,9 @@ import { buildPrnApiUrl } from './controller.js'
 const dateFormat = 'dd/MM/yyyy'
 
 function getDisplayName(org) {
-  if (!org) return ''
+  if (!org) {
+    return ''
+  }
   return org.tradingName || org.name || ''
 }
 

--- a/src/server/routes/prn-activity/controller.js
+++ b/src/server/routes/prn-activity/controller.js
@@ -6,7 +6,9 @@ const statuses =
   'awaiting_authorisation,awaiting_acceptance,accepted,awaiting_cancellation,cancelled,deleted'
 
 function getDisplayName(org) {
-  if (!org) return ''
+  if (!org) {
+    return ''
+  }
   return org.tradingName || org.name || ''
 }
 

--- a/src/server/routes/summary-log/controller.get.test.js
+++ b/src/server/routes/summary-log/controller.get.test.js
@@ -9,7 +9,9 @@ vi.mock('#server/common/helpers/fetch-json-from-backend.js', () => ({
 
 vi.mock('#server/common/helpers/formatters.js', () => ({
   formatDateTime: vi.fn((isoString) => {
-    if (!isoString) return ''
+    if (!isoString) {
+      return ''
+    }
     if (isoString.includes('2026-02-06T14:30')) {
       return '6 February 2026 at 2:30pm'
     }

--- a/src/server/routes/summary-log/controller.post.test.js
+++ b/src/server/routes/summary-log/controller.post.test.js
@@ -8,7 +8,9 @@ vi.mock('#server/common/helpers/fetch-json-from-backend.js', () => ({
 
 vi.mock('#server/common/helpers/formatters.js', () => ({
   formatDateTime: vi.fn((isoString) => {
-    if (!isoString) return ''
+    if (!isoString) {
+      return ''
+    }
     if (isoString.includes('2026-02-06T14:30')) {
       return '6 February 2026 at 2:30pm'
     }


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
adds eslint `curly: ['error', 'all']` rule to require braces around all if/else/for/while bodies, and braces existing violations, catching before commit what sonarqube flags.