### PR TITLE
PAE-1800: hide accreditation approve/reinstate unless registration approved

### DIFF
--- a/src/server/routes/accreditation-status-transition/transitions.js
+++ b/src/server/routes/accreditation-status-transition/transitions.js
@@ -11,6 +11,7 @@
  * @property {string} errorMessage - Flash fallback when the backend gives no message
  * @property {string} logMessage
  * @property {boolean} [hasGrantFields] - Confirm page collects appliesFrom + accreditationNumber
+ * @property {boolean} [requiresApprovedRegistration] - Action offered only when the linked registration is approved (PAE-1800)
  */
 
 const WARNING_BUTTON_CLASS = 'govuk-button--warning'
@@ -27,6 +28,7 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
     fromStatus: 'created',
     toStatus: 'approved',
     linkText: 'Approve',
+    requiresApprovedRegistration: true,
     pageTitle: 'Approve accreditation',
     heading: 'Approve accreditation',
     warningText:
@@ -88,6 +90,7 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
     fromStatus: 'cancelled',
     toStatus: 'approved',
     linkText: 'Reinstate',
+    requiresApprovedRegistration: true,
     pageTitle: 'Reinstate accreditation',
     heading: 'Reinstate accreditation',
     warningText:
@@ -134,14 +137,26 @@ export const ACCREDITATION_STATUS_TRANSITIONS = {
 /**
  * Summary-list action items for every transition available from the given
  * accreditation status. Single source of truth for which actions the
- * registration overview offers per status.
+ * registration overview offers per status. Actions that move the
+ * accreditation to approved are only offered when the linked registration is
+ * itself approved (PAE-1800).
  * @param {string} status - Current accreditation status
  * @param {string} baseUrl - Accreditation URL prefix, `.../accreditations/{id}`
+ * @param {string} registrationStatus - Current status of the linked registration
  * @returns {Array<{href: string, text: string, visuallyHiddenText: string}>}
  */
-export const accreditationStatusActions = (status, baseUrl) =>
+export const accreditationStatusActions = (
+  status,
+  baseUrl,
+  registrationStatus
+) =>
   Object.entries(ACCREDITATION_STATUS_TRANSITIONS)
-    .filter(([, transition]) => transition.fromStatus === status)
+    .filter(
+      ([, transition]) =>
+        transition.fromStatus === status &&
+        (!transition.requiresApprovedRegistration ||
+          registrationStatus === 'approved')
+    )
     .map(([action, transition]) => ({
       href: `${baseUrl}/${action}/confirm`,
       text: transition.linkText,

--- a/src/server/routes/accreditation-status-transition/transitions.test.js
+++ b/src/server/routes/accreditation-status-transition/transitions.test.js
@@ -3,8 +3,8 @@ import { accreditationStatusActions } from './transitions.js'
 const baseUrl = '/organisations/org-1/registrations/reg-1/accreditations/acc-1'
 
 describe('accreditationStatusActions', () => {
-  it('offers Approve and Reject links for a created accreditation', () => {
-    expect(accreditationStatusActions('created', baseUrl)).toEqual([
+  it('offers Approve and Reject links for a created accreditation when the registration is approved', () => {
+    expect(accreditationStatusActions('created', baseUrl, 'approved')).toEqual([
       {
         href: `${baseUrl}/approve/confirm`,
         text: 'Approve',
@@ -18,8 +18,20 @@ describe('accreditationStatusActions', () => {
     ])
   })
 
+  it('offers only Reject for a created accreditation when the registration is not approved', () => {
+    expect(accreditationStatusActions('created', baseUrl, 'created')).toEqual([
+      {
+        href: `${baseUrl}/reject/confirm`,
+        text: 'Reject',
+        visuallyHiddenText: 'accreditation'
+      }
+    ])
+  })
+
   it('offers a Suspend link for an approved accreditation', () => {
-    expect(accreditationStatusActions('approved', baseUrl)).toEqual([
+    expect(
+      accreditationStatusActions('approved', baseUrl, 'cancelled')
+    ).toEqual([
       {
         href: `${baseUrl}/suspend/confirm`,
         text: 'Suspend',
@@ -29,7 +41,9 @@ describe('accreditationStatusActions', () => {
   })
 
   it('offers Reapprove and Cancel links for a suspended accreditation', () => {
-    expect(accreditationStatusActions('suspended', baseUrl)).toEqual([
+    expect(
+      accreditationStatusActions('suspended', baseUrl, 'approved')
+    ).toEqual([
       {
         href: `${baseUrl}/reapprove/confirm`,
         text: 'Reapprove',
@@ -43,8 +57,10 @@ describe('accreditationStatusActions', () => {
     ])
   })
 
-  it('offers a Reinstate link for a cancelled accreditation', () => {
-    expect(accreditationStatusActions('cancelled', baseUrl)).toEqual([
+  it('offers a Reinstate link for a cancelled accreditation when the registration is approved', () => {
+    expect(
+      accreditationStatusActions('cancelled', baseUrl, 'approved')
+    ).toEqual([
       {
         href: `${baseUrl}/reinstate/confirm`,
         text: 'Reinstate',
@@ -53,17 +69,27 @@ describe('accreditationStatusActions', () => {
     ])
   })
 
+  it('offers no Reinstate link for a cancelled accreditation when the registration is not approved', () => {
+    expect(
+      accreditationStatusActions('cancelled', baseUrl, 'cancelled')
+    ).toEqual([])
+  })
+
   it('offers a Reopen link for a rejected accreditation', () => {
-    expect(accreditationStatusActions('rejected', baseUrl)).toEqual([
-      {
-        href: `${baseUrl}/reopen/confirm`,
-        text: 'Reopen',
-        visuallyHiddenText: 'accreditation'
-      }
-    ])
+    expect(accreditationStatusActions('rejected', baseUrl, 'approved')).toEqual(
+      [
+        {
+          href: `${baseUrl}/reopen/confirm`,
+          text: 'Reopen',
+          visuallyHiddenText: 'accreditation'
+        }
+      ]
+    )
   })
 
   it('offers no actions for a status with no transitions', () => {
-    expect(accreditationStatusActions('nonsense', baseUrl)).toEqual([])
+    expect(accreditationStatusActions('nonsense', baseUrl, 'approved')).toEqual(
+      []
+    )
   })
 })

--- a/src/server/routes/registration-overview/controller.get.js
+++ b/src/server/routes/registration-overview/controller.get.js
@@ -179,7 +179,8 @@ export const registrationOverviewGETController = {
       accreditationStatusActions: registration.accreditation
         ? accreditationStatusActions(
             registration.accreditation.status,
-            `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${registration.accreditation.id}`
+            `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${registration.accreditation.id}`,
+            registration.status
           )
         : [],
       registrationStatusActions: registrationStatusActions(

--- a/src/server/routes/registration-overview/get.integration.test.js
+++ b/src/server/routes/registration-overview/get.integration.test.js
@@ -1511,6 +1511,114 @@ describe('#registrationOverviewController', () => {
       })
     })
 
+    describe.each([
+      {
+        action: 'Approve',
+        accreditationStatus: 'created',
+        href: 'approve/confirm'
+      },
+      {
+        action: 'Reinstate',
+        accreditationStatus: 'cancelled',
+        href: 'reinstate/confirm'
+      }
+    ])(
+      '$action accreditation gated on registration status (PAE-1800)',
+      ({ action, accreditationStatus, href }) => {
+        const linkName = new RegExp(`^${action} accreditation$`, 'i')
+        const withStatuses = (registrationStatus) => ({
+          ...mockOverview,
+          registrations: [
+            {
+              ...mockRegistration,
+              status: registrationStatus,
+              accreditation:
+                /** @type {{ id: string, accreditationNumber: string, status: string }} */ ({
+                  ...mockRegistration.accreditation,
+                  status: accreditationStatus
+                })
+            }
+          ]
+        })
+
+        afterEach(() => {
+          vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+        })
+
+        test(`Should render the ${action} action on the Accreditation status row when the registration is approved`, async () => {
+          useMockBackend(withStatuses('approved'))
+
+          const { result } = await server.inject({
+            method: 'GET',
+            url,
+            auth: { strategy: 'session', credentials: mockUserSession }
+          })
+
+          const body = renderPage(result)
+          const statusRow = getSummaryRow(body, 'Accreditation status')
+          const link = within(statusRow).getByRole('link', { name: linkName })
+
+          expect(link).toHaveAttribute(
+            'href',
+            `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/${href}`
+          )
+        })
+
+        test(`Should not render the ${action} action when the registration is not approved`, async () => {
+          useMockBackend(withStatuses('cancelled'))
+
+          const { result } = await server.inject({
+            method: 'GET',
+            url,
+            auth: { strategy: 'session', credentials: mockUserSession }
+          })
+
+          const body = renderPage(result)
+          const statusRow = getSummaryRow(body, 'Accreditation status')
+
+          expect(
+            within(statusRow).queryByRole('link', { name: linkName })
+          ).toBeNull()
+        })
+      }
+    )
+
+    describe('Reject accreditation link visibility when the registration is not approved (PAE-1800)', () => {
+      test('Should still render the Reject action on the Accreditation status row', async () => {
+        useMockBackend({
+          ...mockOverview,
+          registrations: [
+            {
+              ...mockRegistration,
+              status: 'created',
+              accreditation:
+                /** @type {{ id: string, accreditationNumber: string, status: string }} */ ({
+                  ...mockRegistration.accreditation,
+                  status: 'created'
+                })
+            }
+          ]
+        })
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        const body = renderPage(result)
+        const statusRow = getSummaryRow(body, 'Accreditation status')
+        const rejectLink = within(statusRow).getByRole('link', {
+          name: /^reject accreditation$/i
+        })
+
+        expect(rejectLink).toHaveAttribute(
+          'href',
+          `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/reject/confirm`
+        )
+      })
+    })
+
     describe('Approve registration link visibility', () => {
       afterEach(() => {
         vi.mocked(getUserSession).mockResolvedValue(mockUserSession)


### PR DESCRIPTION
Ticket: [PAE-1800](https://eaflood.atlassian.net/browse/PAE-1800)
## Summary

- Hides the accreditation "Approve" and "Reinstate" action links on the registration overview page unless the organisation's registration status is Approved.
- The rule: an accreditation cannot be approved or reinstated unless its parent registration is already approved. Hiding the links here is a UX affordance — the backend is the source of truth and enforces the same rule with a 422 response (see DEFRA/epr-backend#1582, which merges first).

## Changes

- `src/server/routes/accreditation-status-transition/transitions.js` — filter approve/reinstate transitions based on registration status
- `src/server/routes/registration-overview/controller.get.js` — pass registration status through to the transition filter
- Corresponding test coverage in `transitions.test.js` and `get.integration.test.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PAE-1800]: https://eaflood.atlassian.net/browse/PAE-1800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ