### PR TITLE
PAE-1617: approve accreditation journey (grant fields + confirmation page)

### DIFF
--- a/src/server/routes/accreditation-status-transition/confirm-view.js
+++ b/src/server/routes/accreditation-status-transition/confirm-view.js
@@ -2,27 +2,31 @@
 
 /**
  * Builds the view context for a transition's confirm page. Used by the GET
- * controller and by the POST controller when re-rendering with field errors.
+ * controller and by the POST controller when re-rendering with field errors
+ * or a backend rejection.
  * @param {string} action - URL action segment (e.g. 'suspend')
  * @param {AccreditationStatusTransition} transition
  * @param {{ organisationId: string, registrationId: string, accreditationId: string }} params
  * @param {{
- *   pageTitle: string,
  *   values?: { day: string, month: string, year: string, accreditationNumber: string },
- *   errors?: { appliesFrom?: string, accreditationNumber?: string } | null
- * }} state
+ *   errors?: { appliesFrom?: string, accreditationNumber?: string } | null,
+ *   backendError?: string
+ * }} [state]
  */
 export const buildConfirmView = (
   action,
   transition,
   { organisationId, registrationId, accreditationId },
   {
-    pageTitle,
     values = { day: '', month: '', year: '', accreditationNumber: '' },
-    errors = null
-  }
+    errors = null,
+    backendError
+  } = {}
 ) => {
   const errorList = []
+  if (backendError) {
+    errorList.push({ text: backendError })
+  }
   if (errors?.appliesFrom) {
     errorList.push({ text: errors.appliesFrom, href: '#applies-from-day' })
   }
@@ -34,7 +38,7 @@ export const buildConfirmView = (
   }
 
   return {
-    pageTitle,
+    pageTitle: transition.pageTitle,
     heading: transition.heading,
     warningText: transition.warningText,
     buttonText: transition.buttonText,

--- a/src/server/routes/accreditation-status-transition/confirm-view.js
+++ b/src/server/routes/accreditation-status-transition/confirm-view.js
@@ -1,0 +1,49 @@
+/** @import {AccreditationStatusTransition} from './transitions.js' */
+
+/**
+ * Builds the view context for a transition's confirm page. Used by the GET
+ * controller and by the POST controller when re-rendering with field errors.
+ * @param {string} action - URL action segment (e.g. 'suspend')
+ * @param {AccreditationStatusTransition} transition
+ * @param {{ organisationId: string, registrationId: string, accreditationId: string }} params
+ * @param {{
+ *   pageTitle: string,
+ *   values?: { day: string, month: string, year: string, accreditationNumber: string },
+ *   errors?: { appliesFrom?: string, accreditationNumber?: string } | null
+ * }} state
+ */
+export const buildConfirmView = (
+  action,
+  transition,
+  { organisationId, registrationId, accreditationId },
+  {
+    pageTitle,
+    values = { day: '', month: '', year: '', accreditationNumber: '' },
+    errors = null
+  }
+) => {
+  const errorList = []
+  if (errors?.appliesFrom) {
+    errorList.push({ text: errors.appliesFrom, href: '#applies-from-day' })
+  }
+  if (errors?.accreditationNumber) {
+    errorList.push({
+      text: errors.accreditationNumber,
+      href: '#accreditation-number'
+    })
+  }
+
+  return {
+    pageTitle,
+    heading: transition.heading,
+    warningText: transition.warningText,
+    buttonText: transition.buttonText,
+    buttonClasses: transition.buttonClasses,
+    hasGrantFields: Boolean(transition.hasGrantFields),
+    values,
+    errors,
+    errorList,
+    overviewUrl: `/organisations/${organisationId}/registrations/${registrationId}/overview`,
+    postUrl: `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/${action}`
+  }
+}

--- a/src/server/routes/accreditation-status-transition/confirm.njk
+++ b/src/server/routes/accreditation-status-transition/confirm.njk
@@ -8,7 +8,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% if errors %}
+      {% if errorList.length %}
         {{ govukErrorSummary({
           titleText: "There is a problem",
           errorList: errorList

--- a/src/server/routes/accreditation-status-transition/confirm.njk
+++ b/src/server/routes/accreditation-status-transition/confirm.njk
@@ -1,10 +1,20 @@
 {% extends 'layout.njk' %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% if errors %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorList
+        }) }}
+      {% endif %}
+
       <h1 class="govuk-heading-xl">{{ heading }}</h1>
 
       {{ govukWarningText({
@@ -14,6 +24,33 @@
 
       <form method="POST" action="{{ postUrl }}">
         <input type="hidden" name="crumb" value="{{ crumb }}" />
+
+        {% if hasGrantFields %}
+          {{ govukDateInput({
+            id: "applies-from",
+            namePrefix: "appliesFrom",
+            fieldset: {
+              legend: { text: "Applies from", classes: "govuk-fieldset__legend--s" }
+            },
+            hint: { text: "For example, 27 3 2026" },
+            errorMessage: { text: errors.appliesFrom } if errors and errors.appliesFrom,
+            items: [
+              { name: "day", classes: "govuk-input--width-2", value: values.day },
+              { name: "month", classes: "govuk-input--width-2", value: values.month },
+              { name: "year", classes: "govuk-input--width-4", value: values.year }
+            ]
+          }) }}
+
+          {{ govukInput({
+            id: "accreditation-number",
+            name: "accreditationNumber",
+            label: { text: "Accreditation number", classes: "govuk-label--s" },
+            classes: "govuk-input--width-20",
+            value: values.accreditationNumber,
+            errorMessage: { text: errors.accreditationNumber } if errors and errors.accreditationNumber
+          }) }}
+        {% endif %}
+
         {{ govukButton({
           text: buttonText,
           classes: buttonClasses

--- a/src/server/routes/accreditation-status-transition/controller.get-confirm.js
+++ b/src/server/routes/accreditation-status-transition/controller.get-confirm.js
@@ -1,3 +1,5 @@
+import { buildConfirmView } from './confirm-view.js'
+
 /** @import {AccreditationStatusTransition} from './transitions.js' */
 
 /**
@@ -7,17 +9,11 @@
  */
 export const createConfirmGetController = (action, transition) => ({
   handler(request, h) {
-    const { organisationId, registrationId, accreditationId } = request.params
-    const overviewUrl = `/organisations/${organisationId}/registrations/${registrationId}/overview`
-
-    return h.view('routes/accreditation-status-transition/confirm', {
-      pageTitle: request.route.settings.app.pageTitle,
-      heading: transition.heading,
-      warningText: transition.warningText,
-      buttonText: transition.buttonText,
-      buttonClasses: transition.buttonClasses,
-      overviewUrl,
-      postUrl: `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/${action}`
-    })
+    return h.view(
+      'routes/accreditation-status-transition/confirm',
+      buildConfirmView(action, transition, request.params, {
+        pageTitle: request.route.settings.app.pageTitle
+      })
+    )
   }
 })

--- a/src/server/routes/accreditation-status-transition/controller.get-confirm.js
+++ b/src/server/routes/accreditation-status-transition/controller.get-confirm.js
@@ -11,9 +11,7 @@ export const createConfirmGetController = (action, transition) => ({
   handler(request, h) {
     return h.view(
       'routes/accreditation-status-transition/confirm',
-      buildConfirmView(action, transition, request.params, {
-        pageTitle: request.route.settings.app.pageTitle
-      })
+      buildConfirmView(action, transition, request.params)
     )
   }
 })

--- a/src/server/routes/accreditation-status-transition/controller.post.js
+++ b/src/server/routes/accreditation-status-transition/controller.post.js
@@ -1,18 +1,49 @@
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
 import { statusCodes } from '#server/common/constants/status-codes.js'
+import { buildConfirmView } from './confirm-view.js'
+import { parseGrantForm } from './grant-form.js'
 
 /** @import {AccreditationStatusTransition} from './transitions.js' */
 
 /**
  * Builds the POST controller for a status transition action. Posts the
- * transition's target status to the backend status-history endpoint and
- * redirects to the registration overview, flashing any error.
+ * transition's from/to statuses (plus grant fields where the transition
+ * collects them) to the backend status-history endpoint and redirects to the
+ * registration overview, flashing any backend error. Invalid grant fields
+ * re-render the confirm page with an error summary instead.
+ * @param {string} action - URL action segment (e.g. 'suspend')
  * @param {AccreditationStatusTransition} transition
  */
-export const createTransitionPostController = (transition) => ({
+export const createTransitionPostController = (action, transition) => ({
   async handler(request, h) {
     const { organisationId, registrationId, accreditationId } = request.params
     const overviewUrl = `/organisations/${organisationId}/registrations/${registrationId}/overview`
+
+    /** @type {{ fromStatus: string, toStatus: string, appliesFrom?: string, accreditationNumber?: string }} */
+    const body = {
+      fromStatus: transition.fromStatus,
+      toStatus: transition.toStatus
+    }
+
+    if (transition.hasGrantFields) {
+      const { values, errors, appliesFrom } = parseGrantForm(request.payload)
+
+      if (errors) {
+        return h
+          .view(
+            'routes/accreditation-status-transition/confirm',
+            buildConfirmView(action, transition, request.params, {
+              pageTitle: transition.pageTitle,
+              values,
+              errors
+            })
+          )
+          .code(statusCodes.badRequest)
+      }
+
+      body.appliesFrom = /** @type {string} */ (appliesFrom)
+      body.accreditationNumber = values.accreditationNumber
+    }
 
     try {
       await fetchJsonFromBackend(
@@ -20,7 +51,7 @@ export const createTransitionPostController = (transition) => ({
         `/v1/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/status-history`,
         {
           method: 'POST',
-          body: JSON.stringify({ status: transition.targetStatus })
+          body: JSON.stringify(body)
         }
       )
     } catch (error) {

--- a/src/server/routes/accreditation-status-transition/controller.post.js
+++ b/src/server/routes/accreditation-status-transition/controller.post.js
@@ -5,12 +5,15 @@ import { parseGrantForm } from './grant-form.js'
 
 /** @import {AccreditationStatusTransition} from './transitions.js' */
 
+const CONFIRM_VIEW = 'routes/accreditation-status-transition/confirm'
+
 /**
  * Builds the POST controller for a status transition action. Posts the
  * transition's from/to statuses (plus grant fields where the transition
  * collects them) to the backend status-history endpoint and redirects to the
- * registration overview, flashing any backend error. Invalid grant fields
- * re-render the confirm page with an error summary instead.
+ * registration overview, flashing any backend error. Invalid grant fields —
+ * and backend rejections of them — re-render the confirm page with an error
+ * summary instead.
  * @param {string} action - URL action segment (e.g. 'suspend')
  * @param {AccreditationStatusTransition} transition
  */
@@ -25,15 +28,18 @@ export const createTransitionPostController = (action, transition) => ({
       toStatus: transition.toStatus
     }
 
+    /** @type {{ day: string, month: string, year: string, accreditationNumber: string } | undefined} */
+    let grantValues
+
     if (transition.hasGrantFields) {
       const { values, errors, appliesFrom } = parseGrantForm(request.payload)
+      grantValues = values
 
       if (errors) {
         return h
           .view(
-            'routes/accreditation-status-transition/confirm',
+            CONFIRM_VIEW,
             buildConfirmView(action, transition, request.params, {
-              pageTitle: transition.pageTitle,
               values,
               errors
             })
@@ -67,6 +73,21 @@ export const createTransitionPostController = (action, transition) => ({
       const errorMessage =
         (statusCode < statusCodes.internalServerError && payload?.message) ||
         transition.errorMessage
+
+      // A backend rejection of the grant fields re-renders the confirm page
+      // so the admin keeps what they typed; 5xx and network failures still
+      // flash on the overview, where retrying immediately won't help.
+      if (grantValues && statusCode < statusCodes.internalServerError) {
+        return h
+          .view(
+            CONFIRM_VIEW,
+            buildConfirmView(action, transition, request.params, {
+              values: grantValues,
+              backendError: errorMessage
+            })
+          )
+          .code(statusCodes.badRequest)
+      }
 
       request.yar.set('error', errorMessage)
     }

--- a/src/server/routes/accreditation-status-transition/grant-form.js
+++ b/src/server/routes/accreditation-status-transition/grant-form.js
@@ -1,0 +1,59 @@
+/**
+ * Builds a YYYY-MM-DD date from GDS date-input parts, or null when the parts
+ * do not form a real calendar date.
+ * @param {string} day
+ * @param {string} month
+ * @param {string} year
+ * @returns {string | null}
+ */
+const toIsoDate = (day, month, year) => {
+  if (
+    !/^\d{1,2}$/.test(day) ||
+    !/^\d{1,2}$/.test(month) ||
+    !/^\d{4}$/.test(year)
+  ) {
+    return null
+  }
+
+  const iso = `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`
+  const date = new Date(`${iso}T00:00:00.000Z`)
+  if (Number.isNaN(date.getTime()) || !date.toISOString().startsWith(iso)) {
+    return null
+  }
+
+  return iso
+}
+
+/**
+ * Parses and validates the grant fields (applies from date parts and
+ * accreditation number) from a confirm-page POST.
+ * @param {Record<string, string | undefined>} payload
+ * @returns {{
+ *   values: { day: string, month: string, year: string, accreditationNumber: string },
+ *   errors: { appliesFrom?: string, accreditationNumber?: string } | null,
+ *   appliesFrom: string | null
+ * }}
+ */
+export const parseGrantForm = (payload) => {
+  const day = (payload['appliesFrom-day'] ?? '').trim()
+  const month = (payload['appliesFrom-month'] ?? '').trim()
+  const year = (payload['appliesFrom-year'] ?? '').trim()
+  const accreditationNumber = (payload.accreditationNumber ?? '').trim()
+
+  const appliesFrom = toIsoDate(day, month, year)
+
+  /** @type {{ appliesFrom?: string, accreditationNumber?: string }} */
+  const errors = {}
+  if (!appliesFrom) {
+    errors.appliesFrom = 'Enter a valid applies from date'
+  }
+  if (!accreditationNumber) {
+    errors.accreditationNumber = 'Enter an accreditation number'
+  }
+
+  return {
+    values: { day, month, year, accreditationNumber },
+    errors: Object.keys(errors).length > 0 ? errors : null,
+    appliesFrom
+  }
+}

--- a/src/server/routes/accreditation-status-transition/index.integration.test.js
+++ b/src/server/routes/accreditation-status-transition/index.integration.test.js
@@ -15,24 +15,47 @@ vi.mock('#server/common/helpers/auth/get-user-session.js', () => ({
 
 const TRANSITION_CASES = [
   {
+    action: 'approve',
+    heading: 'Approve accreditation',
+    warningText:
+      'This action must only be taken following the required legal process for approval and following instruction from an industry regulator. Approving an operator will grant them permission to issue PRNs and declared tonnages will count towards their waste balance',
+    buttonText: 'Approve now',
+    fallbackError:
+      'There was a problem approving the accreditation. Please try again.',
+    formPayload: {
+      'appliesFrom-day': '1',
+      'appliesFrom-month': '8',
+      'appliesFrom-year': '2026',
+      accreditationNumber: 'ACC999999'
+    },
+    expectedBody: {
+      fromStatus: 'created',
+      toStatus: 'approved',
+      appliesFrom: '2026-08-01',
+      accreditationNumber: 'ACC999999'
+    }
+  },
+  {
     action: 'suspend',
-    targetStatus: 'suspended',
     heading: 'Suspend accreditation',
     warningText:
       'This action must only be taken following the required legal process for suspension and following instruction from an industry regulator. Suspending an operator will remove their ability to issue PRNs and all declared tonnages submitted during the suspended period will not count towards their waste balance',
     buttonText: 'Suspend now',
     fallbackError:
-      'There was a problem suspending the accreditation. Please try again.'
+      'There was a problem suspending the accreditation. Please try again.',
+    formPayload: {},
+    expectedBody: { fromStatus: 'approved', toStatus: 'suspended' }
   },
   {
     action: 'reapprove',
-    targetStatus: 'approved',
     heading: 'Reapprove accreditation',
     warningText:
       'This action must only be taken following the required legal process for lifting a suspension and following instruction from an industry regulator. Lifting a suspension for an operator will reinstate their ability to issue PRNs and declared tonnages newly submitted will then count towards their waste balance. Tonnages during the suspended period will not count towards their waste balance',
     buttonText: 'Reapprove now',
     fallbackError:
-      'There was a problem reapproving the accreditation. Please try again.'
+      'There was a problem reapproving the accreditation. Please try again.',
+    formPayload: {},
+    expectedBody: { fromStatus: 'suspended', toStatus: 'approved' }
   }
 ]
 
@@ -137,16 +160,17 @@ describe('accreditation-status-transition', () => {
     '$action',
     ({
       action,
-      targetStatus,
       heading,
       warningText,
       buttonText,
-      fallbackError
+      fallbackError,
+      formPayload,
+      expectedBody
     }) => {
       const confirmUrl = `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/${action}/confirm`
       const postUrl = `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/${action}`
 
-      const postTransition = async () => {
+      const postTransition = async (payloadOverrides = {}) => {
         const { cookie, crumb } = await getCsrfToken(
           server,
           confirmUrl,
@@ -157,7 +181,7 @@ describe('accreditation-status-transition', () => {
           url: postUrl,
           auth: writeAuth,
           headers: { cookie },
-          payload: { crumb }
+          payload: { crumb, ...formPayload, ...payloadOverrides }
         })
         const postCookies = [postResponse.headers['set-cookie']]
           .flat()
@@ -229,15 +253,15 @@ describe('accreditation-status-transition', () => {
         expect(statusCode).toBe(statusCodes.forbidden)
       })
 
-      test(`successful ${action} posts { status: "${targetStatus}" } to the backend status-history endpoint and redirects to the overview`, async () => {
+      test(`successful ${action} posts the from/to transition to the backend status-history endpoint and redirects to the overview`, async () => {
         vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
         const receivedBodies = []
-        stubTransitionSuccess(targetStatus, receivedBodies)
+        stubTransitionSuccess(expectedBody.toStatus, receivedBodies)
 
         const { postResponse } = await postTransition()
         expect(postResponse.statusCode).toBe(statusCodes.found)
         expect(postResponse.headers.location).toBe(overviewUrl)
-        expect(receivedBodies).toEqual([{ status: targetStatus }])
+        expect(receivedBodies).toEqual([expectedBody])
       })
 
       test(`failed ${action} redirects to the overview and shows a flash error`, async () => {
@@ -333,4 +357,148 @@ describe('accreditation-status-transition', () => {
       })
     }
   )
+
+  describe('approve grant fields', () => {
+    const confirmUrl = `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/approve/confirm`
+    const postUrl = `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/approve`
+
+    const validFormPayload = {
+      'appliesFrom-day': '1',
+      'appliesFrom-month': '8',
+      'appliesFrom-year': '2026',
+      accreditationNumber: 'ACC999999'
+    }
+
+    const postApprove = async (payloadOverrides) => {
+      const { cookie, crumb } = await getCsrfToken(
+        server,
+        confirmUrl,
+        writeAuth
+      )
+      return server.inject({
+        method: 'POST',
+        url: postUrl,
+        auth: writeAuth,
+        headers: { cookie },
+        payload: { crumb, ...validFormPayload, ...payloadOverrides }
+      })
+    }
+
+    test('confirm page renders the applies from date input and accreditation number field', async () => {
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+
+      const { result } = await server.inject({
+        method: 'GET',
+        url: confirmUrl,
+        auth: writeAuth
+      })
+
+      const $ = cheerio.load(result)
+      expect($('input[name="appliesFrom-day"]').length).toBe(1)
+      expect($('input[name="appliesFrom-month"]').length).toBe(1)
+      expect($('input[name="appliesFrom-year"]').length).toBe(1)
+      expect($('input[name="accreditationNumber"]').length).toBe(1)
+    })
+
+    test('suspend confirm page does not render the grant fields', async () => {
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+
+      const { result } = await server.inject({
+        method: 'GET',
+        url: `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/suspend/confirm`,
+        auth: writeAuth
+      })
+
+      const $ = cheerio.load(result)
+      expect($('input[name="appliesFrom-day"]').length).toBe(0)
+      expect($('input[name="accreditationNumber"]').length).toBe(0)
+    })
+
+    test('missing accreditation number re-renders the page with an error, preserving the date', async () => {
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+      const receivedBodies = []
+      stubTransitionSuccess('approved', receivedBodies)
+
+      const response = await postApprove({ accreditationNumber: '  ' })
+
+      expect(response.statusCode).toBe(statusCodes.badRequest)
+      const $ = cheerio.load(response.result)
+      expect($('.govuk-error-summary').text()).toContain(
+        'Enter an accreditation number'
+      )
+      expect($('input[name="appliesFrom-day"]').attr('value')).toBe('1')
+      expect($('input[name="appliesFrom-year"]').attr('value')).toBe('2026')
+      expect(receivedBodies).toEqual([])
+    })
+
+    test.each([
+      ['a missing day', { 'appliesFrom-day': '' }],
+      ['a non-numeric month', { 'appliesFrom-month': 'August' }],
+      ['a month past December', { 'appliesFrom-month': '13' }],
+      ['a two-digit year', { 'appliesFrom-year': '26' }],
+      [
+        'an impossible date',
+        { 'appliesFrom-month': '2', 'appliesFrom-day': '30' }
+      ]
+    ])(
+      'an invalid applies from date (%s) re-renders the page with an error, preserving the number',
+      async (_label, payloadOverrides) => {
+        vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+        const receivedBodies = []
+        stubTransitionSuccess('approved', receivedBodies)
+
+        const response = await postApprove(payloadOverrides)
+
+        expect(response.statusCode).toBe(statusCodes.badRequest)
+        const $ = cheerio.load(response.result)
+        expect($('.govuk-error-summary').text()).toContain(
+          'Enter a valid applies from date'
+        )
+        expect($('input[name="accreditationNumber"]').attr('value')).toBe(
+          'ACC999999'
+        )
+        expect(receivedBodies).toEqual([])
+      }
+    )
+
+    test('missing both fields lists both errors in the summary', async () => {
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+
+      const response = await postApprove({
+        'appliesFrom-day': '',
+        'appliesFrom-month': '',
+        'appliesFrom-year': '',
+        accreditationNumber: ''
+      })
+
+      expect(response.statusCode).toBe(statusCodes.badRequest)
+      const $ = cheerio.load(response.result)
+      const summary = $('.govuk-error-summary').text()
+      expect(summary).toContain('Enter a valid applies from date')
+      expect(summary).toContain('Enter an accreditation number')
+    })
+
+    test('a submission without any grant fields lists both errors in the summary', async () => {
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+      const { cookie, crumb } = await getCsrfToken(
+        server,
+        confirmUrl,
+        writeAuth
+      )
+
+      const response = await server.inject({
+        method: 'POST',
+        url: postUrl,
+        auth: writeAuth,
+        headers: { cookie },
+        payload: { crumb }
+      })
+
+      expect(response.statusCode).toBe(statusCodes.badRequest)
+      const $ = cheerio.load(response.result)
+      const summary = $('.govuk-error-summary').text()
+      expect(summary).toContain('Enter a valid applies from date')
+      expect(summary).toContain('Enter an accreditation number')
+    })
+  })
 })

--- a/src/server/routes/accreditation-status-transition/index.integration.test.js
+++ b/src/server/routes/accreditation-status-transition/index.integration.test.js
@@ -33,7 +33,8 @@ const TRANSITION_CASES = [
       toStatus: 'approved',
       appliesFrom: '2026-08-01',
       accreditationNumber: 'ACC999999'
-    }
+    },
+    hasGrantFields: true
   },
   {
     action: 'suspend',
@@ -156,6 +157,43 @@ describe('accreditation-status-transition', () => {
   const writeAuth = { strategy: 'session', credentials: mockUserSession }
   const readAuth = { strategy: 'session', credentials: readOnlySession }
 
+  const postTransition = async (
+    action,
+    formPayload = {},
+    payloadOverrides = {}
+  ) => {
+    const confirmUrl = `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/${action}/confirm`
+    const postUrl = `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/${action}`
+    const { cookie, crumb } = await getCsrfToken(server, confirmUrl, writeAuth)
+    const postResponse = await server.inject({
+      method: 'POST',
+      url: postUrl,
+      auth: writeAuth,
+      headers: { cookie },
+      payload: { crumb, ...formPayload, ...payloadOverrides }
+    })
+    const postCookies = [postResponse.headers['set-cookie']]
+      .flat()
+      .filter(Boolean)
+    const redirectCookie = postCookies.length
+      ? postCookies.map((c) => c.split(';')[0]).join('; ')
+      : cookie
+    return { postResponse, redirectCookie }
+  }
+
+  const expectOverviewFlash = async (redirectCookie, message) => {
+    stubOverview()
+    stubCalendarAndSummaryLogs()
+    const { result } = await server.inject({
+      method: 'GET',
+      url: overviewUrl,
+      headers: { cookie: redirectCookie },
+      auth: writeAuth
+    })
+    const $ = cheerio.load(result)
+    expect($('.govuk-error-summary').text()).toContain(message)
+  }
+
   describe.each(TRANSITION_CASES)(
     '$action',
     ({
@@ -169,28 +207,6 @@ describe('accreditation-status-transition', () => {
     }) => {
       const confirmUrl = `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/${action}/confirm`
       const postUrl = `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/${action}`
-
-      const postTransition = async (payloadOverrides = {}) => {
-        const { cookie, crumb } = await getCsrfToken(
-          server,
-          confirmUrl,
-          writeAuth
-        )
-        const postResponse = await server.inject({
-          method: 'POST',
-          url: postUrl,
-          auth: writeAuth,
-          headers: { cookie },
-          payload: { crumb, ...formPayload, ...payloadOverrides }
-        })
-        const postCookies = [postResponse.headers['set-cookie']]
-          .flat()
-          .filter(Boolean)
-        const redirectCookie = postCookies.length
-          ? postCookies.map((c) => c.split(';')[0]).join('; ')
-          : cookie
-        return { postResponse, redirectCookie }
-      }
 
       test('confirm page is rejected with 401 when unauthenticated', async () => {
         const { statusCode } = await server.inject({
@@ -258,79 +274,10 @@ describe('accreditation-status-transition', () => {
         const receivedBodies = []
         stubTransitionSuccess(expectedBody.toStatus, receivedBodies)
 
-        const { postResponse } = await postTransition()
+        const { postResponse } = await postTransition(action, formPayload)
         expect(postResponse.statusCode).toBe(statusCodes.found)
         expect(postResponse.headers.location).toBe(overviewUrl)
         expect(receivedBodies).toEqual([expectedBody])
-      })
-
-      test(`failed ${action} redirects to the overview and shows a flash error`, async () => {
-        vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
-        stubTransitionFailure()
-
-        const { postResponse, redirectCookie } = await postTransition()
-        expect(postResponse.statusCode).toBe(statusCodes.found)
-        expect(postResponse.headers.location).toBe(overviewUrl)
-
-        stubOverview()
-        stubCalendarAndSummaryLogs()
-        const { result } = await server.inject({
-          method: 'GET',
-          url: overviewUrl,
-          headers: { cookie: redirectCookie },
-          auth: writeAuth
-        })
-
-        const $ = cheerio.load(result)
-        expect($('.govuk-error-summary').text()).toContain(
-          'Cannot transition from suspended to suspended'
-        )
-      })
-
-      test(`failed ${action} without a backend message falls back to a generic flash error`, async () => {
-        vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
-        stubTransitionFailureWithoutMessage()
-
-        const { postResponse, redirectCookie } = await postTransition()
-        expect(postResponse.statusCode).toBe(statusCodes.found)
-        expect(postResponse.headers.location).toBe(overviewUrl)
-
-        stubOverview()
-        stubCalendarAndSummaryLogs()
-        const { result } = await server.inject({
-          method: 'GET',
-          url: overviewUrl,
-          headers: { cookie: redirectCookie },
-          auth: writeAuth
-        })
-
-        const $ = cheerio.load(result)
-        expect($('.govuk-error-summary').text()).toContain(fallbackError)
-      })
-
-      test(`failed ${action} with a non-object error body falls back to the generic flash error`, async () => {
-        vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
-        mswServer.use(
-          http.post(backendStatusHistoryUrl, () =>
-            HttpResponse.json(null, { status: 422 })
-          )
-        )
-
-        const { postResponse, redirectCookie } = await postTransition()
-        expect(postResponse.statusCode).toBe(statusCodes.found)
-        expect(postResponse.headers.location).toBe(overviewUrl)
-
-        stubOverview()
-        stubCalendarAndSummaryLogs()
-        const { result } = await server.inject({
-          method: 'GET',
-          url: overviewUrl,
-          headers: { cookie: redirectCookie },
-          auth: writeAuth
-        })
-
-        const $ = cheerio.load(result)
-        expect($('.govuk-error-summary').text()).toContain(fallbackError)
       })
 
       test(`failed ${action} when the backend is unreachable falls back to the generic flash error`, async () => {
@@ -339,21 +286,59 @@ describe('accreditation-status-transition', () => {
           http.post(backendStatusHistoryUrl, () => HttpResponse.error())
         )
 
-        const { postResponse, redirectCookie } = await postTransition()
+        const { postResponse, redirectCookie } = await postTransition(
+          action,
+          formPayload
+        )
         expect(postResponse.statusCode).toBe(statusCodes.found)
         expect(postResponse.headers.location).toBe(overviewUrl)
 
-        stubOverview()
-        stubCalendarAndSummaryLogs()
-        const { result } = await server.inject({
-          method: 'GET',
-          url: overviewUrl,
-          headers: { cookie: redirectCookie },
-          auth: writeAuth
-        })
+        await expectOverviewFlash(redirectCookie, fallbackError)
+      })
+    }
+  )
 
-        const $ = cheerio.load(result)
-        expect($('.govuk-error-summary').text()).toContain(fallbackError)
+  describe.each(TRANSITION_CASES.filter((c) => !c.hasGrantFields))(
+    '$action backend rejection',
+    ({ action, fallbackError }) => {
+      test('redirects to the overview and shows the backend message as a flash error', async () => {
+        vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+        stubTransitionFailure()
+
+        const { postResponse, redirectCookie } = await postTransition(action)
+        expect(postResponse.statusCode).toBe(statusCodes.found)
+        expect(postResponse.headers.location).toBe(overviewUrl)
+
+        await expectOverviewFlash(
+          redirectCookie,
+          'Cannot transition from suspended to suspended'
+        )
+      })
+
+      test('without a backend message falls back to a generic flash error', async () => {
+        vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+        stubTransitionFailureWithoutMessage()
+
+        const { postResponse, redirectCookie } = await postTransition(action)
+        expect(postResponse.statusCode).toBe(statusCodes.found)
+        expect(postResponse.headers.location).toBe(overviewUrl)
+
+        await expectOverviewFlash(redirectCookie, fallbackError)
+      })
+
+      test('with a non-object error body falls back to the generic flash error', async () => {
+        vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+        mswServer.use(
+          http.post(backendStatusHistoryUrl, () =>
+            HttpResponse.json(null, { status: 422 })
+          )
+        )
+
+        const { postResponse, redirectCookie } = await postTransition(action)
+        expect(postResponse.statusCode).toBe(statusCodes.found)
+        expect(postResponse.headers.location).toBe(overviewUrl)
+
+        await expectOverviewFlash(redirectCookie, fallbackError)
       })
     }
   )
@@ -499,6 +484,62 @@ describe('accreditation-status-transition', () => {
       const summary = $('.govuk-error-summary').text()
       expect(summary).toContain('Enter a valid applies from date')
       expect(summary).toContain('Enter an accreditation number')
+    })
+
+    test('a backend rejection re-renders the page with the backend message, preserving input', async () => {
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+      mswServer.use(
+        http.post(backendStatusHistoryUrl, () =>
+          HttpResponse.json(
+            { message: 'Accreditation number ACC999999 is already in use' },
+            { status: 422 }
+          )
+        )
+      )
+
+      const response = await postApprove()
+
+      expect(response.statusCode).toBe(statusCodes.badRequest)
+      const $ = cheerio.load(response.result)
+      expect($('.govuk-error-summary').text()).toContain(
+        'Accreditation number ACC999999 is already in use'
+      )
+      expect($('input[name="appliesFrom-day"]').attr('value')).toBe('1')
+      expect($('input[name="appliesFrom-month"]').attr('value')).toBe('8')
+      expect($('input[name="appliesFrom-year"]').attr('value')).toBe('2026')
+      expect($('input[name="accreditationNumber"]').attr('value')).toBe(
+        'ACC999999'
+      )
+    })
+
+    test('a backend rejection without a message re-renders the page with the generic error', async () => {
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+      stubTransitionFailureWithoutMessage()
+
+      const response = await postApprove()
+
+      expect(response.statusCode).toBe(statusCodes.badRequest)
+      const $ = cheerio.load(response.result)
+      expect($('.govuk-error-summary').text()).toContain(
+        'There was a problem approving the accreditation. Please try again.'
+      )
+    })
+
+    test('a backend 5xx failure redirects to the overview with the generic flash error', async () => {
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+      stubTransitionFailure(statusCodes.internalServerError)
+
+      const { postResponse, redirectCookie } = await postTransition(
+        'approve',
+        validFormPayload
+      )
+      expect(postResponse.statusCode).toBe(statusCodes.found)
+      expect(postResponse.headers.location).toBe(overviewUrl)
+
+      await expectOverviewFlash(
+        redirectCookie,
+        'There was a problem approving the accreditation. Please try again.'
+      )
     })
   })
 })

--- a/src/server/routes/accreditation-status-transition/index.integration.test.js
+++ b/src/server/routes/accreditation-status-transition/index.integration.test.js
@@ -394,10 +394,10 @@ describe('accreditation-status-transition', () => {
       })
 
       const $ = cheerio.load(result)
-      expect($('input[name="appliesFrom-day"]').length).toBe(1)
-      expect($('input[name="appliesFrom-month"]').length).toBe(1)
-      expect($('input[name="appliesFrom-year"]').length).toBe(1)
-      expect($('input[name="accreditationNumber"]').length).toBe(1)
+      expect($('input[name="appliesFrom-day"]')).toHaveLength(1)
+      expect($('input[name="appliesFrom-month"]')).toHaveLength(1)
+      expect($('input[name="appliesFrom-year"]')).toHaveLength(1)
+      expect($('input[name="accreditationNumber"]')).toHaveLength(1)
     })
 
     test('suspend confirm page does not render the grant fields', async () => {
@@ -410,8 +410,8 @@ describe('accreditation-status-transition', () => {
       })
 
       const $ = cheerio.load(result)
-      expect($('input[name="appliesFrom-day"]').length).toBe(0)
-      expect($('input[name="accreditationNumber"]').length).toBe(0)
+      expect($('input[name="appliesFrom-day"]')).toHaveLength(0)
+      expect($('input[name="accreditationNumber"]')).toHaveLength(0)
     })
 
     test('missing accreditation number re-renders the page with an error, preserving the date', async () => {

--- a/src/server/routes/accreditation-status-transition/index.js
+++ b/src/server/routes/accreditation-status-transition/index.js
@@ -21,8 +21,7 @@ export const accreditationStatusTransition = {
             path: `${BASE}/${action}/confirm`,
             ...createConfirmGetController(action, transition),
             options: {
-              pre: requireWrite,
-              app: { pageTitle: transition.pageTitle }
+              pre: requireWrite
             }
           },
           {

--- a/src/server/routes/accreditation-status-transition/index.js
+++ b/src/server/routes/accreditation-status-transition/index.js
@@ -28,7 +28,7 @@ export const accreditationStatusTransition = {
           {
             method: 'POST',
             path: `${BASE}/${action}`,
-            ...createTransitionPostController(transition),
+            ...createTransitionPostController(action, transition),
             options: {
               pre: requireWrite
             }

--- a/src/server/routes/accreditation-status-transition/transitions.js
+++ b/src/server/routes/accreditation-status-transition/transitions.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {object} AccreditationStatusTransition
- * @property {string} targetStatus - Status posted to the backend status-history endpoint
+ * @property {string} fromStatus - Status the accreditation must currently hold
+ * @property {string} toStatus - Status posted to the backend status-history endpoint
  * @property {string} pageTitle
  * @property {string} heading
  * @property {string} warningText - Confirm-page warning copy
@@ -8,17 +9,34 @@
  * @property {string} buttonClasses
  * @property {string} errorMessage - Flash fallback when the backend gives no message
  * @property {string} logMessage
+ * @property {boolean} [hasGrantFields] - Confirm page collects appliesFrom + accreditationNumber
  */
 
 /**
  * Accreditation status transitions the admin UI can action, keyed by the URL
  * action segment. Each entry drives a confirm page and a POST of
- * `{ status: targetStatus }` to the backend status-history endpoint.
+ * `{ fromStatus, toStatus, ...params }` to the backend status-history
+ * endpoint.
  * @type {Record<string, AccreditationStatusTransition>}
  */
 export const ACCREDITATION_STATUS_TRANSITIONS = {
+  approve: {
+    fromStatus: 'created',
+    toStatus: 'approved',
+    pageTitle: 'Approve accreditation',
+    heading: 'Approve accreditation',
+    warningText:
+      'This action must only be taken following the required legal process for approval and following instruction from an industry regulator. Approving an operator will grant them permission to issue PRNs and declared tonnages will count towards their waste balance',
+    buttonText: 'Approve now',
+    buttonClasses: '',
+    errorMessage:
+      'There was a problem approving the accreditation. Please try again.',
+    logMessage: 'Approve accreditation failed',
+    hasGrantFields: true
+  },
   suspend: {
-    targetStatus: 'suspended',
+    fromStatus: 'approved',
+    toStatus: 'suspended',
     pageTitle: 'Suspend accreditation',
     heading: 'Suspend accreditation',
     warningText:
@@ -30,7 +48,8 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
     logMessage: 'Suspend accreditation failed'
   },
   reapprove: {
-    targetStatus: 'approved',
+    fromStatus: 'suspended',
+    toStatus: 'approved',
     pageTitle: 'Reapprove accreditation',
     heading: 'Reapprove accreditation',
     warningText:

--- a/src/server/routes/registration-overview/get.integration.test.js
+++ b/src/server/routes/registration-overview/get.integration.test.js
@@ -1266,5 +1266,89 @@ describe('#registrationOverviewController', () => {
         ).toBeNull()
       })
     })
+
+    describe('Approve link visibility', () => {
+      const withCreatedAccreditation = () => ({
+        ...mockOverview,
+        registrations: [
+          {
+            ...mockRegistration,
+            accreditation:
+              /** @type {{ id: string, accreditationNumber: string, status: string }} */ ({
+                ...mockRegistration.accreditation,
+                status: 'created'
+              })
+          }
+        ]
+      })
+
+      afterEach(() => {
+        vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+      })
+
+      test('Should render the Approve action on the Accreditation status row for a created accreditation when the user has admin.write scope', async () => {
+        useMockBackend(withCreatedAccreditation())
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        const body = renderPage(result)
+        const statusRow = getSummaryRow(body, 'Accreditation status')
+        const approveLink = within(statusRow).getByRole('link', {
+          name: /^approve accreditation$/i
+        })
+
+        expect(approveLink).toHaveAttribute(
+          'href',
+          `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/approve/confirm`
+        )
+      })
+
+      test('Should not render the Approve action when the accreditation status is not created', async () => {
+        useMockBackend()
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        const body = renderPage(result)
+        const statusRow = getSummaryRow(body, 'Accreditation status')
+
+        expect(
+          within(statusRow).queryByRole('link', {
+            name: /^approve accreditation$/i
+          })
+        ).toBeNull()
+      })
+
+      test('Should not render the Approve action when the user lacks admin.write scope', async () => {
+        const readOnlySession = {
+          ...mockUserSession,
+          scopes: ['admin.read']
+        }
+        vi.mocked(getUserSession).mockResolvedValue(readOnlySession)
+        useMockBackend(withCreatedAccreditation())
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: readOnlySession }
+        })
+
+        const body = renderPage(result)
+        const statusRow = getSummaryRow(body, 'Accreditation status')
+
+        expect(
+          within(statusRow).queryByRole('link', {
+            name: /^approve accreditation$/i
+          })
+        ).toBeNull()
+      })
+    })
   })
 })

--- a/src/server/routes/registration-overview/index.njk
+++ b/src/server/routes/registration-overview/index.njk
@@ -29,6 +29,11 @@
       {% set accreditationStatusActions = [] %}
       {% if SCOPES.adminWrite in scopes %}
         {% set accreditationBaseUrl = '/organisations/' ~ organisationId ~ '/registrations/' ~ registrationId ~ '/accreditations/' ~ registration.accreditation.id %}
+        {% if registration.accreditation.status === 'created' %}
+          {% set accreditationStatusActions = accreditationStatusActions.concat([
+            { href: accreditationBaseUrl ~ '/approve/confirm', text: "Approve", visuallyHiddenText: "accreditation" }
+          ]) %}
+        {% endif %}
         {% if registration.accreditation.status === 'approved' %}
           {% set accreditationStatusActions = accreditationStatusActions.concat([
             { href: accreditationBaseUrl ~ '/suspend/confirm', text: "Suspend", visuallyHiddenText: "accreditation" }


### PR DESCRIPTION
Ticket: [PAE-1617](https://eaflood.atlassian.net/browse/PAE-1617)
## Summary

- Adds an Approve journey for `created` accreditations: an Approve action on the registration overview's Accreditation status row (admin.write only), and a confirmation page with the ticket's warning copy, a GDS date input (applies from) and an accreditation number field — both mandatory
- Field validation re-renders the confirm page with a GDS error summary preserving input; backend 4xx rejections of the grant fields (e.g. accreditation number already in use) now also re-render with the backend message and input preserved, while 5xx/network failures — and all suspend/reapprove errors — continue to flash on the overview
- All transitions (approve, suspend, reapprove) now post explicit `{ fromStatus, toStatus }` to the backend status-history endpoint, matching the backend's new discriminated payload (DEFRA/epr-backend#1556); approve additionally sends `appliesFrom` and `accreditationNumber`
- The confirm page title is single-sourced from the transition config rather than duplicated via route settings


[PAE-1617]: https://eaflood.atlassian.net/browse/PAE-1617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
