### PR TITLE
PAE-250: Fix js-yaml, postcss and undici vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5739,9 +5739,9 @@
       }
     },
     "node_modules/ajv-cli/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6528,9 +6528,9 @@
       }
     },
     "node_modules/cheerio/node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9977,9 +9977,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -16305,35 +16305,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.12",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -126,14 +126,14 @@
     "webpack-cli": "7.2.2"
   },
   "overrides": {
-    "fast-uri": "3.1.5",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
+    "postcss": "8.5.26",
     "jsoneditor": {
       "ajv": "6.14.0"
     },
     "ajv-cli": {
       "fast-json-patch": "3.1.1",
-      "js-yaml": "3.15.0"
+      "js-yaml": "3.15.1"
     },
     "stylelint-config-gds": {
       "stylelint": "$stylelint"


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## What

Fixes four known vulnerabilities flagged by npm audit and Dependabot alerts, and removes one now-redundant override.

### js-yaml — high severity (GHSA-5p4m-2wfm-xmqj)

`js-yaml` is vulnerable to quadratic CPU consumption while resolving `!!omap`, allowing a denial-of-service on untrusted YAML. Two existing overrides were pinning versions that sit *inside* the vulnerable range, so they were actively holding the tree on a vulnerable release:

- top-level `js-yaml` pin `4.3.0` → `4.3.1`
- `ajv-cli`'s nested `js-yaml` pin `3.15.0` → `3.15.1`

Both `4.3.1` and `3.15.1` carry the fix.

### postcss — moderate severity (GHSA-fxqj-rqcc-2cmp)

An incomplete fix of an earlier advisory lets an attacker-controlled `sourceMappingURL` read arbitrary `.map` files when `from` is unset. The top-level `postcss` was already safe (`8.5.26`), but `vite` bundled its own vulnerable `postcss@8.5.19`. Added a `postcss` override pinned to `8.5.26` to pull the vite-nested copy up to the patched release.

### undici — five CVEs

Fixed the cheerio-nested `undici` (request smuggling, information disclosure, CRLF and cookie injection) via a lockfile bump, the same class of issue as the other frontend repos.

### Removed redundant `fast-uri` override

The `fast-uri` override pinned `3.1.5`, but `ajv@8.20.0` already requires `^3.1.5`, so the pin was doing nothing — the resolved tree is unchanged without it. Removed to keep the override list honest.

## Verification

- `npm audit` — 0 vulnerabilities
- `snyk test` — clean
- Full test suite passes via the pre-commit hook

Needs team approval.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ