### PR TITLE
PAE-1622 PAE-1785 admin actions to cancel and reinstate an accreditation

### DIFF
--- a/src/server/routes/accreditation-status-transition/index.integration.test.js
+++ b/src/server/routes/accreditation-status-transition/index.integration.test.js
@@ -57,6 +57,28 @@ const TRANSITION_CASES = [
       'There was a problem reapproving the accreditation. Please try again.',
     formPayload: {},
     expectedBody: { fromStatus: 'suspended', toStatus: 'approved' }
+  },
+  {
+    action: 'cancel',
+    heading: 'Cancel accreditation',
+    warningText:
+      'This action must only be taken following the required legal process for cancellation and following instruction from an industry regulator. Cancelling an accreditation is permanent: the operator will no longer be able to issue PRNs and tonnages declared after the cancellation will not count towards their waste balance',
+    buttonText: 'Cancel accreditation now',
+    fallbackError:
+      'There was a problem cancelling the accreditation. Please try again.',
+    formPayload: {},
+    expectedBody: { fromStatus: 'suspended', toStatus: 'cancelled' }
+  },
+  {
+    action: 'reinstate',
+    heading: 'Reinstate accreditation',
+    warningText:
+      'This action must only be taken where a cancellation has been overturned by the required legal process (for example a successful appeal through the courts) and following instruction from an industry regulator. Reinstating the operator will restore their ability to issue PRNs and newly declared tonnages will count towards their waste balance from the date of reinstatement. Tonnages dated during the cancelled period will not count towards their waste balance',
+    buttonText: 'Reinstate now',
+    fallbackError:
+      'There was a problem reinstating the accreditation. Please try again.',
+    formPayload: {},
+    expectedBody: { fromStatus: 'cancelled', toStatus: 'approved' }
   }
 ]
 

--- a/src/server/routes/accreditation-status-transition/transitions.js
+++ b/src/server/routes/accreditation-status-transition/transitions.js
@@ -59,5 +59,35 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
     errorMessage:
       'There was a problem reapproving the accreditation. Please try again.',
     logMessage: 'Reapprove accreditation failed'
+  },
+  // Cancellation is only reachable from suspended — there is deliberately no
+  // approved -> cancelled action (suspend first, PAE-1624 / ADR 0042).
+  cancel: {
+    fromStatus: 'suspended',
+    toStatus: 'cancelled',
+    pageTitle: 'Cancel accreditation',
+    heading: 'Cancel accreditation',
+    warningText:
+      'This action must only be taken following the required legal process for cancellation and following instruction from an industry regulator. Cancelling an accreditation is permanent: the operator will no longer be able to issue PRNs and tonnages declared after the cancellation will not count towards their waste balance',
+    buttonText: 'Cancel accreditation now',
+    buttonClasses: 'govuk-button--warning',
+    errorMessage:
+      'There was a problem cancelling the accreditation. Please try again.',
+    logMessage: 'Cancel accreditation failed'
+  },
+  // Reinstatement after a cancellation is overturned on appeal (PAE-1785),
+  // effective on the day it is actioned — not retrospective.
+  reinstate: {
+    fromStatus: 'cancelled',
+    toStatus: 'approved',
+    pageTitle: 'Reinstate accreditation',
+    heading: 'Reinstate accreditation',
+    warningText:
+      'This action must only be taken where a cancellation has been overturned by the required legal process (for example a successful appeal through the courts) and following instruction from an industry regulator. Reinstating the operator will restore their ability to issue PRNs and newly declared tonnages will count towards their waste balance from the date of reinstatement. Tonnages dated during the cancelled period will not count towards their waste balance',
+    buttonText: 'Reinstate now',
+    buttonClasses: '',
+    errorMessage:
+      'There was a problem reinstating the accreditation. Please try again.',
+    logMessage: 'Reinstate accreditation failed'
   }
 }

--- a/src/server/routes/registration-overview/get.integration.test.js
+++ b/src/server/routes/registration-overview/get.integration.test.js
@@ -1267,6 +1267,166 @@ describe('#registrationOverviewController', () => {
       })
     })
 
+    describe('Cancel accreditation link visibility', () => {
+      const withSuspendedAccreditation = () => ({
+        ...mockOverview,
+        registrations: [
+          {
+            ...mockRegistration,
+            accreditation:
+              /** @type {{ id: string, accreditationNumber: string, status: string }} */ ({
+                ...mockRegistration.accreditation,
+                status: 'suspended'
+              })
+          }
+        ]
+      })
+
+      afterEach(() => {
+        vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+      })
+
+      test('Should render the Cancel action on the Accreditation status row for a suspended accreditation when the user has admin.write scope', async () => {
+        useMockBackend(withSuspendedAccreditation())
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        const body = renderPage(result)
+        const statusRow = getSummaryRow(body, 'Accreditation status')
+        const cancelLink = within(statusRow).getByRole('link', {
+          name: /cancel accreditation/i
+        })
+
+        expect(cancelLink).toHaveAttribute(
+          'href',
+          `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/cancel/confirm`
+        )
+      })
+
+      test('Should not render the Cancel action when the accreditation status is not suspended', async () => {
+        useMockBackend()
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        const body = renderPage(result)
+        const statusRow = getSummaryRow(body, 'Accreditation status')
+
+        expect(
+          within(statusRow).queryByRole('link', { name: /cancel/i })
+        ).toBeNull()
+      })
+
+      test('Should not render the Cancel action when the user lacks admin.write scope', async () => {
+        const readOnlySession = {
+          ...mockUserSession,
+          scopes: ['admin.read']
+        }
+        vi.mocked(getUserSession).mockResolvedValue(readOnlySession)
+        useMockBackend(withSuspendedAccreditation())
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: readOnlySession }
+        })
+
+        const body = renderPage(result)
+        const statusRow = getSummaryRow(body, 'Accreditation status')
+
+        expect(
+          within(statusRow).queryByRole('link', { name: /cancel/i })
+        ).toBeNull()
+      })
+    })
+
+    describe('Reinstate link visibility', () => {
+      const withCancelledAccreditation = () => ({
+        ...mockOverview,
+        registrations: [
+          {
+            ...mockRegistration,
+            accreditation:
+              /** @type {{ id: string, accreditationNumber: string, status: string }} */ ({
+                ...mockRegistration.accreditation,
+                status: 'cancelled'
+              })
+          }
+        ]
+      })
+
+      afterEach(() => {
+        vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+      })
+
+      test('Should render the Reinstate action on the Accreditation status row for a cancelled accreditation when the user has admin.write scope', async () => {
+        useMockBackend(withCancelledAccreditation())
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        const body = renderPage(result)
+        const statusRow = getSummaryRow(body, 'Accreditation status')
+        const reinstateLink = within(statusRow).getByRole('link', {
+          name: /reinstate accreditation/i
+        })
+
+        expect(reinstateLink).toHaveAttribute(
+          'href',
+          `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/reinstate/confirm`
+        )
+      })
+
+      test('Should not render the Reinstate action when the accreditation status is not cancelled', async () => {
+        useMockBackend()
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        const body = renderPage(result)
+        const statusRow = getSummaryRow(body, 'Accreditation status')
+
+        expect(
+          within(statusRow).queryByRole('link', { name: /reinstate/i })
+        ).toBeNull()
+      })
+
+      test('Should not render the Reinstate action when the user lacks admin.write scope', async () => {
+        const readOnlySession = {
+          ...mockUserSession,
+          scopes: ['admin.read']
+        }
+        vi.mocked(getUserSession).mockResolvedValue(readOnlySession)
+        useMockBackend(withCancelledAccreditation())
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: readOnlySession }
+        })
+
+        const body = renderPage(result)
+        const statusRow = getSummaryRow(body, 'Accreditation status')
+
+        expect(
+          within(statusRow).queryByRole('link', { name: /reinstate/i })
+        ).toBeNull()
+      })
+    })
+
     describe('Approve link visibility', () => {
       const withCreatedAccreditation = () => ({
         ...mockOverview,

--- a/src/server/routes/registration-overview/index.njk
+++ b/src/server/routes/registration-overview/index.njk
@@ -41,7 +41,13 @@
         {% endif %}
         {% if registration.accreditation.status === 'suspended' %}
           {% set accreditationStatusActions = accreditationStatusActions.concat([
-            { href: accreditationBaseUrl ~ '/reapprove/confirm', text: "Reapprove", visuallyHiddenText: "accreditation" }
+            { href: accreditationBaseUrl ~ '/reapprove/confirm', text: "Reapprove", visuallyHiddenText: "accreditation" },
+            { href: accreditationBaseUrl ~ '/cancel/confirm', text: "Cancel", visuallyHiddenText: "accreditation" }
+          ]) %}
+        {% endif %}
+        {% if registration.accreditation.status === 'cancelled' %}
+          {% set accreditationStatusActions = accreditationStatusActions.concat([
+            { href: accreditationBaseUrl ~ '/reinstate/confirm', text: "Reinstate", visuallyHiddenText: "accreditation" }
           ]) %}
         {% endif %}
       {% endif %}


### PR DESCRIPTION
## Summary

Admin-frontend half of [PAE-1622](https://eaflood.atlassian.net/browse/PAE-1622), [PAE-1624](https://eaflood.atlassian.net/browse/PAE-1624) and [PAE-1785](https://eaflood.atlassian.net/browse/PAE-1785) (backend: DEFRA/epr-backend#1565 — do not release this ahead of it):

- **Cancel accreditation** (PAE-1622): new `cancel` transition (`suspended -> cancelled`) with a permanence warning on the confirm page; shown alongside Reapprove on suspended accreditations.
- **Reinstate accreditation** (PAE-1785): new `reinstate` transition (`cancelled -> approved`) for a cancellation overturned on appeal, effective on the day actioned; shown on cancelled accreditations.
- **No direct approved -> cancelled action** (PAE-1624): the suspend-first rule stands — an approved accreditation still only offers Suspend.


[PAE-1622]: https://eaflood.atlassian.net/browse/PAE-1622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PAE-1624]: https://eaflood.atlassian.net/browse/PAE-1624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PAE-1785]: https://eaflood.atlassian.net/browse/PAE-1785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ