### PR TITLE
PAE-1599: hoist GDS date-input to ISO conversion to a common helper

### DIFF
--- a/src/server/common/helpers/date-input.js
+++ b/src/server/common/helpers/date-input.js
@@ -1,0 +1,25 @@
+/**
+ * Builds a YYYY-MM-DD date from GDS date-input parts, or null when the parts
+ * do not form a real calendar date.
+ * @param {string} day
+ * @param {string} month
+ * @param {string} year
+ * @returns {string | null}
+ */
+export const dateInputToIsoDate = (day, month, year) => {
+  if (
+    !/^\d{1,2}$/.test(day) ||
+    !/^\d{1,2}$/.test(month) ||
+    !/^\d{4}$/.test(year)
+  ) {
+    return null
+  }
+
+  const iso = `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`
+  const date = new Date(`${iso}T00:00:00.000Z`)
+  if (Number.isNaN(date.getTime()) || !date.toISOString().startsWith(iso)) {
+    return null
+  }
+
+  return iso
+}

--- a/src/server/common/helpers/status-transition/applies-from-date.js
+++ b/src/server/common/helpers/status-transition/applies-from-date.js
@@ -1,28 +1,4 @@
-/**
- * Builds a YYYY-MM-DD date from GDS date-input parts, or null when the parts
- * do not form a real calendar date.
- * @param {string} day
- * @param {string} month
- * @param {string} year
- * @returns {string | null}
- */
-const toIsoDate = (day, month, year) => {
-  if (
-    !/^\d{1,2}$/.test(day) ||
-    !/^\d{1,2}$/.test(month) ||
-    !/^\d{4}$/.test(year)
-  ) {
-    return null
-  }
-
-  const iso = `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`
-  const date = new Date(`${iso}T00:00:00.000Z`)
-  if (Number.isNaN(date.getTime()) || !date.toISOString().startsWith(iso)) {
-    return null
-  }
-
-  return iso
-}
+import { dateInputToIsoDate } from '#server/common/helpers/date-input.js'
 
 /**
  * Parses and validates the "applies from" GDS date-input fields from a
@@ -42,7 +18,7 @@ export const parseAppliesFromDate = (payload) => {
   const day = (payload['appliesFrom-day'] ?? '').trim()
   const month = (payload['appliesFrom-month'] ?? '').trim()
   const year = (payload['appliesFrom-year'] ?? '').trim()
-  const appliesFrom = toIsoDate(day, month, year)
+  const appliesFrom = dateInputToIsoDate(day, month, year)
 
   return {
     day,


### PR DESCRIPTION
Ticket: [PAE-1599](https://eaflood.atlassian.net/browse/PAE-1599)
Follow-up to #443 review comments (the PR merged before this could land on its branch).

## What

- Hoists the generic GDS date-input → ISO date conversion out of `status-transition/applies-from-date.js` into a new discoverable common helper, `src/server/common/helpers/date-input.js` (`dateInputToIsoDate`), so future date-input forms reuse it rather than rebuilding it.
- `parseAppliesFromDate` keeps only the transition-specific parts (the `appliesFrom-*` field names and error copy) and now imports the shared converter.

No behaviour change; existing coverage exercises both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PAE-1599]: https://eaflood.atlassian.net/browse/PAE-1599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ