### PR TITLE
PAE-250: Fix brace-expansion, js-yaml and fast-uri vulnerabilities

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,4 +2,5 @@ git-tag-version=false
 save-exact=true
 engine-strict=true
 allow-git=none
-min-release-age=3
+ignore-scripts=true
+min-release-age=7

--- a/.snyk
+++ b/.snyk
@@ -1,8 +1,4 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.25.1
-ignore:
-  'SNYK-JS-POSTCSSSELECTORPARSER-16873882':
-    - '*':
-        reason: 'No upstream fix available. postcss-selector-parser is pulled in transitively by cssnano during the webpack CSS build only and is never reached at application runtime, so the uncontrolled-recursion DoS is not exploitable here. Revisit when a patched version is published.'
-        expires: '2027-06-12T00:00:00.000Z'
+ignore: {}
 patch: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2685,19 +2685,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -2812,6 +2799,40 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@hapi/bell/node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@hapi/bell/node_modules/@hapi/topo/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/bell/node_modules/joi": {
+      "version": "17.13.4",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+      "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
+    "node_modules/@hapi/bell/node_modules/joi/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@hapi/boom": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.1.tgz",
@@ -2893,6 +2914,40 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@hapi/catbox-redis/node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@hapi/catbox-redis/node_modules/@hapi/topo/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/catbox-redis/node_modules/joi": {
+      "version": "17.13.4",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+      "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
+    "node_modules/@hapi/catbox-redis/node_modules/joi/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/content": {
       "version": "6.0.2",
@@ -4219,6 +4274,33 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/address/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@sindresorhus/base62": {
       "version": "1.0.0",
@@ -6154,16 +6236,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -6746,19 +6828,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/cross-spawn": {
@@ -8142,9 +8211,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -9880,6 +9949,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsdoc-type-pratt-parser": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-8.0.0.tgz",
@@ -10724,9 +10816,9 @@
       "license": "MIT"
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -126,12 +126,14 @@
     "webpack-cli": "7.2.2"
   },
   "overrides": {
-    "joi": "18.2.3",
+    "fast-uri": "3.1.5",
+    "js-yaml": "4.3.0",
     "jsoneditor": {
       "ajv": "6.14.0"
     },
     "ajv-cli": {
-      "fast-json-patch": "3.1.1"
+      "fast-json-patch": "3.1.1",
+      "js-yaml": "3.15.0"
     },
     "stylelint-config-gds": {
       "stylelint": "$stylelint"


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
Clears every outstanding npm advisory in this repo, drops two pieces of mitigation that had gone stale, and brings `.npmrc` up to the CDP security standard. `npm audit` reports zero vulnerabilities and `snyk test` is clean afterwards.

## Vulnerability fixes

| Package | From → to | How |
|---|---|---|
| `brace-expansion` (root) | 5.0.7 → 5.0.9 | re-resolved |
| `brace-expansion` (under minimatch) | 1.1.16 → 1.1.18 | re-resolved |
| `js-yaml` (under `@eslint/eslintrc` and `cosmiconfig`) | 4.1.1 → 4.3.0 | override |
| `fast-uri` (under `ajv`) | 3.1.4 → 3.1.5 | override |

### The js-yaml fix needed a carve-out

The obvious shape — a scoped override under `cosmiconfig` — does not work, because npm matches nested override keys against the root package's **direct** dependencies only, and `cosmiconfig` arrives transitively through `postcss-loader` and `stylelint`. So the fix is a top-level `"js-yaml": "4.3.0"`.

That alone would break `ajv-cli`, which needs `^3.14.0` and calls `safeLoad` — an API that no longer exists in 4.x. Hence the paired `"ajv-cli": { "js-yaml": "3.15.0" }` carve-out, which holds it on the 3.x line it expects. `npm run schema:compile` exercises that path and passes.

All override versions are exact, so the `Preparation` job's pin check is satisfied.

## Removed the `joi` override

`joi` was pinned to 18.2.3 through `overrides`, but it is also a direct dependency at the same version, so the override was duplicating what `dependencies` already guarantees — and reaching further than it should. `@hapi/bell` and `@hapi/catbox-redis` both declare `^17.7.1`, and the override was forcing them onto a major version they never asked for.

With it removed, the application's own `joi` stays at 18.2.3 (confirmed with `npm ls joi`) and only those two hapi plugins fall back to the 17.13.4 they actually declare. Both scanners stay clean.

## Removed the `postcss-selector-parser` Snyk ignore

The entry's reason said "no upstream fix available". The advisory's affected range is `<6.1.3 || >=7.0.0 <7.1.2` and it is fixed in 7.1.2, while this repo already resolves 7.1.4 — so the ignore suppressed nothing and its stated reason had become misleading. The three genuine compatibility shims (`jsoneditor > ajv`, `ajv-cli > fast-json-patch`, `stylelint-config-gds > stylelint`) are untouched.

## `.npmrc` — two settings brought up to the CDP standard

**`min-release-age` raised from 3 to 7.** The supply-chain cooldown: npm refuses to resolve any package published inside the window, giving a week for a package takeover or typosquat to surface first. It gates *resolution* only, so `npm ci` from the committed lockfile is unaffected and CI behaves exactly as before.

**`ignore-scripts=true` added.** Blocks package lifecycle scripts during install — a well-worn route for a compromised package to run arbitrary code on a developer machine. The setting was already present in epr-backend, epr-frontend and epr-re-ex-journey-tests; this repo and two others were the gap.

Little changes in practice, because the Dockerfile already passes `--ignore-scripts` on both its `npm install` and `npm ci` stages and calls `npm run build:frontend` explicitly rather than relying on a lifecycle hook.

<details>
<summary>Every package here that declares an install script, and why blocking it is safe</summary>

- **root `postinstall` → `setup:husky`** — see the consequence below.
- **`@defra/cdp-auditing`, `@defra/hapi-secure-context`, `@defra/hapi-tracing`** — each declares `postinstall: npm run setup:husky`, which is that package's own dev-repo hook setup. Meaningless when consumed as a dependency.
- **`@parcel/watcher`** — its `install` script builds from source, but the prebuilt `watcher-linux-x64-glibc` binary arrives through optionalDependencies, so the build is never needed. Only reached by `sass --watch`, not the one-shot build.
- **`fsevents`** — macOS-only optional dependency, not installed on Linux.
- **`msw`** — its postinstall early-returns unless `package.json` carries an `msw.workerDirectory` key, which it does not. This repo uses `msw/node` `setupServer`, never the browser service worker. All msw-backed tests pass.

</details>

### Two behavioural consequences worth knowing

**Git hooks lie dormant in a fresh clone.** `postinstall` runs `setup:husky`, so with scripts ignored `npm ci` no longer wires the hooks — `.husky/_` is left empty and `core.hooksPath` unset until someone runs `npm run setup:husky` by hand. Verified by deleting `node_modules` and `.husky/_` and reinstalling. The tracked `.husky/pre-commit` is untouched; it is only the generated shim that goes missing. This already happens in the three repos that have the setting today, so it is a pre-existing wrinkle rather than a new one — but it is easy to be caught out by, since a commit made in a fresh worktree will silently skip the pre-commit checks.

**`pretest` and `prestart` no longer fire.** Verified directly: `npm test` goes straight to vitest. CI is unaffected (workflows pass `build-command: npm run build:frontend` explicitly) and Docker is unaffected (explicit build step, runtime is `node src` rather than `npm start`). The only impact is local `npm test` when `.public/` is missing, which then fails in `serve-static-files.test.js` until the build is run.

## Verification

From a deleted `node_modules` and `.husky/_`, so a lifecycle script would have had to run to succeed: clean `npm ci` (1095 packages, no `postinstall` output at all), `npm run build:frontend`, the full test suite at 100% coverage, `lint:js`, `lint:scss`, and `lint:types` — all passing.

The lockfile was rebuilt from `main`'s rather than re-blessing the existing one, so the guard was genuinely re-checked rather than accepted from an already-pinned entry. That is also why the diff is small: 16 changed resolutions, being the five security fixes plus the `joi` fallout. Held-back packages are untouched — `lint-staged` still resolves to 17.1.0, and `gitleaks` and `cssnano` are not in this tree.


[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ