### PR TITLE
PAE-000: fix Snyk fast-uri vuln by relocking to 3.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8078,9 +8078,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
## Summary

- Remediates **CVE-2026-13676 / SNYK-JS-FASTURI-17675102** (high, CWE-436): interpretation conflict in `fast-uri` — Unicode/fullwidth hostnames (e.g. `http://127。0。0。1/`) are left unconverted, so host-based security checks can disagree with Node's WHATWG URL canonicalization.
- `fast-uri@3.1.2` (via `ajv`) relocked to the patched 3.1.3 within ajv's existing `^3.0.1` range. Lockfile-only change.
- Note: 3.1.3 is itself affected by the newer CVE-2026-16221 (fixed in 3.1.4, published 19 July). That version is currently blocked by the `min-release-age=3` npm policy; a follow-up relock will be needed once it ages in.

## Changes

- `package-lock.json` — relocked `fast-uri` 3.1.2 → 3.1.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
