### PR TITLE
PAE-1788: fix jsoneditor icons broken by webpack 5.109

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -98,6 +98,10 @@ export default {
           {
             loader: 'css-loader',
             options: {
+              // esModule output makes css url() assets `new URL()` refs, which
+              // webpack >= 5.109 emits as asset-url literals under outputModule;
+              // mini-css-extract-plugin then renders them as "[object Object]"
+              esModule: false,
               sourceMap: NODE_ENV !== 'production'
             }
           },


### PR DESCRIPTION
Ticket: [PAE-1788](https://eaflood.atlassian.net/browse/PAE-1788)
## Summary

- The webpack 5.108.4 → 5.109.0 bump (#502) broke every `url()` asset reference in extracted CSS: the jsoneditor expander/collapse arrows (and any other CSS background asset) stopped rendering because the built CSS pointed at `url("..//[object%20Object]")` instead of the icon sprite.
- Root cause: css-loader's default `esModule` output represents `url()` assets as `new URL(..., import.meta.url)` refs. webpack ≥ 5.109 now emits those as analyzable asset-url literals when `output.module` is enabled and `publicPath` is absolute (new `_hasAbsolutePublicPath` path in `AssetGenerator`), which mini-css-extract-plugin's build-time evaluation stringifies as `[object Object]`. Reproduced on 5.109.0 and 5.109.1; both loaders are already on their latest versions.
- Fix: set `esModule: false` on css-loader so `url()` assets are exported as plain strings again, restoring the pre-bump codegen path. The resulting build output is byte-identical to the last good build (same content hashes).

## Changes

- `webpack.config.js` — add `esModule: false` to the css-loader options, with a comment explaining the webpack ≥ 5.109 constraint.


[PAE-1788]: https://eaflood.atlassian.net/browse/PAE-1788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ