### PR TITLE
PAE-1618 PAE-1623: reject and reopen accreditation actions

### DIFF
--- a/src/server/routes/accreditation-status-transition/index.integration.test.js
+++ b/src/server/routes/accreditation-status-transition/index.integration.test.js
@@ -79,6 +79,28 @@ const TRANSITION_CASES = [
       'There was a problem reinstating the accreditation. Please try again.',
     formPayload: {},
     expectedBody: { fromStatus: 'cancelled', toStatus: 'approved' }
+  },
+  {
+    action: 'reject',
+    heading: 'Reject accreditation',
+    warningText:
+      'This action must only be taken following the required legal process for refusing an accreditation application and following instruction from an industry regulator. Rejecting an accreditation means the operator remains registered-only: they cannot issue PRNs and declared tonnages will not count towards a waste balance',
+    buttonText: 'Reject now',
+    fallbackError:
+      'There was a problem rejecting the accreditation. Please try again.',
+    formPayload: {},
+    expectedBody: { fromStatus: 'created', toStatus: 'rejected' }
+  },
+  {
+    action: 'reopen',
+    heading: 'Reopen accreditation',
+    warningText:
+      'This action must only be taken following instruction from an industry regulator. Reopening a rejected accreditation returns the application to created so it can be reworked and reconsidered. The operator remains registered-only and cannot issue PRNs unless the accreditation is subsequently approved',
+    buttonText: 'Reopen now',
+    fallbackError:
+      'There was a problem reopening the accreditation. Please try again.',
+    formPayload: {},
+    expectedBody: { fromStatus: 'rejected', toStatus: 'created' }
   }
 ]
 

--- a/src/server/routes/accreditation-status-transition/transitions.js
+++ b/src/server/routes/accreditation-status-transition/transitions.js
@@ -14,6 +14,8 @@
  * @property {boolean} [hasGrantFields] - Confirm page collects appliesFrom + accreditationNumber
  */
 
+const WARNING_BUTTON_CLASS = 'govuk-button--warning'
+
 /**
  * Accreditation status transitions the admin UI can action, keyed by the URL
  * action segment. Each entry drives a confirm page and a POST of
@@ -48,7 +50,7 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
     warningText:
       'This action must only be taken following the required legal process for suspension and following instruction from an industry regulator. Suspending an operator will remove their ability to issue PRNs and all declared tonnages submitted during the suspended period will not count towards their waste balance',
     buttonText: 'Suspend now',
-    buttonClasses: 'govuk-button--warning',
+    buttonClasses: WARNING_BUTTON_CLASS,
     errorMessage:
       'There was a problem suspending the accreditation. Please try again.',
     logMessage: 'Suspend accreditation failed'
@@ -80,7 +82,7 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
     warningText:
       'This action must only be taken following the required legal process for cancellation and following instruction from an industry regulator. Cancelling an accreditation is permanent: the operator will no longer be able to issue PRNs and tonnages declared after the cancellation will not count towards their waste balance',
     buttonText: 'Cancel accreditation now',
-    buttonClasses: 'govuk-button--warning',
+    buttonClasses: WARNING_BUTTON_CLASS,
     errorMessage:
       'There was a problem cancelling the accreditation. Please try again.',
     logMessage: 'Cancel accreditation failed'
@@ -114,7 +116,7 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
     warningText:
       'This action must only be taken following the required legal process for refusing an accreditation application and following instruction from an industry regulator. Rejecting an accreditation means the operator remains registered-only: they cannot issue PRNs and declared tonnages will not count towards a waste balance',
     buttonText: 'Reject now',
-    buttonClasses: 'govuk-button--warning',
+    buttonClasses: WARNING_BUTTON_CLASS,
     errorMessage:
       'There was a problem rejecting the accreditation. Please try again.',
     logMessage: 'Reject accreditation failed'
@@ -138,7 +140,7 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
 }
 
 const GREEN_BUTTON = 'govuk-button govuk-!-margin-bottom-0'
-const RED_BUTTON = 'govuk-button govuk-button--warning govuk-!-margin-bottom-0'
+const RED_BUTTON = `govuk-button ${WARNING_BUTTON_CLASS} govuk-!-margin-bottom-0`
 
 /**
  * Summary-list action items for every transition available from the given

--- a/src/server/routes/accreditation-status-transition/transitions.js
+++ b/src/server/routes/accreditation-status-transition/transitions.js
@@ -2,6 +2,8 @@
  * @typedef {object} AccreditationStatusTransition
  * @property {string} fromStatus - Status the accreditation must currently hold
  * @property {string} toStatus - Status posted to the backend status-history endpoint
+ * @property {string} linkText - Overview action label, e.g. "Suspend"
+ * @property {'positive'|'negative'} polarity - Drives the green/red CTA styling of the overview action
  * @property {string} pageTitle
  * @property {string} heading
  * @property {string} warningText - Confirm-page warning copy
@@ -23,6 +25,8 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
   approve: {
     fromStatus: 'created',
     toStatus: 'approved',
+    linkText: 'Approve',
+    polarity: 'positive',
     pageTitle: 'Approve accreditation',
     heading: 'Approve accreditation',
     warningText:
@@ -37,6 +41,8 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
   suspend: {
     fromStatus: 'approved',
     toStatus: 'suspended',
+    linkText: 'Suspend',
+    polarity: 'negative',
     pageTitle: 'Suspend accreditation',
     heading: 'Suspend accreditation',
     warningText:
@@ -50,6 +56,8 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
   reapprove: {
     fromStatus: 'suspended',
     toStatus: 'approved',
+    linkText: 'Reapprove',
+    polarity: 'positive',
     pageTitle: 'Reapprove accreditation',
     heading: 'Reapprove accreditation',
     warningText:
@@ -65,6 +73,8 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
   cancel: {
     fromStatus: 'suspended',
     toStatus: 'cancelled',
+    linkText: 'Cancel',
+    polarity: 'negative',
     pageTitle: 'Cancel accreditation',
     heading: 'Cancel accreditation',
     warningText:
@@ -80,6 +90,8 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
   reinstate: {
     fromStatus: 'cancelled',
     toStatus: 'approved',
+    linkText: 'Reinstate',
+    polarity: 'positive',
     pageTitle: 'Reinstate accreditation',
     heading: 'Reinstate accreditation',
     warningText:
@@ -89,5 +101,60 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
     errorMessage:
       'There was a problem reinstating the accreditation. Please try again.',
     logMessage: 'Reinstate accreditation failed'
+  },
+  // Refusing a non-compliant application (PAE-1618): the operator stays
+  // registered-only — no number or validity dates are involved.
+  reject: {
+    fromStatus: 'created',
+    toStatus: 'rejected',
+    linkText: 'Reject',
+    polarity: 'negative',
+    pageTitle: 'Reject accreditation',
+    heading: 'Reject accreditation',
+    warningText:
+      'This action must only be taken following the required legal process for refusing an accreditation application and following instruction from an industry regulator. Rejecting an accreditation means the operator remains registered-only: they cannot issue PRNs and declared tonnages will not count towards a waste balance',
+    buttonText: 'Reject now',
+    buttonClasses: 'govuk-button--warning',
+    errorMessage:
+      'There was a problem rejecting the accreditation. Please try again.',
+    logMessage: 'Reject accreditation failed'
+  },
+  // Reopening a rejected application for rework (PAE-1623).
+  reopen: {
+    fromStatus: 'rejected',
+    toStatus: 'created',
+    linkText: 'Reopen',
+    polarity: 'positive',
+    pageTitle: 'Reopen accreditation',
+    heading: 'Reopen accreditation',
+    warningText:
+      'This action must only be taken following instruction from an industry regulator. Reopening a rejected accreditation returns the application to created so it can be reworked and reconsidered. The operator remains registered-only and cannot issue PRNs unless the accreditation is subsequently approved',
+    buttonText: 'Reopen now',
+    buttonClasses: '',
+    errorMessage:
+      'There was a problem reopening the accreditation. Please try again.',
+    logMessage: 'Reopen accreditation failed'
   }
 }
+
+const GREEN_BUTTON = 'govuk-button govuk-!-margin-bottom-0'
+const RED_BUTTON = 'govuk-button govuk-button--warning govuk-!-margin-bottom-0'
+
+/**
+ * Summary-list action items for every transition available from the given
+ * accreditation status, styled as green (positive) or red (negative) CTA
+ * buttons. Single source of truth for which actions the registration
+ * overview offers per status.
+ * @param {string} status - Current accreditation status
+ * @param {string} baseUrl - Accreditation URL prefix, `.../accreditations/{id}`
+ * @returns {Array<{href: string, text: string, visuallyHiddenText: string, classes: string}>}
+ */
+export const accreditationStatusActions = (status, baseUrl) =>
+  Object.entries(ACCREDITATION_STATUS_TRANSITIONS)
+    .filter(([, transition]) => transition.fromStatus === status)
+    .map(([action, transition]) => ({
+      href: `${baseUrl}/${action}/confirm`,
+      text: transition.linkText,
+      visuallyHiddenText: 'accreditation',
+      classes: transition.polarity === 'negative' ? RED_BUTTON : GREEN_BUTTON
+    }))

--- a/src/server/routes/accreditation-status-transition/transitions.js
+++ b/src/server/routes/accreditation-status-transition/transitions.js
@@ -109,7 +109,7 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
     warningText:
       'This action must only be taken following the required legal process for refusing an accreditation application and following instruction from an industry regulator. Rejecting an accreditation means the operator remains registered-only: they cannot issue PRNs and declared tonnages will not count towards a waste balance',
     buttonText: 'Reject now',
-    buttonClasses: WARNING_BUTTON_CLASS,
+    buttonClasses: '',
     errorMessage:
       'There was a problem rejecting the accreditation. Please try again.',
     logMessage: 'Reject accreditation failed'

--- a/src/server/routes/accreditation-status-transition/transitions.js
+++ b/src/server/routes/accreditation-status-transition/transitions.js
@@ -3,7 +3,6 @@
  * @property {string} fromStatus - Status the accreditation must currently hold
  * @property {string} toStatus - Status posted to the backend status-history endpoint
  * @property {string} linkText - Overview action label, e.g. "Suspend"
- * @property {'positive'|'negative'} polarity - Drives the green/red CTA styling of the overview action
  * @property {string} pageTitle
  * @property {string} heading
  * @property {string} warningText - Confirm-page warning copy
@@ -28,7 +27,6 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
     fromStatus: 'created',
     toStatus: 'approved',
     linkText: 'Approve',
-    polarity: 'positive',
     pageTitle: 'Approve accreditation',
     heading: 'Approve accreditation',
     warningText:
@@ -44,7 +42,6 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
     fromStatus: 'approved',
     toStatus: 'suspended',
     linkText: 'Suspend',
-    polarity: 'negative',
     pageTitle: 'Suspend accreditation',
     heading: 'Suspend accreditation',
     warningText:
@@ -59,7 +56,6 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
     fromStatus: 'suspended',
     toStatus: 'approved',
     linkText: 'Reapprove',
-    polarity: 'positive',
     pageTitle: 'Reapprove accreditation',
     heading: 'Reapprove accreditation',
     warningText:
@@ -76,7 +72,6 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
     fromStatus: 'suspended',
     toStatus: 'cancelled',
     linkText: 'Cancel',
-    polarity: 'negative',
     pageTitle: 'Cancel accreditation',
     heading: 'Cancel accreditation',
     warningText:
@@ -93,7 +88,6 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
     fromStatus: 'cancelled',
     toStatus: 'approved',
     linkText: 'Reinstate',
-    polarity: 'positive',
     pageTitle: 'Reinstate accreditation',
     heading: 'Reinstate accreditation',
     warningText:
@@ -110,7 +104,6 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
     fromStatus: 'created',
     toStatus: 'rejected',
     linkText: 'Reject',
-    polarity: 'negative',
     pageTitle: 'Reject accreditation',
     heading: 'Reject accreditation',
     warningText:
@@ -126,7 +119,6 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
     fromStatus: 'rejected',
     toStatus: 'created',
     linkText: 'Reopen',
-    polarity: 'positive',
     pageTitle: 'Reopen accreditation',
     heading: 'Reopen accreditation',
     warningText:
@@ -139,17 +131,13 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
   }
 }
 
-const GREEN_BUTTON = 'govuk-button govuk-!-margin-bottom-0'
-const RED_BUTTON = `govuk-button ${WARNING_BUTTON_CLASS} govuk-!-margin-bottom-0`
-
 /**
  * Summary-list action items for every transition available from the given
- * accreditation status, styled as green (positive) or red (negative) CTA
- * buttons. Single source of truth for which actions the registration
- * overview offers per status.
+ * accreditation status. Single source of truth for which actions the
+ * registration overview offers per status.
  * @param {string} status - Current accreditation status
  * @param {string} baseUrl - Accreditation URL prefix, `.../accreditations/{id}`
- * @returns {Array<{href: string, text: string, visuallyHiddenText: string, classes: string}>}
+ * @returns {Array<{href: string, text: string, visuallyHiddenText: string}>}
  */
 export const accreditationStatusActions = (status, baseUrl) =>
   Object.entries(ACCREDITATION_STATUS_TRANSITIONS)
@@ -157,6 +145,5 @@ export const accreditationStatusActions = (status, baseUrl) =>
     .map(([action, transition]) => ({
       href: `${baseUrl}/${action}/confirm`,
       text: transition.linkText,
-      visuallyHiddenText: 'accreditation',
-      classes: transition.polarity === 'negative' ? RED_BUTTON : GREEN_BUTTON
+      visuallyHiddenText: 'accreditation'
     }))

--- a/src/server/routes/accreditation-status-transition/transitions.test.js
+++ b/src/server/routes/accreditation-status-transition/transitions.test.js
@@ -1,0 +1,79 @@
+import { accreditationStatusActions } from './transitions.js'
+
+const baseUrl = '/organisations/org-1/registrations/reg-1/accreditations/acc-1'
+
+const GREEN_BUTTON = 'govuk-button govuk-!-margin-bottom-0'
+const RED_BUTTON = 'govuk-button govuk-button--warning govuk-!-margin-bottom-0'
+
+describe('accreditationStatusActions', () => {
+  it('offers Approve as a green CTA and Reject as a red CTA for a created accreditation', () => {
+    expect(accreditationStatusActions('created', baseUrl)).toEqual([
+      {
+        href: `${baseUrl}/approve/confirm`,
+        text: 'Approve',
+        visuallyHiddenText: 'accreditation',
+        classes: GREEN_BUTTON
+      },
+      {
+        href: `${baseUrl}/reject/confirm`,
+        text: 'Reject',
+        visuallyHiddenText: 'accreditation',
+        classes: RED_BUTTON
+      }
+    ])
+  })
+
+  it('offers Suspend as a red CTA for an approved accreditation', () => {
+    expect(accreditationStatusActions('approved', baseUrl)).toEqual([
+      {
+        href: `${baseUrl}/suspend/confirm`,
+        text: 'Suspend',
+        visuallyHiddenText: 'accreditation',
+        classes: RED_BUTTON
+      }
+    ])
+  })
+
+  it('offers Reapprove as a green CTA and Cancel as a red CTA for a suspended accreditation', () => {
+    expect(accreditationStatusActions('suspended', baseUrl)).toEqual([
+      {
+        href: `${baseUrl}/reapprove/confirm`,
+        text: 'Reapprove',
+        visuallyHiddenText: 'accreditation',
+        classes: GREEN_BUTTON
+      },
+      {
+        href: `${baseUrl}/cancel/confirm`,
+        text: 'Cancel',
+        visuallyHiddenText: 'accreditation',
+        classes: RED_BUTTON
+      }
+    ])
+  })
+
+  it('offers Reinstate as a green CTA for a cancelled accreditation', () => {
+    expect(accreditationStatusActions('cancelled', baseUrl)).toEqual([
+      {
+        href: `${baseUrl}/reinstate/confirm`,
+        text: 'Reinstate',
+        visuallyHiddenText: 'accreditation',
+        classes: GREEN_BUTTON
+      }
+    ])
+  })
+
+  it('offers Reopen as a green CTA for a rejected accreditation', () => {
+    expect(accreditationStatusActions('rejected', baseUrl)).toEqual([
+      {
+        href: `${baseUrl}/reopen/confirm`,
+        text: 'Reopen',
+        visuallyHiddenText: 'accreditation',
+        classes: GREEN_BUTTON
+      }
+    ])
+  })
+
+  it('offers no actions for a status with no transitions', () => {
+    expect(accreditationStatusActions('nonsense', baseUrl)).toEqual([])
+  })
+})

--- a/src/server/routes/accreditation-status-transition/transitions.test.js
+++ b/src/server/routes/accreditation-status-transition/transitions.test.js
@@ -2,73 +2,63 @@ import { accreditationStatusActions } from './transitions.js'
 
 const baseUrl = '/organisations/org-1/registrations/reg-1/accreditations/acc-1'
 
-const GREEN_BUTTON = 'govuk-button govuk-!-margin-bottom-0'
-const RED_BUTTON = 'govuk-button govuk-button--warning govuk-!-margin-bottom-0'
-
 describe('accreditationStatusActions', () => {
-  it('offers Approve as a green CTA and Reject as a red CTA for a created accreditation', () => {
+  it('offers Approve and Reject links for a created accreditation', () => {
     expect(accreditationStatusActions('created', baseUrl)).toEqual([
       {
         href: `${baseUrl}/approve/confirm`,
         text: 'Approve',
-        visuallyHiddenText: 'accreditation',
-        classes: GREEN_BUTTON
+        visuallyHiddenText: 'accreditation'
       },
       {
         href: `${baseUrl}/reject/confirm`,
         text: 'Reject',
-        visuallyHiddenText: 'accreditation',
-        classes: RED_BUTTON
+        visuallyHiddenText: 'accreditation'
       }
     ])
   })
 
-  it('offers Suspend as a red CTA for an approved accreditation', () => {
+  it('offers a Suspend link for an approved accreditation', () => {
     expect(accreditationStatusActions('approved', baseUrl)).toEqual([
       {
         href: `${baseUrl}/suspend/confirm`,
         text: 'Suspend',
-        visuallyHiddenText: 'accreditation',
-        classes: RED_BUTTON
+        visuallyHiddenText: 'accreditation'
       }
     ])
   })
 
-  it('offers Reapprove as a green CTA and Cancel as a red CTA for a suspended accreditation', () => {
+  it('offers Reapprove and Cancel links for a suspended accreditation', () => {
     expect(accreditationStatusActions('suspended', baseUrl)).toEqual([
       {
         href: `${baseUrl}/reapprove/confirm`,
         text: 'Reapprove',
-        visuallyHiddenText: 'accreditation',
-        classes: GREEN_BUTTON
+        visuallyHiddenText: 'accreditation'
       },
       {
         href: `${baseUrl}/cancel/confirm`,
         text: 'Cancel',
-        visuallyHiddenText: 'accreditation',
-        classes: RED_BUTTON
+        visuallyHiddenText: 'accreditation'
       }
     ])
   })
 
-  it('offers Reinstate as a green CTA for a cancelled accreditation', () => {
+  it('offers a Reinstate link for a cancelled accreditation', () => {
     expect(accreditationStatusActions('cancelled', baseUrl)).toEqual([
       {
         href: `${baseUrl}/reinstate/confirm`,
         text: 'Reinstate',
-        visuallyHiddenText: 'accreditation',
-        classes: GREEN_BUTTON
+        visuallyHiddenText: 'accreditation'
       }
     ])
   })
 
-  it('offers Reopen as a green CTA for a rejected accreditation', () => {
+  it('offers a Reopen link for a rejected accreditation', () => {
     expect(accreditationStatusActions('rejected', baseUrl)).toEqual([
       {
         href: `${baseUrl}/reopen/confirm`,
         text: 'Reopen',
-        visuallyHiddenText: 'accreditation',
-        classes: GREEN_BUTTON
+        visuallyHiddenText: 'accreditation'
       }
     ])
   })

--- a/src/server/routes/registration-overview/controller.get.js
+++ b/src/server/routes/registration-overview/controller.get.js
@@ -4,6 +4,7 @@ import {
   findRegistration
 } from '#server/common/helpers/fetch-organisation-overview.js'
 import { formatPeriod } from '#server/common/helpers/format-reporting-period.js'
+import { accreditationStatusActions } from '#server/routes/accreditation-status-transition/transitions.js'
 
 const GREEN_TAG = 'govuk-tag--green'
 const RED_TAG = 'govuk-tag--red'
@@ -140,6 +141,14 @@ export const registrationOverviewGETController = {
       organisationId,
       registrationId,
       registration,
+      // The template only attaches these to the Accreditation status row for
+      // users holding admin.write (hiding is UX — the backend enforces scope).
+      accreditationStatusActions: registration.accreditation
+        ? accreditationStatusActions(
+            registration.accreditation.status,
+            `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${registration.accreditation.id}`
+          )
+        : [],
       cadence: calendar.cadence,
       reportingPeriods: toReportingPeriods(
         calendar.reportingPeriods,

--- a/src/server/routes/registration-overview/get.integration.test.js
+++ b/src/server/routes/registration-overview/get.integration.test.js
@@ -1551,29 +1551,6 @@ describe('#registrationOverviewController', () => {
         )
       })
 
-      test('Should style Reject as a red CTA and Approve as a green CTA on a created accreditation', async () => {
-        useMockBackend(withCreatedAccreditation())
-
-        const { result } = await server.inject({
-          method: 'GET',
-          url,
-          auth: { strategy: 'session', credentials: mockUserSession }
-        })
-
-        const body = renderPage(result)
-        const statusRow = getSummaryRow(body, 'Accreditation status')
-        const rejectLink = within(statusRow).getByRole('link', {
-          name: /^reject accreditation$/i
-        })
-        const approveLink = within(statusRow).getByRole('link', {
-          name: /^approve accreditation$/i
-        })
-
-        expect(rejectLink.className).toContain('govuk-button--warning')
-        expect(approveLink.className).toContain('govuk-button')
-        expect(approveLink.className).not.toContain('govuk-button--warning')
-      })
-
       test('Should not render the Reject action when the accreditation status is not created', async () => {
         useMockBackend()
 
@@ -1637,7 +1614,7 @@ describe('#registrationOverviewController', () => {
         vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
       })
 
-      test('Should render the Reopen action as a green CTA on the Accreditation status row for a rejected accreditation when the user has admin.write scope', async () => {
+      test('Should render the Reopen action on the Accreditation status row for a rejected accreditation when the user has admin.write scope', async () => {
         useMockBackend(withRejectedAccreditation())
 
         const { result } = await server.inject({
@@ -1656,8 +1633,6 @@ describe('#registrationOverviewController', () => {
           'href',
           `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/reopen/confirm`
         )
-        expect(reopenLink.className).toContain('govuk-button')
-        expect(reopenLink.className).not.toContain('govuk-button--warning')
       })
 
       test('Should not render the Reopen action when the accreditation status is not rejected', async () => {
@@ -1701,26 +1676,6 @@ describe('#registrationOverviewController', () => {
             name: /^reopen accreditation$/i
           })
         ).toBeNull()
-      })
-    })
-
-    describe('Accreditation status action styling', () => {
-      test('Should style the Suspend action as a red CTA on an approved accreditation', async () => {
-        useMockBackend()
-
-        const { result } = await server.inject({
-          method: 'GET',
-          url,
-          auth: { strategy: 'session', credentials: mockUserSession }
-        })
-
-        const body = renderPage(result)
-        const statusRow = getSummaryRow(body, 'Accreditation status')
-        const suspendLink = within(statusRow).getByRole('link', {
-          name: /^suspend accreditation$/i
-        })
-
-        expect(suspendLink.className).toContain('govuk-button--warning')
       })
     })
   })

--- a/src/server/routes/registration-overview/get.integration.test.js
+++ b/src/server/routes/registration-overview/get.integration.test.js
@@ -1510,5 +1510,218 @@ describe('#registrationOverviewController', () => {
         ).toBeNull()
       })
     })
+
+    describe('Reject accreditation link visibility', () => {
+      const withCreatedAccreditation = () => ({
+        ...mockOverview,
+        registrations: [
+          {
+            ...mockRegistration,
+            accreditation:
+              /** @type {{ id: string, accreditationNumber: string, status: string }} */ ({
+                ...mockRegistration.accreditation,
+                status: 'created'
+              })
+          }
+        ]
+      })
+
+      afterEach(() => {
+        vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+      })
+
+      test('Should render the Reject action on the Accreditation status row for a created accreditation when the user has admin.write scope', async () => {
+        useMockBackend(withCreatedAccreditation())
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        const body = renderPage(result)
+        const statusRow = getSummaryRow(body, 'Accreditation status')
+        const rejectLink = within(statusRow).getByRole('link', {
+          name: /^reject accreditation$/i
+        })
+
+        expect(rejectLink).toHaveAttribute(
+          'href',
+          `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/reject/confirm`
+        )
+      })
+
+      test('Should style Reject as a red CTA and Approve as a green CTA on a created accreditation', async () => {
+        useMockBackend(withCreatedAccreditation())
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        const body = renderPage(result)
+        const statusRow = getSummaryRow(body, 'Accreditation status')
+        const rejectLink = within(statusRow).getByRole('link', {
+          name: /^reject accreditation$/i
+        })
+        const approveLink = within(statusRow).getByRole('link', {
+          name: /^approve accreditation$/i
+        })
+
+        expect(rejectLink.className).toContain('govuk-button--warning')
+        expect(approveLink.className).toContain('govuk-button')
+        expect(approveLink.className).not.toContain('govuk-button--warning')
+      })
+
+      test('Should not render the Reject action when the accreditation status is not created', async () => {
+        useMockBackend()
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        const body = renderPage(result)
+        const statusRow = getSummaryRow(body, 'Accreditation status')
+
+        expect(
+          within(statusRow).queryByRole('link', {
+            name: /^reject accreditation$/i
+          })
+        ).toBeNull()
+      })
+
+      test('Should not render the Reject action when the user lacks admin.write scope', async () => {
+        const readOnlySession = {
+          ...mockUserSession,
+          scopes: ['admin.read']
+        }
+        vi.mocked(getUserSession).mockResolvedValue(readOnlySession)
+        useMockBackend(withCreatedAccreditation())
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: readOnlySession }
+        })
+
+        const body = renderPage(result)
+        const statusRow = getSummaryRow(body, 'Accreditation status')
+
+        expect(
+          within(statusRow).queryByRole('link', {
+            name: /^reject accreditation$/i
+          })
+        ).toBeNull()
+      })
+    })
+
+    describe('Reopen accreditation link visibility', () => {
+      const withRejectedAccreditation = () => ({
+        ...mockOverview,
+        registrations: [
+          {
+            ...mockRegistration,
+            accreditation:
+              /** @type {{ id: string, accreditationNumber: string, status: string }} */ ({
+                ...mockRegistration.accreditation,
+                status: 'rejected'
+              })
+          }
+        ]
+      })
+
+      afterEach(() => {
+        vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+      })
+
+      test('Should render the Reopen action as a green CTA on the Accreditation status row for a rejected accreditation when the user has admin.write scope', async () => {
+        useMockBackend(withRejectedAccreditation())
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        const body = renderPage(result)
+        const statusRow = getSummaryRow(body, 'Accreditation status')
+        const reopenLink = within(statusRow).getByRole('link', {
+          name: /^reopen accreditation$/i
+        })
+
+        expect(reopenLink).toHaveAttribute(
+          'href',
+          `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/reopen/confirm`
+        )
+        expect(reopenLink.className).toContain('govuk-button')
+        expect(reopenLink.className).not.toContain('govuk-button--warning')
+      })
+
+      test('Should not render the Reopen action when the accreditation status is not rejected', async () => {
+        useMockBackend()
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        const body = renderPage(result)
+        const statusRow = getSummaryRow(body, 'Accreditation status')
+
+        expect(
+          within(statusRow).queryByRole('link', {
+            name: /^reopen accreditation$/i
+          })
+        ).toBeNull()
+      })
+
+      test('Should not render the Reopen action when the user lacks admin.write scope', async () => {
+        const readOnlySession = {
+          ...mockUserSession,
+          scopes: ['admin.read']
+        }
+        vi.mocked(getUserSession).mockResolvedValue(readOnlySession)
+        useMockBackend(withRejectedAccreditation())
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: readOnlySession }
+        })
+
+        const body = renderPage(result)
+        const statusRow = getSummaryRow(body, 'Accreditation status')
+
+        expect(
+          within(statusRow).queryByRole('link', {
+            name: /^reopen accreditation$/i
+          })
+        ).toBeNull()
+      })
+    })
+
+    describe('Accreditation status action styling', () => {
+      test('Should style the Suspend action as a red CTA on an approved accreditation', async () => {
+        useMockBackend()
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        const body = renderPage(result)
+        const statusRow = getSummaryRow(body, 'Accreditation status')
+        const suspendLink = within(statusRow).getByRole('link', {
+          name: /^suspend accreditation$/i
+        })
+
+        expect(suspendLink.className).toContain('govuk-button--warning')
+      })
+    })
   })
 })

--- a/src/server/routes/registration-overview/index.njk
+++ b/src/server/routes/registration-overview/index.njk
@@ -26,34 +26,9 @@
       { key: { text: "Site" }, value: { text: registration.site } }
     ] %}
     {% if registration.accreditation %}
-      {% set accreditationStatusActions = [] %}
-      {% if SCOPES.adminWrite in scopes %}
-        {% set accreditationBaseUrl = '/organisations/' ~ organisationId ~ '/registrations/' ~ registrationId ~ '/accreditations/' ~ registration.accreditation.id %}
-        {% if registration.accreditation.status === 'created' %}
-          {% set accreditationStatusActions = accreditationStatusActions.concat([
-            { href: accreditationBaseUrl ~ '/approve/confirm', text: "Approve", visuallyHiddenText: "accreditation" }
-          ]) %}
-        {% endif %}
-        {% if registration.accreditation.status === 'approved' %}
-          {% set accreditationStatusActions = accreditationStatusActions.concat([
-            { href: accreditationBaseUrl ~ '/suspend/confirm', text: "Suspend", visuallyHiddenText: "accreditation" }
-          ]) %}
-        {% endif %}
-        {% if registration.accreditation.status === 'suspended' %}
-          {% set accreditationStatusActions = accreditationStatusActions.concat([
-            { href: accreditationBaseUrl ~ '/reapprove/confirm', text: "Reapprove", visuallyHiddenText: "accreditation" },
-            { href: accreditationBaseUrl ~ '/cancel/confirm', text: "Cancel", visuallyHiddenText: "accreditation" }
-          ]) %}
-        {% endif %}
-        {% if registration.accreditation.status === 'cancelled' %}
-          {% set accreditationStatusActions = accreditationStatusActions.concat([
-            { href: accreditationBaseUrl ~ '/reinstate/confirm', text: "Reinstate", visuallyHiddenText: "accreditation" }
-          ]) %}
-        {% endif %}
-      {% endif %}
       {% set summaryRows = summaryRows.concat([
         { key: { text: "Accreditation number" }, value: { text: registration.accreditation.accreditationNumber } },
-        { key: { text: "Accreditation status" }, value: { html: govukTag({ text: registration.accreditation.status }) }, actions: { items: accreditationStatusActions } },
+        { key: { text: "Accreditation status" }, value: { html: govukTag({ text: registration.accreditation.status }) }, actions: { items: accreditationStatusActions if SCOPES.adminWrite in scopes else [] } },
         { key: { text: "Waste balance (tonnes)" }, value: { text: wasteBalance.amount if wasteBalance else "No data" } },
         { key: { text: "Waste balance available (tonnes)" }, value: { text: wasteBalance.availableAmount if wasteBalance else "No data" } },
         { key: { text: "Waste balance events" }, value: { html: '<a class="govuk-link govuk-link--no-visited-state" href="' ~ wasteBalanceEventsUrl ~ '">View</a>' } }
@@ -77,7 +52,9 @@
     {% endif %}
 
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third">
+      {# Two-thirds so multi-action rows (e.g. Approve | Reject) keep their
+         CTA buttons on one line instead of wrapping into a stack. #}
+      <div class="govuk-grid-column-two-thirds">
         {{ govukSummaryList({ rows: summaryRows }) }}
       </div>
     </div>

--- a/src/server/routes/registration-overview/index.njk
+++ b/src/server/routes/registration-overview/index.njk
@@ -53,7 +53,7 @@
 
     <div class="govuk-grid-row">
       {# Two-thirds so multi-action rows (e.g. Approve | Reject) keep their
-         CTA buttons on one line instead of wrapping into a stack. #}
+         links horizontally aligned on one line instead of wrapping into a stack. #}
       <div class="govuk-grid-column-two-thirds">
         {{ govukSummaryList({ rows: summaryRows }) }}
       </div>


### PR DESCRIPTION
Ticket: [PAE-1618](https://eaflood.atlassian.net/browse/PAE-1618)
## Summary

- Adds two accreditation actions: **Reject** (`created → rejected`, PAE-1618) and **Reopen** (`rejected → created`, PAE-1623), each with a confirm page and POST driven entirely by the existing transition config/route factory.
- Registration-overview status actions are now derived from `ACCREDITATION_STATUS_TRANSITIONS` in the controller — single source of truth; the per-status `{% if %}` chain in the template is gone. New transitions no longer need template edits.
- Overview actions render as standard summary-list links (no CTA styling). Confirm-page buttons keep their red warning styling for destructive transitions.
- Summary-list column widened from one-third to two-thirds so multi-action rows (`created`: Approve | Reject, `suspended`: Reapprove | Cancel) keep their links horizontally aligned on one line instead of stacking.

Backend counterpart (release first): DEFRA/epr-backend#1568.


[PAE-1618]: https://eaflood.atlassian.net/browse/PAE-1618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
