### PR TITLE
feat(organisation-overview): show unlinked accreditations and assign them (PAE-1816)

### DIFF
--- a/src/server/common/helpers/fetch-organisation-overview.js
+++ b/src/server/common/helpers/fetch-organisation-overview.js
@@ -5,10 +5,16 @@ import { notFound } from '#server/common/helpers/logging/cdp-boom.js'
 /** @import { HapiRequest } from '#server/common/hapi-types.js' */
 
 /**
+ * An accreditation as the overview returns it, whether linked to a
+ * registration or standing on its own. `accreditationNumber` is null until the
+ * accreditation is approved, and `site` is absent for an exporter.
  * @typedef {{
  *   id: string,
- *   accreditationNumber: string,
- *   status: string
+ *   accreditationNumber: string | null,
+ *   status: string,
+ *   material?: string,
+ *   processingType?: string,
+ *   site?: string
  * }} Accreditation
  *
  * @typedef {{
@@ -18,6 +24,7 @@ import { notFound } from '#server/common/helpers/logging/cdp-boom.js'
  *   material: string,
  *   site: string,
  *   processingType: string,
+ *   reprocessingType?: string | null,
  *   accreditation?: Accreditation
  * }} Registration
  *
@@ -32,6 +39,7 @@ import { notFound } from '#server/common/helpers/logging/cdp-boom.js'
  *   id: string,
  *   companyName: string,
  *   registrations: Registration[],
+ *   unlinkedAccreditations?: Accreditation[],
  *   linkedDefraOrganisation?: LinkedDefraOrganisation
  * }} OrganisationOverview
  */
@@ -71,4 +79,39 @@ export const findRegistration = (overview, organisationId, registrationId) => {
   }
 
   return registration
+}
+
+/**
+ * Find an accreditation that is not linked to any registration, throwing an
+ * enriched 404 if it's missing. An accreditation that has since been assigned
+ * has left this collection, so the 404 also covers "someone else assigned it
+ * while this page was open".
+ * @param {OrganisationOverview} overview
+ * @param {string} organisationId
+ * @param {string} accreditationId
+ * @returns {Accreditation}
+ */
+export const findUnlinkedAccreditation = (
+  overview,
+  organisationId,
+  accreditationId
+) => {
+  const accreditation = overview.unlinkedAccreditations?.find(
+    (a) => a.id === accreditationId
+  )
+
+  if (!accreditation) {
+    throw notFound(
+      'Unlinked accreditation not found',
+      errorCodes.accreditationNotFound,
+      {
+        event: {
+          action: 'fetch_unlinked_accreditation',
+          reason: `organisationId=${organisationId} accreditationId=${accreditationId}`
+        }
+      }
+    )
+  }
+
+  return accreditation
 }

--- a/src/server/common/helpers/fetch-organisation-overview.test.js
+++ b/src/server/common/helpers/fetch-organisation-overview.test.js
@@ -1,12 +1,13 @@
 import { vi } from 'vitest'
 import {
   fetchOrganisationOverview,
-  findRegistration
+  findRegistration,
+  findUnlinkedAccreditation
 } from './fetch-organisation-overview.js'
 import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
 
 /** @import { Request } from '@hapi/hapi' */
-/** @import { OrganisationOverview, Registration } from './fetch-organisation-overview.js' */
+/** @import { Accreditation, OrganisationOverview, Registration } from './fetch-organisation-overview.js' */
 
 vi.mock('#server/common/helpers/fetch-json-from-backend.js', () => ({
   fetchJsonFromBackend: vi.fn()
@@ -93,5 +94,63 @@ describe(findRegistration, () => {
         }
       })
     )
+  })
+})
+
+describe(findUnlinkedAccreditation, () => {
+  const organisationId = 'aaa111bbb222ccc333ddd4444'
+  const accreditationId = 'ccc333ddd444eee555fff6666'
+
+  const expectedNotFound = expect.objectContaining({
+    isBoom: true,
+    message: 'Unlinked accreditation not found',
+    code: 'accreditation_not_found',
+    event: {
+      action: 'fetch_unlinked_accreditation',
+      reason: `organisationId=${organisationId} accreditationId=${accreditationId}`
+    }
+  })
+
+  /**
+   * @param {Accreditation[]} [unlinkedAccreditations]
+   * @returns {OrganisationOverview}
+   */
+  const overviewWith = (unlinkedAccreditations) => ({
+    id: organisationId,
+    companyName: 'ACME ltd',
+    registrations: [],
+    unlinkedAccreditations
+  })
+
+  test('returns the matching unlinked accreditation when present', () => {
+    const accreditation = /** @type {Accreditation} */ ({
+      id: accreditationId,
+      accreditationNumber: null,
+      status: 'created'
+    })
+
+    expect(
+      findUnlinkedAccreditation(
+        overviewWith([accreditation]),
+        organisationId,
+        accreditationId
+      )
+    ).toBe(accreditation)
+  })
+
+  test('throws notFound when the accreditation is not in the collection', () => {
+    expect(() =>
+      findUnlinkedAccreditation(
+        overviewWith([]),
+        organisationId,
+        accreditationId
+      )
+    ).toThrow(expectedNotFound)
+  })
+
+  test('throws notFound when the overview has no unlinked accreditations at all', () => {
+    expect(() =>
+      findUnlinkedAccreditation(overviewWith(), organisationId, accreditationId)
+    ).toThrow(expectedNotFound)
   })
 })

--- a/src/server/common/helpers/status-transition/post-status-transition.js
+++ b/src/server/common/helpers/status-transition/post-status-transition.js
@@ -8,22 +8,23 @@ import { statusCodes } from '#server/common/constants/status-codes.js'
  */
 
 /**
- * Posts a status-transition body to the backend status-history endpoint.
- * Shared between accreditation-status-transition and
- * registration-status-transition — only the backend URL and the transition's
- * own error copy differ; the request/response handling is identical.
+ * Posts a confirm-page body to the backend and reports how the failure should
+ * surface. Shared between accreditation-status-transition,
+ * registration-status-transition and accreditation-assign — only the backend
+ * URL and the caller's own error copy differ; the request/response handling is
+ * identical.
  *
  * Returns `null` on success, or when a 5xx/network failure has already been
  * flashed on the request's session (the caller redirects to the overview
  * either way). Returns `{ backendError }` when a client-side (4xx) rejection
- * of grant fields should instead re-render the confirm page, preserving what
- * the admin typed.
+ * of the submitted fields should instead re-render the confirm page,
+ * preserving what the admin entered.
  * @param {string} statusHistoryUrl
  * @param {Record<string, string | undefined>} body
  * @param {StatusTransitionErrorCopy} transition
- * @param {Record<string, string> | undefined} grantValues - Parsed grant
- *   field values, present only when the transition collects them; used to
- *   decide whether a 4xx rejection re-renders the confirm page
+ * @param {Record<string, string> | undefined} grantValues - Parsed form
+ *   values, present only when the confirm page collects them; used to decide
+ *   whether a 4xx rejection re-renders the confirm page
  * @returns {Promise<{ backendError: string } | null>}
  */
 export const postStatusTransition = async (

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -28,6 +28,7 @@ import { accreditationOverseasSites } from './routes/accreditation-overseas-site
 import { creditedTonnage } from './routes/credited-tonnage/index.js'
 import { accreditationStatusTransition } from './routes/accreditation-status-transition/index.js'
 import { registrationStatusTransition } from './routes/registration-status-transition/index.js'
+import { accreditationAssign } from './routes/accreditation-assign/index.js'
 
 import { serveStaticFiles } from './common/helpers/serve-static-files.js'
 
@@ -68,7 +69,8 @@ export const router = {
         accreditationOverseasSites,
         creditedTonnage,
         accreditationStatusTransition,
-        registrationStatusTransition
+        registrationStatusTransition,
+        accreditationAssign
       ])
 
       await server.register([serveStaticFiles])

--- a/src/server/routes/accreditation-assign/assign-view.js
+++ b/src/server/routes/accreditation-assign/assign-view.js
@@ -1,0 +1,64 @@
+import { candidateRegistrations } from './candidate-registrations.js'
+
+/** @import { Accreditation, Registration } from '#server/common/helpers/fetch-organisation-overview.js' */
+
+const NO_CANDIDATES_TEXT =
+  'There are no registrations this accreditation can be assigned to. A registration must be approved, have the same material, processing type and site, have a reprocessing type, and not already have an accreditation.'
+
+/**
+ * Builds the view context for the assign page. Used by the GET controller and
+ * by the POST controller when re-rendering after a missing selection or a
+ * backend rejection, so the candidate list is derived the same way each time.
+ * @param {{ organisationId: string, accreditationId: string }} params
+ * @param {Accreditation} accreditation
+ * @param {Registration[]} registrations
+ * @param {{
+ *   registrationId?: string,
+ *   error?: string | null,
+ *   backendError?: string
+ * }} [state]
+ */
+export const buildAssignView = (
+  { organisationId, accreditationId },
+  accreditation,
+  registrations,
+  { registrationId = '', error = null, backendError } = {}
+) => {
+  const candidates = candidateRegistrations(registrations, accreditation)
+
+  const errorList = []
+  if (backendError) {
+    errorList.push({ text: backendError })
+  }
+  if (error) {
+    errorList.push({ text: error, href: '#registrationId' })
+  }
+
+  const overviewUrl = `/organisations/${organisationId}/overview`
+
+  return {
+    pageTitle: 'Assign accreditation to registration',
+    heading: 'Assign accreditation to registration',
+    breadcrumbs: [
+      { text: 'Organisations', href: '/organisations' },
+      { text: 'Organisation overview', href: overviewUrl }
+    ],
+    hintText: `Only approved ${accreditation.material} registrations matching this accreditation and without an accreditation of their own are listed.`,
+    noCandidatesText: NO_CANDIDATES_TEXT,
+    hasCandidates: candidates.length > 0,
+    // A blank leading option keeps the browser from pre-selecting the first
+    // registration, so "mandatory" means the admin actually chose one.
+    items: [
+      { value: '', text: '', selected: !registrationId },
+      ...candidates.map((registration) => ({
+        value: registration.id,
+        text: `${registration.registrationNumber} - ${registration.material} - ${registration.reprocessingType}`,
+        selected: registration.id === registrationId
+      }))
+    ],
+    error,
+    errorList,
+    overviewUrl,
+    postUrl: `/organisations/${organisationId}/accreditations/${accreditationId}/assign`
+  }
+}

--- a/src/server/routes/accreditation-assign/candidate-registrations.js
+++ b/src/server/routes/accreditation-assign/candidate-registrations.js
@@ -1,0 +1,26 @@
+/** @import { Accreditation, Registration } from '#server/common/helpers/fetch-organisation-overview.js' */
+
+const APPROVED_STATUS = 'approved'
+
+/**
+ * The registrations an unlinked accreditation may be assigned to.
+ *
+ * A registration qualifies when it is approved, describes the same waste
+ * activity as the accreditation (material, processing type and site), carries a
+ * reprocessing type, and does not already hold an accreditation of its own.
+ * Filtering here is UX — the backend enforces the same rules — but it keeps the
+ * admin from picking an option the backend would only reject.
+ * @param {Registration[]} registrations
+ * @param {Accreditation} accreditation
+ * @returns {Registration[]}
+ */
+export const candidateRegistrations = (registrations, accreditation) =>
+  registrations.filter(
+    (registration) =>
+      registration.status === APPROVED_STATUS &&
+      !registration.accreditation &&
+      Boolean(registration.reprocessingType) &&
+      registration.material === accreditation.material &&
+      registration.processingType === accreditation.processingType &&
+      registration.site === accreditation.site
+  )

--- a/src/server/routes/accreditation-assign/candidate-registrations.test.js
+++ b/src/server/routes/accreditation-assign/candidate-registrations.test.js
@@ -1,0 +1,100 @@
+import { candidateRegistrations } from './candidate-registrations.js'
+
+/** @import { Accreditation, Registration } from '#server/common/helpers/fetch-organisation-overview.js' */
+
+const accreditation = /** @type {Accreditation} */ ({
+  id: 'acc-1',
+  accreditationNumber: null,
+  status: 'created',
+  material: 'glass',
+  processingType: 'reprocessor',
+  site: 'Site A'
+})
+
+/**
+ * @param {Partial<Registration>} overrides
+ * @returns {Registration}
+ */
+const registration = (overrides) =>
+  /** @type {Registration} */ ({
+    id: 'reg-1',
+    registrationNumber: 'REG-001',
+    status: 'approved',
+    material: 'glass',
+    processingType: 'reprocessor',
+    site: 'Site A',
+    reprocessingType: 'input',
+    ...overrides
+  })
+
+describe(candidateRegistrations, () => {
+  test('offers an approved, matching, unaccredited registration', () => {
+    const match = registration({})
+
+    expect(candidateRegistrations([match], accreditation)).toEqual([match])
+  })
+
+  test('excludes a registration that is not approved', () => {
+    const pending = registration({ status: 'created' })
+
+    expect(candidateRegistrations([pending], accreditation)).toEqual([])
+  })
+
+  test('excludes a registration that already has an accreditation', () => {
+    const linked = registration({
+      accreditation: /** @type {Accreditation} */ ({
+        id: 'acc-2',
+        accreditationNumber: 'ACC-002',
+        status: 'approved'
+      })
+    })
+
+    expect(candidateRegistrations([linked], accreditation)).toEqual([])
+  })
+
+  test('excludes a registration with no reprocessing type', () => {
+    const noReprocessingType = registration({ reprocessingType: null })
+
+    expect(candidateRegistrations([noReprocessingType], accreditation)).toEqual(
+      []
+    )
+  })
+
+  test('excludes a registration for a different material', () => {
+    const otherMaterial = registration({ material: 'plastic' })
+
+    expect(candidateRegistrations([otherMaterial], accreditation)).toEqual([])
+  })
+
+  test('excludes a registration with a different processing type', () => {
+    const otherProcessingType = registration({ processingType: 'exporter' })
+
+    expect(
+      candidateRegistrations([otherProcessingType], accreditation)
+    ).toEqual([])
+  })
+
+  test('excludes a registration at a different site', () => {
+    const otherSite = registration({ site: 'Site B' })
+
+    expect(candidateRegistrations([otherSite], accreditation)).toEqual([])
+  })
+
+  test('matches an exporter accreditation that has no site against a registration with no site', () => {
+    const exporterAccreditation = /** @type {Accreditation} */ ({
+      id: 'acc-3',
+      accreditationNumber: null,
+      status: 'created',
+      material: 'glass',
+      processingType: 'exporter'
+    })
+    const exporterRegistration = registration({
+      processingType: 'exporter',
+      site: undefined
+    })
+
+    expect(
+      candidateRegistrations([exporterRegistration], exporterAccreditation)
+    ).toEqual([exporterRegistration])
+  })
+})

--- a/src/server/routes/accreditation-assign/confirm.njk
+++ b/src/server/routes/accreditation-assign/confirm.njk
@@ -1,0 +1,46 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errorList.length %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorList
+        }) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-xl">{{ heading }}</h1>
+
+      {% if hasCandidates %}
+        <form method="POST" action="{{ postUrl }}">
+          <input type="hidden" name="crumb" value="{{ crumb }}" />
+
+          {{ govukSelect({
+            id: "registrationId",
+            name: "registrationId",
+            label: { text: "Registration", classes: "govuk-label--s" },
+            hint: { text: hintText },
+            errorMessage: { text: error } if error,
+            items: items
+          }) }}
+
+          {{ govukButton({
+            text: "Assign to registration"
+          }) }}
+          <p class="govuk-body">
+            <a class="govuk-link" href="{{ overviewUrl }}">Cancel</a>
+          </p>
+        </form>
+      {% else %}
+        <p class="govuk-body">{{ noCandidatesText }}</p>
+        <p class="govuk-body">
+          <a class="govuk-link" href="{{ overviewUrl }}">Back to organisation overview</a>
+        </p>
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}

--- a/src/server/routes/accreditation-assign/controller.get-confirm.js
+++ b/src/server/routes/accreditation-assign/controller.get-confirm.js
@@ -1,0 +1,23 @@
+import {
+  fetchOrganisationOverview,
+  findUnlinkedAccreditation
+} from '#server/common/helpers/fetch-organisation-overview.js'
+import { buildAssignView } from './assign-view.js'
+
+export const accreditationAssignGetController = {
+  async handler(request, h) {
+    const { organisationId, accreditationId } = request.params
+
+    const overview = await fetchOrganisationOverview(request, organisationId)
+    const accreditation = findUnlinkedAccreditation(
+      overview,
+      organisationId,
+      accreditationId
+    )
+
+    return h.view(
+      'routes/accreditation-assign/confirm',
+      buildAssignView(request.params, accreditation, overview.registrations)
+    )
+  }
+}

--- a/src/server/routes/accreditation-assign/controller.post.js
+++ b/src/server/routes/accreditation-assign/controller.post.js
@@ -1,0 +1,77 @@
+import { statusCodes } from '#server/common/constants/status-codes.js'
+import {
+  fetchOrganisationOverview,
+  findUnlinkedAccreditation
+} from '#server/common/helpers/fetch-organisation-overview.js'
+import { postStatusTransition } from '#server/common/helpers/status-transition/post-status-transition.js'
+import { buildAssignView } from './assign-view.js'
+
+const CONFIRM_VIEW = 'routes/accreditation-assign/confirm'
+
+const ASSIGN_ERROR_COPY = {
+  errorMessage:
+    'There was a problem assigning the accreditation to the registration. Please try again.',
+  logMessage: 'Assign accreditation to registration failed'
+}
+
+export const accreditationAssignPostController = {
+  async handler(request, h) {
+    const { organisationId, accreditationId } = request.params
+    const overviewUrl = `/organisations/${organisationId}/overview`
+
+    const registrationId = (request.payload.registrationId ?? '').trim()
+
+    // The overview is needed on every path but the redirect: both re-renders
+    // rebuild the candidate list from it, and it is what proves the
+    // accreditation is still unassigned.
+    const overview = await fetchOrganisationOverview(request, organisationId)
+    const accreditation = findUnlinkedAccreditation(
+      overview,
+      organisationId,
+      accreditationId
+    )
+
+    if (!registrationId) {
+      return h
+        .view(
+          CONFIRM_VIEW,
+          buildAssignView(
+            request.params,
+            accreditation,
+            overview.registrations,
+            {
+              error: 'Select a registration'
+            }
+          )
+        )
+        .code(statusCodes.badRequest)
+    }
+
+    const outcome = await postStatusTransition(
+      request,
+      `/v1/organisations/${organisationId}/accreditations/${accreditationId}/registration`,
+      { registrationId },
+      ASSIGN_ERROR_COPY,
+      { registrationId }
+    )
+
+    if (outcome) {
+      return h
+        .view(
+          CONFIRM_VIEW,
+          buildAssignView(
+            request.params,
+            accreditation,
+            overview.registrations,
+            {
+              registrationId,
+              backendError: outcome.backendError
+            }
+          )
+        )
+        .code(statusCodes.badRequest)
+    }
+
+    return h.redirect(overviewUrl)
+  }
+}

--- a/src/server/routes/accreditation-assign/index.integration.test.js
+++ b/src/server/routes/accreditation-assign/index.integration.test.js
@@ -1,0 +1,302 @@
+import { vi } from 'vitest'
+import * as cheerio from 'cheerio'
+import { config } from '#config/config.js'
+import { statusCodes } from '#server/common/constants/status-codes.js'
+import { mockUserSession } from '#server/common/test-helpers/fixtures.js'
+import { getUserSession } from '#server/common/helpers/auth/get-user-session.js'
+import { createMockOidcServer } from '#server/common/test-helpers/mock-oidc.js'
+import { getCsrfToken } from '#server/common/test-helpers/csrf-helper.js'
+import { http, server as mswServer, HttpResponse } from '#vite/setup-msw.js'
+import { createServer } from '#server/server.js'
+
+vi.mock('#server/common/helpers/auth/get-user-session.js', () => ({
+  getUserSession: vi.fn().mockReturnValue(null)
+}))
+
+describe('accreditation-assign', () => {
+  const backendUrl = config.get('eprBackendUrl')
+  const organisationId = 'aaa111bbb222ccc333ddd4444'
+  const accreditationId = 'ccc333ddd444eee555fff6666'
+  const registrationId = 'bbb222ccc333ddd444eee5555'
+
+  const overviewUrl = `/organisations/${organisationId}/overview`
+  const confirmUrl = `/organisations/${organisationId}/accreditations/${accreditationId}/assign/confirm`
+  const postUrl = `/organisations/${organisationId}/accreditations/${accreditationId}/assign`
+  const assignEndpoint = `${backendUrl}/v1/organisations/${organisationId}/accreditations/${accreditationId}/registration`
+
+  const readOnlySession = { ...mockUserSession, scopes: ['admin.read'] }
+  const writeAuth = { strategy: 'session', credentials: mockUserSession }
+  const readAuth = { strategy: 'session', credentials: readOnlySession }
+
+  const unlinkedAccreditation = {
+    id: accreditationId,
+    accreditationNumber: null,
+    status: 'created',
+    material: 'glass',
+    processingType: 'reprocessor',
+    site: 'Site A'
+  }
+
+  const candidate = {
+    id: registrationId,
+    registrationNumber: 'REG-50030-001',
+    status: 'approved',
+    material: 'glass',
+    processingType: 'reprocessor',
+    site: 'Site A',
+    reprocessingType: 'input'
+  }
+
+  const nonCandidate = {
+    id: 'ddd444eee555fff666aaa7777',
+    registrationNumber: 'REG-50030-002',
+    status: 'approved',
+    material: 'plastic',
+    processingType: 'reprocessor',
+    site: 'Site A',
+    reprocessingType: 'output'
+  }
+
+  const overviewWith = (registrations) => ({
+    id: organisationId,
+    companyName: 'ACME Ltd',
+    registrations,
+    unlinkedAccreditations: [unlinkedAccreditation]
+  })
+
+  let server
+
+  beforeAll(async () => {
+    createMockOidcServer()
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    await server.stop({ timeout: 0 })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const stubOverview = (overview) =>
+    mswServer.use(
+      http.get(
+        `${backendUrl}/v1/organisations/${organisationId}/overview`,
+        () => HttpResponse.json(overview)
+      )
+    )
+
+  const stubAssign = (respond) =>
+    mswServer.use(http.post(assignEndpoint, respond))
+
+  const postAssign = async (payload) => {
+    const { cookie, crumb } = await getCsrfToken(server, confirmUrl, writeAuth)
+    const postResponse = await server.inject({
+      method: 'POST',
+      url: postUrl,
+      auth: writeAuth,
+      headers: { cookie },
+      payload: { crumb, ...payload }
+    })
+    const postCookies = [postResponse.headers['set-cookie']]
+      .flat()
+      .filter(Boolean)
+    const redirectCookie = postCookies.length
+      ? postCookies.map((c) => c.split(';')[0]).join('; ')
+      : cookie
+    return { postResponse, redirectCookie }
+  }
+
+  describe('the assign form', () => {
+    test('is rejected with 401 when unauthenticated', async () => {
+      const { statusCode } = await server.inject({
+        method: 'GET',
+        url: confirmUrl
+      })
+
+      expect(statusCode).toBe(statusCodes.unauthorised)
+    })
+
+    test('returns 403 for a read-only admin', async () => {
+      vi.mocked(getUserSession).mockResolvedValue(readOnlySession)
+
+      const { statusCode } = await server.inject({
+        method: 'GET',
+        url: confirmUrl,
+        auth: readAuth
+      })
+
+      expect(statusCode).toBe(statusCodes.forbidden)
+    })
+
+    test('lists only the registrations the accreditation can be assigned to', async () => {
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+      stubOverview(overviewWith([candidate, nonCandidate]))
+
+      const { statusCode, result } = await server.inject({
+        method: 'GET',
+        url: confirmUrl,
+        auth: writeAuth
+      })
+
+      expect(statusCode).toBe(statusCodes.ok)
+      const $ = cheerio.load(result)
+      const options = $('#registrationId option')
+      expect(options).toHaveLength(2)
+      expect($(options[0]).attr('value')).toBe('')
+      expect($(options[1]).attr('value')).toBe(registrationId)
+      expect($(options[1]).text()).toBe('REG-50030-001 - glass - input')
+      expect($('form').attr('action')).toBe(postUrl)
+    })
+
+    test('explains there is nothing to assign to, with no select and no submit, when no registration qualifies', async () => {
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+      stubOverview(overviewWith([nonCandidate]))
+
+      const { statusCode, result } = await server.inject({
+        method: 'GET',
+        url: confirmUrl,
+        auth: writeAuth
+      })
+
+      expect(statusCode).toBe(statusCodes.ok)
+      const $ = cheerio.load(result)
+      expect($('select')).toHaveLength(0)
+      expect($('form')).toHaveLength(0)
+      expect($('button:contains("Assign to registration")')).toHaveLength(0)
+      expect(result).toContain(
+        'There are no registrations this accreditation can be assigned to'
+      )
+    })
+
+    test('is not found when the accreditation is not an unlinked one', async () => {
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+      stubOverview({
+        id: organisationId,
+        companyName: 'ACME Ltd',
+        registrations: [candidate]
+      })
+
+      const { statusCode } = await server.inject({
+        method: 'GET',
+        url: confirmUrl,
+        auth: writeAuth
+      })
+
+      expect(statusCode).toBe(statusCodes.notFound)
+    })
+  })
+
+  describe('submitting the assign form', () => {
+    test('is rejected with 401 when unauthenticated', async () => {
+      const { statusCode } = await server.inject({
+        method: 'POST',
+        url: postUrl
+      })
+
+      expect(statusCode).toBe(statusCodes.unauthorised)
+    })
+
+    test('returns 403 for a read-only admin', async () => {
+      vi.mocked(getUserSession).mockResolvedValue(readOnlySession)
+
+      const { statusCode } = await server.inject({
+        method: 'POST',
+        url: postUrl,
+        auth: readAuth
+      })
+
+      expect(statusCode).toBe(statusCodes.forbidden)
+    })
+
+    test('re-renders with an error linked to the field when no registration is chosen', async () => {
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+      stubOverview(overviewWith([candidate]))
+
+      const { postResponse } = await postAssign({ registrationId: '' })
+
+      expect(postResponse.statusCode).toBe(statusCodes.badRequest)
+      const $ = cheerio.load(postResponse.result)
+      const errorLink = $('.govuk-error-summary a')
+      expect(errorLink.text()).toBe('Select a registration')
+      expect(errorLink.attr('href')).toBe('#registrationId')
+      expect($('#registrationId option')).toHaveLength(2)
+    })
+
+    test('re-renders with an error when the field is missing from the submission', async () => {
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+      stubOverview(overviewWith([candidate]))
+
+      const { postResponse } = await postAssign({})
+
+      expect(postResponse.statusCode).toBe(statusCodes.badRequest)
+      expect(postResponse.result).toContain('Select a registration')
+    })
+
+    test('posts the chosen registration to the backend and redirects to the organisation overview', async () => {
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+      stubOverview(overviewWith([candidate]))
+
+      let assignBody
+      stubAssign(async ({ request }) => {
+        assignBody = await request.json()
+        return new HttpResponse(null, { status: 204 })
+      })
+
+      const { postResponse } = await postAssign({ registrationId })
+
+      expect(assignBody).toEqual({ registrationId })
+      expect(postResponse.statusCode).toBe(statusCodes.found)
+      expect(postResponse.headers.location).toBe(overviewUrl)
+    })
+
+    test('re-renders with the backend message when the backend rejects the assignment', async () => {
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+      stubOverview(overviewWith([candidate]))
+      stubAssign(() =>
+        HttpResponse.json(
+          { message: 'Registration already has an accreditation' },
+          { status: 409 }
+        )
+      )
+
+      const { postResponse } = await postAssign({ registrationId })
+
+      expect(postResponse.statusCode).toBe(statusCodes.badRequest)
+      const $ = cheerio.load(postResponse.result)
+      expect($('.govuk-error-summary').text()).toContain(
+        'Registration already has an accreditation'
+      )
+      expect(
+        $(`#registrationId option[value="${registrationId}"]`).attr('selected')
+      ).toBeDefined()
+    })
+
+    test('flashes on the organisation overview when the backend fails', async () => {
+      vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+      stubOverview(overviewWith([candidate]))
+      stubAssign(() => new HttpResponse(null, { status: 500 }))
+
+      const { postResponse, redirectCookie } = await postAssign({
+        registrationId
+      })
+
+      expect(postResponse.statusCode).toBe(statusCodes.found)
+      expect(postResponse.headers.location).toBe(overviewUrl)
+
+      stubOverview(overviewWith([candidate]))
+      const { result } = await server.inject({
+        method: 'GET',
+        url: overviewUrl,
+        headers: { cookie: redirectCookie },
+        auth: writeAuth
+      })
+
+      expect(cheerio.load(result)('.govuk-error-summary').text()).toContain(
+        'There was a problem assigning the accreditation to the registration'
+      )
+    })
+  })
+})

--- a/src/server/routes/accreditation-assign/index.js
+++ b/src/server/routes/accreditation-assign/index.js
@@ -1,0 +1,38 @@
+import { accreditationAssignGetController } from './controller.get-confirm.js'
+import { accreditationAssignPostController } from './controller.post.js'
+import { requireScope } from '#server/common/helpers/auth/require-scope.js'
+import { SCOPES } from '#server/common/helpers/auth/scopes.js'
+
+// Deliberately not nested under a registration: every other admin
+// accreditation route is, and an accreditation with no registration cannot be
+// addressed that way.
+const BASE =
+  '/organisations/{organisationId}/accreditations/{accreditationId}/assign'
+const requireWrite = [requireScope(SCOPES.adminWrite)]
+
+export const accreditationAssign = {
+  plugin: {
+    name: 'accreditation-assign',
+    register(server) {
+      server.route([
+        {
+          method: 'GET',
+          path: `${BASE}/confirm`,
+          ...accreditationAssignGetController,
+          options: {
+            pre: requireWrite,
+            app: { pageTitle: 'Assign accreditation to registration' }
+          }
+        },
+        {
+          method: 'POST',
+          path: BASE,
+          ...accreditationAssignPostController,
+          options: {
+            pre: requireWrite
+          }
+        }
+      ])
+    }
+  }
+}

--- a/src/server/routes/organisation-overview/controller.get.js
+++ b/src/server/routes/organisation-overview/controller.get.js
@@ -9,6 +9,9 @@ export const organisationOverviewGETController = {
     const unlinkResult = request.yar.get('unlinkResult')
     request.yar.clear('unlinkResult')
 
+    const errorMessage = request.yar.get('error')
+    request.yar.clear('error')
+
     const pageTitle = request.route.settings.app.pageTitle
 
     return h.view('routes/organisation-overview/index', {
@@ -17,8 +20,10 @@ export const organisationOverviewGETController = {
       heading: data.companyName,
       organisationId: id,
       registrations: data.registrations,
+      unlinkedAccreditations: data.unlinkedAccreditations,
       linkedDefraOrganisation: data.linkedDefraOrganisation,
-      unlinkResult
+      unlinkResult,
+      error: errorMessage
     })
   }
 }

--- a/src/server/routes/organisation-overview/get.integration.test.js
+++ b/src/server/routes/organisation-overview/get.integration.test.js
@@ -224,6 +224,133 @@ describe('#organisationOverviewController', () => {
       expect($(cells[6]).text().trim()).toEqual('-')
     })
 
+    describe('Unlinked accreditations', () => {
+      const unapprovedOrphan = {
+        id: '69c3b4f0abda9efa68dd66a0',
+        accreditationNumber: null,
+        status: 'created',
+        processingType: 'reprocessor',
+        material: 'plastic',
+        site: 'Site C'
+      }
+
+      const approvedOrphan = {
+        id: '69c3b4f0abda9efa68dd66a1',
+        accreditationNumber: 'ACC-50030-009',
+        status: 'approved',
+        processingType: 'exporter',
+        material: 'glass'
+      }
+
+      const stubOverview = (overview) =>
+        mswServer.use(
+          http.get(
+            `${backendUrl}/v1/organisations/${organisationId}/overview`,
+            () => HttpResponse.json(overview)
+          )
+        )
+
+      const renderRows = async (overview, credentials = mockUserSession) => {
+        vi.mocked(getUserSession).mockResolvedValue(credentials)
+        stubOverview(overview)
+
+        const { result } = await server.inject({
+          method: 'GET',
+          url: `/organisations/${organisationId}/overview`,
+          auth: { strategy: 'session', credentials }
+        })
+
+        return cheerio.load(result)('table tbody tr')
+      }
+
+      test('renders an unlinked accreditation after the registration rows, with dashes for the registration columns', async () => {
+        const $rows = await renderRows({
+          ...mockOverview,
+          unlinkedAccreditations: [unapprovedOrphan]
+        })
+
+        expect($rows).toHaveLength(2)
+        const cells = cheerio.load($rows[1])('td')
+        expect(cells.eq(0).text().trim()).toEqual('-')
+        expect(cells.eq(1).text().trim()).toEqual('-')
+        expect(cells.eq(2).text().trim()).toEqual('reprocessor')
+        expect(cells.eq(3).text().trim()).toEqual('plastic')
+        expect(cells.eq(4).text().trim()).toEqual('Site C')
+        expect(cells.eq(5).text().trim()).toEqual('-')
+        expect(cells.eq(6).find('strong.govuk-tag').text().trim()).toEqual(
+          'created'
+        )
+      })
+
+      test('renders the accreditation number once the orphan is approved, and leaves the site blank for an exporter', async () => {
+        const $rows = await renderRows({
+          ...mockOverview,
+          registrations: [],
+          unlinkedAccreditations: [approvedOrphan]
+        })
+
+        const cells = cheerio.load($rows[0])('td')
+        expect(cells.eq(4).text().trim()).toEqual('')
+        expect(cells.eq(5).text().trim()).toEqual('ACC-50030-009')
+        expect(cells.eq(6).find('strong.govuk-tag').text().trim()).toEqual(
+          'approved'
+        )
+      })
+
+      test('offers assigning to a registration as the only action for a write admin', async () => {
+        const $rows = await renderRows({
+          ...mockOverview,
+          registrations: [],
+          unlinkedAccreditations: [unapprovedOrphan]
+        })
+
+        const actions = cheerio.load($rows[0])('td').eq(7).find('a')
+        expect(actions).toHaveLength(1)
+        expect(actions.text()).toEqual('Assign to registration')
+        expect(actions.attr('href')).toEqual(
+          `/organisations/${organisationId}/accreditations/${unapprovedOrphan.id}/assign/confirm`
+        )
+      })
+
+      test('offers no action on an unlinked row for a read-only admin', async () => {
+        const $rows = await renderRows(
+          {
+            ...mockOverview,
+            registrations: [],
+            unlinkedAccreditations: [unapprovedOrphan]
+          },
+          { ...mockUserSession, scopes: ['admin.read'] }
+        )
+
+        expect(cheerio.load($rows[0])('td').eq(7).find('a')).toHaveLength(0)
+      })
+
+      test('renders the table unchanged when there are no unlinked accreditations', async () => {
+        vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+        stubOverview(mockOverview)
+        const withoutKey = await server.inject({
+          method: 'GET',
+          url: `/organisations/${organisationId}/overview`,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        stubOverview({ ...mockOverview, unlinkedAccreditations: [] })
+        const withEmptyCollection = await server.inject({
+          method: 'GET',
+          url: `/organisations/${organisationId}/overview`,
+          auth: { strategy: 'session', credentials: mockUserSession }
+        })
+
+        const table = (response) =>
+          cheerio.load(response.result)('table').toString()
+
+        expect(table(withEmptyCollection)).toEqual(table(withoutKey))
+        expect(cheerio.load(withoutKey.result)('table tbody tr')).toHaveLength(
+          1
+        )
+      })
+    })
+
     describe('Defra ID link section', () => {
       const readOnlySession = { ...mockUserSession, scopes: ['admin.read'] }
       const linkedOverview = {

--- a/src/server/routes/organisation-overview/index.njk
+++ b/src/server/routes/organisation-overview/index.njk
@@ -4,9 +4,21 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% block content %}
   <div class="govuk-width-container">
+    {% if error %}
+      {{ govukErrorSummary({
+        titleText: "There is a problem",
+        errorList: [
+          {
+            text: error
+          }
+        ]
+      }) }}
+    {% endif %}
+
     <h1 class="govuk-heading-xl">{{ heading }}</h1>
 
     {% if unlinkResult === 'success' %}
@@ -57,6 +69,22 @@
         { html: actionsHtml }
       ] %}
       {% set tableRows = tableRows.concat([row]) %}
+    {% endfor %}
+
+    {% for accreditation in unlinkedAccreditations %}
+      {% set assignUrl = '/organisations/' ~ organisationId ~ '/accreditations/' ~ accreditation.id ~ '/assign/confirm' %}
+      {% set assignHtml = '<a class="govuk-link govuk-link--no-visited-state" href="' ~ assignUrl ~ '">Assign to registration</a>' if SCOPES.adminWrite in scopes else '' %}
+      {% set unlinkedRow = [
+        { text: '-' },
+        { text: '-' },
+        { text: accreditation.processingType },
+        { text: accreditation.material },
+        { text: accreditation.site },
+        { text: accreditation.accreditationNumber if accreditation.accreditationNumber else '-' },
+        { html: govukTag({ text: accreditation.status }) },
+        { html: assignHtml }
+      ] %}
+      {% set tableRows = tableRows.concat([unlinkedRow]) %}
     {% endfor %}
 
     {{ govukTable({


### PR DESCRIPTION
Ticket: [PAE-1816](https://eaflood.atlassian.net/browse/PAE-1816)
## Summary

Unlinked accreditations — accreditations that exist without a registration — were invisible in the admin UI, and there was no way to attach one to the registration it belongs to. This adds both: the rows that surface them, and the form that assigns them.

They appear as extra rows in the *existing* registrations table on the organisation overview rather than a second table, so an admin sees the whole picture in one place. The eight columns are unchanged; the registration columns show the same `-` already used when a registration has no accreditation.

The assign route deliberately sits outside the `/registrations/{registrationId}` nesting that every other admin accreditation route uses — an accreditation with no registration cannot be addressed that way.

The backend endpoints are being built in parallel (`unlinkedAccreditations` on the overview, and `POST /v1/organisations/{organisationId}/accreditations/{accreditationId}/registration`); the integration tests stub them over msw.

## Changes

- `organisation-overview/index.njk` appends a row per unlinked accreditation after the registration rows: dash for registration number and status, processing type / material / site / accreditation number from the accreditation (dash when the number is null, which it is until approval), status as a `govukTag`, and a single `Assign to registration` link gated on `admin.write`. With no unlinked accreditations the table renders exactly as before.
- New `accreditation-assign` route at `/organisations/{organisationId}/accreditations/{accreditationId}/assign[/confirm]`, `admin.write` on both GET and POST. It offers a `govukSelect` of registrations that are approved, match the accreditation's material, processing type and site, carry a `reprocessingType`, and have no accreditation of their own. Where no registration qualifies the page says so and renders neither a select nor a submit button.
- A missing selection re-renders at 400 with an error summary anchored to the field; a backend 4xx re-renders with the backend's message; a 5xx flashes on the organisation overview, which now renders that flash.
- `fetch-organisation-overview.js` gains `unlinkedAccreditations` on the overview typedef, `material` / `processingType` / `site` on the accreditation typedef, `reprocessingType` on the registration typedef, and a `findUnlinkedAccreditation` lookup that 404s — which also covers "someone else assigned it while this page was open".
- `postStatusTransition` is reused unchanged for the assign POST; only its doc comment widens to name the third caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PAE-1816]: https://eaflood.atlassian.net/browse/PAE-1816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ