### PR TITLE
PAE-1405: point journey tests at consolidated epr-re-ex-journey-tests repo

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -91,7 +91,7 @@ jobs:
         id: journey-branch
         run: |
           BRANCH="${{ github.head_ref }}"
-          if git ls-remote --heads https://github.com/DEFRA/epr-re-ex-admin-frontend-tests.git "$BRANCH" | grep -q .; then
+          if git ls-remote --heads https://github.com/DEFRA/epr-re-ex-journey-tests.git "$BRANCH" | grep -q .; then
             echo "ref=$BRANCH" >> "$GITHUB_OUTPUT"
           else
             echo "ref=main" >> "$GITHUB_OUTPUT"
@@ -108,10 +108,11 @@ jobs:
         run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Run journey tests on ${{ steps.journey-branch.outputs.ref }}
-        uses: DEFRA/epr-re-ex-admin-frontend-tests/run-journey-tests@main
+        uses: DEFRA/epr-re-ex-journey-tests/run-journey-tests@main
         with:
           epr-re-ex-admin-frontend: ${{github.sha}}
           branch: ${{ steps.journey-branch.outputs.ref }}
+          test-scope: admin
 
       - name: Write journey test summary
         if: always()


### PR DESCRIPTION
Ticket: [PAE-1405](https://eaflood.atlassian.net/browse/PAE-1405)
## Summary

- Repoints the `test-journey` job's branch-match check and `run-journey-tests` call from `DEFRA/epr-re-ex-admin-frontend-tests` (superseded) to `DEFRA/epr-re-ex-journey-tests`, the consolidated journey-test repo from PAE-1405.
- Passes `test-scope: admin`, so this repo's PRs only run `test/specs/admin/**` instead of the full consolidated suite (which also covers epr-frontend and epr-backend).

**Depends on** [DEFRA/epr-re-ex-journey-tests#3](https://github.com/DEFRA/epr-re-ex-journey-tests/pull/3), which adds the `test-scope` input this PR relies on. CI here will fail until that PR merges to `epr-re-ex-journey-tests`'s `main`.

## Test plan

- [x] Merge DEFRA/epr-re-ex-journey-tests#3 first
- [x] Confirm this PR's journey-test job passes and runs only `test/specs/admin/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PAE-1405]: https://eaflood.atlassian.net/browse/PAE-1405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ