### PR TITLE
PAE-000: standardise jsdoc type imports on @import

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,5 @@
 import neostandard from 'neostandard'
+import jsdoc from 'eslint-plugin-jsdoc'
 
 export default [
   ...neostandard({
@@ -10,6 +11,18 @@ export default [
     noJsx: true,
     noStyle: true
   }),
+  {
+    plugins: { jsdoc },
+    rules: {
+      // Prefer `@import { X } from '...'` over inline `import('...').X` in types.
+      // named-import avoids the fixer's mangled namespace output; do not rely on
+      // --fix (wrong placement, no block merge) - hoist by hand when flagged.
+      'jsdoc/prefer-import-tag': [
+        'error',
+        { outputType: 'named-import', exemptTypedefs: false }
+      ]
+    }
+  },
   {
     rules: {
       eqeqeq: ['error', 'always'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "copy-webpack-plugin": "14.0.0",
         "css-loader": "7.1.4",
         "eslint": "9.39.2",
+        "eslint-plugin-jsdoc": "63.0.13",
         "happy-dom": "20.10.2",
         "husky": "9.1.7",
         "lint-staged": "17.0.7",
@@ -2533,6 +2534,47 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.88.0.tgz",
+      "integrity": "sha512-GK/HL/claLLNo5KG705auIlZMwEtmn88ofSGuLsmVZwKBqMPJhW9DiznYNq07QEqz9BPtA3LBfYImtZmhVvRAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.9",
+        "@typescript-eslint/types": "^8.59.4",
+        "comment-parser": "1.4.7",
+        "esquery": "^1.7.0",
+        "jsdoc-type-pratt-parser": "~7.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment/node_modules/@typescript-eslint/types": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
+      "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@es-joy/resolve.exports": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz",
+      "integrity": "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -4174,6 +4216,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sindresorhus/base62": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
+      "integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
@@ -4303,9 +4358,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5444,6 +5499,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -6451,6 +6516,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/comment-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
+      "integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/concat-map": {
@@ -7531,6 +7606,77 @@
       },
       "peerDependencies": {
         "eslint": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "63.0.13",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.0.13.tgz",
+      "integrity": "sha512-ahG1kWA8jYNwaQJtzJlnF+v4Gb9w5r+WL98gp+L8qjLN9ErpL5sevGuemN+fCYsU3Np27F36KmDc8UPi1ml/dg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.88.0",
+        "@es-joy/resolve.exports": "1.2.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.7",
+        "debug": "^4.4.3",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "html-entities": "^2.6.0",
+        "object-deep-merge": "^2.0.1",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.8.5",
+        "spdx-expression-parse": "^4.0.0",
+        "to-valid-identifier": "^1.0.0"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "node_modules/eslint-plugin-n": {
@@ -8702,6 +8848,23 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -9634,6 +9797,16 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz",
+      "integrity": "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -11411,6 +11584,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-deep-merge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.1.tgz",
+      "integrity": "sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -11684,6 +11864,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/parse-imports-exports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+      "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-statements": "1.0.11"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -11702,6 +11892,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse-statements": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+      "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -13194,6 +13391,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/reserved-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+      "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/resolve": {
@@ -15519,6 +15729,23 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/to-valid-identifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
+      "integrity": "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/base62": "^1.0.0",
+        "reserved-identifiers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/touch": {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "copy-webpack-plugin": "14.0.0",
     "css-loader": "7.1.4",
     "eslint": "9.39.2",
+    "eslint-plugin-jsdoc": "63.0.13",
     "happy-dom": "20.10.2",
     "husky": "9.1.7",
     "lint-staged": "17.0.7",

--- a/src/client/javascripts/jsoneditor.js
+++ b/src/client/javascripts/jsoneditor.js
@@ -3,8 +3,9 @@ import { initJSONEditor } from './jsoneditor.helpers.js'
 import rawValidate from '#server/common/schemas/organisation.ajv.js'
 // @ts-expect-error -- JSON import; eslint parser doesn't support import attributes yet
 import schema from '#server/common/schemas/organisation.json'
+/** @import { ValidateFunction } from 'ajv' */
 
-/** @type {import('ajv').ValidateFunction} */
+/** @type {ValidateFunction} */
 const validate = rawValidate
 
 initJSONEditor({

--- a/src/client/javascripts/jsoneditor.js
+++ b/src/client/javascripts/jsoneditor.js
@@ -3,6 +3,7 @@ import { initJSONEditor } from './jsoneditor.helpers.js'
 import rawValidate from '#server/common/schemas/organisation.ajv.js'
 // @ts-expect-error -- JSON import; eslint parser doesn't support import attributes yet
 import schema from '#server/common/schemas/organisation.json'
+
 /** @import { ValidateFunction } from 'ajv' */
 
 /** @type {ValidateFunction} */

--- a/src/server/common/helpers/auth/require-scope.js
+++ b/src/server/common/helpers/auth/require-scope.js
@@ -1,5 +1,6 @@
 import { statusCodes } from '#server/common/constants/status-codes.js'
 import { getUserSession } from './get-user-session.js'
+
 /** @import { Lifecycle } from '@hapi/hapi' */
 
 /**

--- a/src/server/common/helpers/auth/require-scope.js
+++ b/src/server/common/helpers/auth/require-scope.js
@@ -1,5 +1,6 @@
 import { statusCodes } from '#server/common/constants/status-codes.js'
 import { getUserSession } from './get-user-session.js'
+/** @import { Lifecycle } from '@hapi/hapi' */
 
 /**
  * Hapi pre-handler that gates a route on the presence of an `admin.*` scope
@@ -12,7 +13,7 @@ import { getUserSession } from './get-user-session.js'
  * than letting the backend 403 surface as a generic error after a render.
  *
  * @param {string} scope - Required scope, e.g. 'admin.write' or 'admin.dlq.purge'.
- * @returns {{ method: import('@hapi/hapi').Lifecycle.Method }}
+ * @returns {{ method: Lifecycle.Method }}
  */
 export function requireScope(scope) {
   return {

--- a/src/server/common/helpers/auth/require-scope.test.js
+++ b/src/server/common/helpers/auth/require-scope.test.js
@@ -2,6 +2,8 @@ import { vi, describe, test, beforeEach, expect } from 'vitest'
 
 import { requireScope } from './require-scope.js'
 import { getUserSession } from './get-user-session.js'
+/** @import { Request, ResponseToolkit } from '@hapi/hapi' */
+/** @import { Mock } from 'vitest' */
 
 vi.mock('./get-user-session.js')
 
@@ -11,10 +13,10 @@ vi.mock('./get-user-session.js')
  * methods Hapi normally returns from `h.view(...)` can be asserted directly
  * on `h` (the test fixture wires them with `mockReturnThis` to flatten the
  * chain).
- * @typedef {import('@hapi/hapi').ResponseToolkit & {
- *   view: import('vitest').Mock,
- *   code: import('vitest').Mock,
- *   takeover: import('vitest').Mock
+ * @typedef {ResponseToolkit & {
+ *   view: Mock,
+ *   code: Mock,
+ *   takeover: Mock
  * }} MockToolkit
  */
 
@@ -29,9 +31,9 @@ describe('#requireScope', () => {
       })
     )
 
-  /** @returns {import('@hapi/hapi').Request} */
+  /** @returns {Request} */
   const mockRequest = () =>
-    /** @type {import('@hapi/hapi').Request} */ (
+    /** @type {Request} */ (
       /** @type {unknown} */ ({ logger: { info: vi.fn() } })
     )
 

--- a/src/server/common/helpers/auth/require-scope.test.js
+++ b/src/server/common/helpers/auth/require-scope.test.js
@@ -2,6 +2,7 @@ import { vi, describe, test, beforeEach, expect } from 'vitest'
 
 import { requireScope } from './require-scope.js'
 import { getUserSession } from './get-user-session.js'
+
 /** @import { Request, ResponseToolkit } from '@hapi/hapi' */
 /** @import { Mock } from 'vitest' */
 

--- a/src/server/common/helpers/auth/validate-and-refresh-session.test.js
+++ b/src/server/common/helpers/auth/validate-and-refresh-session.test.js
@@ -3,8 +3,9 @@ import Jwt from '@hapi/jwt'
 
 import { validateAndRefreshSession } from './validate-and-refresh-session.js'
 import { makeToken } from '#server/common/test-helpers/test-constants.js'
+/** @import { HapiJwt } from '@hapi/jwt' */
 
-/** @typedef {import('@hapi/jwt').HapiJwt.Artifacts} JwtArtifacts */
+/** @typedef {HapiJwt.Artifacts} JwtArtifacts */
 
 /**
  * Cast a partial decoded-token shape (just enough for the consumer's

--- a/src/server/common/helpers/auth/validate-and-refresh-session.test.js
+++ b/src/server/common/helpers/auth/validate-and-refresh-session.test.js
@@ -3,6 +3,7 @@ import Jwt from '@hapi/jwt'
 
 import { validateAndRefreshSession } from './validate-and-refresh-session.js'
 import { makeToken } from '#server/common/test-helpers/test-constants.js'
+
 /** @import { HapiJwt } from '@hapi/jwt' */
 
 /** @typedef {HapiJwt.Artifacts} JwtArtifacts */

--- a/src/server/common/helpers/fetch-json-from-backend.test.js
+++ b/src/server/common/helpers/fetch-json-from-backend.test.js
@@ -13,6 +13,7 @@ import { config } from '#config/config.js'
 import { getUserSession } from '#server/common/helpers/auth/get-user-session.js'
 import { mockUserSession } from '#server/common/test-helpers/fixtures.js'
 import { http, HttpResponse, server as mswServer } from '#vite/setup-msw.js'
+
 /** @import { HapiRequest } from '#server/common/hapi-types.js' */
 
 /**

--- a/src/server/common/helpers/fetch-json-from-backend.test.js
+++ b/src/server/common/helpers/fetch-json-from-backend.test.js
@@ -13,8 +13,7 @@ import { config } from '#config/config.js'
 import { getUserSession } from '#server/common/helpers/auth/get-user-session.js'
 import { mockUserSession } from '#server/common/test-helpers/fixtures.js'
 import { http, HttpResponse, server as mswServer } from '#vite/setup-msw.js'
-
-/** @typedef {import('#server/common/hapi-types.js').HapiRequest} HapiRequest */
+/** @import { HapiRequest } from '#server/common/hapi-types.js' */
 
 /**
  * The helper reads the request only via the mocked `getUserSession`, so an

--- a/src/server/common/helpers/fetch-organisation-overview.js
+++ b/src/server/common/helpers/fetch-organisation-overview.js
@@ -1,6 +1,7 @@
 import { errorCodes } from '#server/common/enums/error-codes.js'
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
 import { notFound } from '#server/common/helpers/logging/cdp-boom.js'
+/** @import { Request } from '@hapi/hapi' */
 
 /**
  * @typedef {{
@@ -35,7 +36,7 @@ import { notFound } from '#server/common/helpers/logging/cdp-boom.js'
  */
 
 /**
- * @param {import('@hapi/hapi').Request} request
+ * @param {Request} request
  * @param {string} organisationId
  * @returns {Promise<OrganisationOverview>}
  */

--- a/src/server/common/helpers/fetch-organisation-overview.js
+++ b/src/server/common/helpers/fetch-organisation-overview.js
@@ -1,6 +1,7 @@
 import { errorCodes } from '#server/common/enums/error-codes.js'
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
 import { notFound } from '#server/common/helpers/logging/cdp-boom.js'
+
 /** @import { Request } from '@hapi/hapi' */
 
 /**

--- a/src/server/common/helpers/fetch-redirect-from-backend.js
+++ b/src/server/common/helpers/fetch-redirect-from-backend.js
@@ -4,6 +4,7 @@ import { badGateway, classifierTail, internal } from './logging/cdp-boom.js'
 import { getUserSession } from './auth/get-user-session.js'
 import { withTraceId } from '@defra/hapi-tracing'
 import { getTracingHeaderName } from './request-tracing.js'
+
 /** @import { Request } from '@hapi/hapi' */
 
 /**

--- a/src/server/common/helpers/fetch-redirect-from-backend.js
+++ b/src/server/common/helpers/fetch-redirect-from-backend.js
@@ -4,11 +4,12 @@ import { badGateway, classifierTail, internal } from './logging/cdp-boom.js'
 import { getUserSession } from './auth/get-user-session.js'
 import { withTraceId } from '@defra/hapi-tracing'
 import { getTracingHeaderName } from './request-tracing.js'
+/** @import { Request } from '@hapi/hapi' */
 
 /**
  * Fetch a redirect response from the backend without following it.
  * Returns the Location header URL from the redirect response.
- * @param {import('@hapi/hapi').Request} request - The Hapi request object
+ * @param {Request} request - The Hapi request object
  * @param {string} path - The API path to append to the backend URL
  * @returns {Promise<string>} The redirect Location URL
  */

--- a/src/server/routes/accreditation-overseas-sites/get.integration.test.js
+++ b/src/server/routes/accreditation-overseas-sites/get.integration.test.js
@@ -13,6 +13,7 @@ import {
 } from '@testing-library/dom'
 import { Window } from 'happy-dom'
 import { vi } from 'vitest'
+/** @import { OverseasSites } from './controller.get.js' */
 
 vi.mock('#server/common/helpers/auth/get-user-session.js', () => ({
   getUserSession: vi.fn().mockReturnValue(null)
@@ -68,10 +69,6 @@ describe('#accreditationOverseasSitesController', () => {
     companyName: 'ACME ltd',
     registrations: []
   }
-
-  /**
-   * @typedef {import('./controller.get.js').OverseasSites} OverseasSites
-   */
 
   /** @type {OverseasSites} */
   const mockSites = {

--- a/src/server/routes/accreditation-overseas-sites/get.integration.test.js
+++ b/src/server/routes/accreditation-overseas-sites/get.integration.test.js
@@ -13,6 +13,7 @@ import {
 } from '@testing-library/dom'
 import { Window } from 'happy-dom'
 import { vi } from 'vitest'
+
 /** @import { OverseasSites } from './controller.get.js' */
 
 vi.mock('#server/common/helpers/auth/get-user-session.js', () => ({

--- a/src/server/routes/auth/callback/get.integration.test.js
+++ b/src/server/routes/auth/callback/get.integration.test.js
@@ -11,6 +11,8 @@ import {
 import { http, server as mswServer, HttpResponse } from '#vite/setup-msw.js'
 import Jwt from '@hapi/jwt'
 
+/** @import * as MetricsModule from '#server/common/helpers/metrics/index.js' */
+
 const mock = {
   cdpAuditing: vi.fn(),
   signInSuccessMetric: vi.fn(),
@@ -19,9 +21,7 @@ const mock = {
 
 vi.mock('#server/common/helpers/metrics/index.js', async (importOriginal) => ({
   metrics: {
-    .../** @type {typeof import('#server/common/helpers/metrics/index.js')} */ (
-      await importOriginal()
-    ).metrics,
+    .../** @type {typeof MetricsModule} */ (await importOriginal()).metrics,
     signInFailure: () => mock.signInFailureMetric(),
     signInSuccess: () => mock.signInSuccessMetric()
   }

--- a/src/server/routes/auth/callback/index.test.js
+++ b/src/server/routes/auth/callback/index.test.js
@@ -6,6 +6,7 @@ import { fetchAdminMe } from '#server/common/helpers/auth/fetch-admin-me.js'
 import { randomUUID } from 'node:crypto'
 import { auditSignIn } from '#server/common/helpers/auditing/index.js'
 import { asRequest } from '#server/common/test-helpers/fixtures.js'
+/** @import { ResponseToolkit } from '@hapi/hapi' */
 
 vi.mock('#server/common/helpers/auth/create-user-session.js')
 vi.mock('#server/common/helpers/auth/fetch-admin-me.js')
@@ -15,10 +16,9 @@ vi.mock('node:crypto')
 /**
  * Cast a partial mock toolkit to the full `ResponseToolkit` shape.
  * @param {unknown} obj
- * @returns {import('@hapi/hapi').ResponseToolkit}
+ * @returns {ResponseToolkit}
  */
-const asToolkit = (obj) =>
-  /** @type {import('@hapi/hapi').ResponseToolkit} */ (obj)
+const asToolkit = (obj) => /** @type {ResponseToolkit} */ (obj)
 
 const ADMIN_ME_DEFAULT = {
   scopes: ['admin.read', 'admin.write', 'admin.dlq.purge']

--- a/src/server/routes/auth/callback/index.test.js
+++ b/src/server/routes/auth/callback/index.test.js
@@ -6,6 +6,7 @@ import { fetchAdminMe } from '#server/common/helpers/auth/fetch-admin-me.js'
 import { randomUUID } from 'node:crypto'
 import { auditSignIn } from '#server/common/helpers/auditing/index.js'
 import { asRequest } from '#server/common/test-helpers/fixtures.js'
+
 /** @import { ResponseToolkit } from '@hapi/hapi' */
 
 vi.mock('#server/common/helpers/auth/create-user-session.js')

--- a/src/server/routes/credited-tonnage/controller.post.js
+++ b/src/server/routes/credited-tonnage/controller.post.js
@@ -2,6 +2,7 @@ import { writeToString } from '@fast-csv/format'
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
 import { sanitizeFormulaInjection } from '#server/common/helpers/sanitize-formula-injection.js'
 import { createLogger } from '#server/common/helpers/logging/logger.js'
+
 /** @import { CreditedTonnageApiRow } from './types.js' */
 
 const logger = createLogger()

--- a/src/server/routes/credited-tonnage/controller.post.js
+++ b/src/server/routes/credited-tonnage/controller.post.js
@@ -2,6 +2,7 @@ import { writeToString } from '@fast-csv/format'
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
 import { sanitizeFormulaInjection } from '#server/common/helpers/sanitize-formula-injection.js'
 import { createLogger } from '#server/common/helpers/logging/logger.js'
+/** @import { CreditedTonnageApiRow } from './types.js' */
 
 const logger = createLogger()
 
@@ -18,7 +19,7 @@ function toFilenameTimestamp(isoTimestamp) {
 }
 
 /**
- * @param {import('./types.js').CreditedTonnageApiRow} row
+ * @param {CreditedTonnageApiRow} row
  * @returns {string[]}
  */
 function buildDataRow(row) {
@@ -35,7 +36,7 @@ function buildDataRow(row) {
 }
 
 /**
- * @param {import('./types.js').CreditedTonnageApiRow[]} data
+ * @param {CreditedTonnageApiRow[]} data
  * @returns {Promise<string>}
  */
 function generateCsv(data) {

--- a/src/server/routes/credited-tonnage/formatters.js
+++ b/src/server/routes/credited-tonnage/formatters.js
@@ -1,5 +1,6 @@
 import { format, parseISO } from 'date-fns'
 import { formatMaterialName } from '#server/common/helpers/format-material-name.js'
+
 /** @import { CreditedTonnageApiRow, CreditedTonnageRow } from './types.js' */
 
 const numberFormatter = new Intl.NumberFormat('en-GB', {

--- a/src/server/routes/credited-tonnage/formatters.js
+++ b/src/server/routes/credited-tonnage/formatters.js
@@ -1,5 +1,6 @@
 import { format, parseISO } from 'date-fns'
 import { formatMaterialName } from '#server/common/helpers/format-material-name.js'
+/** @import { CreditedTonnageApiRow, CreditedTonnageRow } from './types.js' */
 
 const numberFormatter = new Intl.NumberFormat('en-GB', {
   minimumFractionDigits: 2,
@@ -32,8 +33,8 @@ export function formatProcessingType(processingType) {
 }
 
 /**
- * @param {import('./types.js').CreditedTonnageApiRow} row
- * @returns {import('./types.js').CreditedTonnageRow}
+ * @param {CreditedTonnageApiRow} row
+ * @returns {CreditedTonnageRow}
  */
 export function mapCreditedTonnageRow(row) {
   return {

--- a/src/server/routes/report-submissions/controller.post.js
+++ b/src/server/routes/report-submissions/controller.post.js
@@ -3,6 +3,7 @@ import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-bac
 import { sanitizeFormulaInjection } from '#server/common/helpers/sanitize-formula-injection.js'
 import { formatDateTime } from '#server/common/helpers/formatters.js'
 import { createLogger } from '#server/common/helpers/logging/logger.js'
+
 /** @import { ReportSubmissionsRow } from './types.js' */
 
 const logger = createLogger()

--- a/src/server/routes/report-submissions/controller.post.js
+++ b/src/server/routes/report-submissions/controller.post.js
@@ -3,11 +3,12 @@ import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-bac
 import { sanitizeFormulaInjection } from '#server/common/helpers/sanitize-formula-injection.js'
 import { formatDateTime } from '#server/common/helpers/formatters.js'
 import { createLogger } from '#server/common/helpers/logging/logger.js'
+/** @import { ReportSubmissionsRow } from './types.js' */
 
 const logger = createLogger()
 
 /**
- * @param {import('./types.js').ReportSubmissionsRow} row
+ * @param {ReportSubmissionsRow} row
  * @returns {(string | number)[]}
  */
 function buildDataRow(row) {
@@ -48,7 +49,7 @@ function buildDataRow(row) {
 }
 
 /**
- * @param {import('./types.js').ReportSubmissionsRow[]} reportSubmissions
+ * @param {ReportSubmissionsRow[]} reportSubmissions
  * @param {string} generatedAt
  * @returns {Promise<string>}
  */


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)

hoist inline `import('...').Type` jsdoc annotations to `@import { Type } from '...'` across the codebase, and enforce it going forward.

- replace inline type imports in `@param`/`@returns`/`@type`/casts with hoisted `@import` blocks
- convert plain `@typedef {import('...').X} X` redeclares to `@import`; keep composed/dotted typedefs, hoisting their inner import
- add `eslint-plugin-jsdoc` and enable `jsdoc/prefer-import-tag` (`error`, `named-import`, `exemptTypedefs: false`) to prevent regressions
- convert a `typeof import()` residual to a namespace `@import`

no runtime changes - all edits are within jsdoc comments.