### PR TITLE
PAE-1823: Allow an admin to cancel an accepted PRN/PERN from the PRN activity page

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -88,6 +88,14 @@ export const config = convict({
       env: 'AUDIT_ENABLED'
     }
   },
+  featureFlags: {
+    prnAdminCancellation: {
+      doc: 'Feature Flag: Show the Cancel action against an accepted PRN/PERN on the PRN activity page (PAE-1823)',
+      format: Boolean,
+      default: false,
+      env: 'FEATURE_FLAG_PRN_ADMIN_CANCELLATION'
+    }
+  },
   log: {
     enabled: {
       doc: 'Is logging enabled',

--- a/src/config/nunjucks/globals/globals.js
+++ b/src/config/nunjucks/globals/globals.js
@@ -1,1 +1,2 @@
 export { SCOPES } from '#server/common/helpers/auth/scopes.js'
+export { FEATURE_FLAGS } from '#server/common/helpers/feature-flags.js'

--- a/src/server/common/helpers/feature-flags.js
+++ b/src/server/common/helpers/feature-flags.js
@@ -1,0 +1,5 @@
+import { config } from '#config/config.js'
+
+export const FEATURE_FLAGS = Object.freeze({
+  prnAdminCancellation: config.get('featureFlags.prnAdminCancellation')
+})

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -16,6 +16,7 @@ import { prnTonnage } from './routes/prn-tonnage/index.js'
 import { wasteBalanceAvailability } from './routes/waste-balance-availability/index.js'
 import { linkedOrganisations } from './routes/linked-organisations/index.js'
 import { prnActivity } from './routes/prn-activity/index.js'
+import { prnCancel } from './routes/prn-cancel/index.js'
 import { summaryLogUploadsReport } from './routes/summary-log/index.js'
 import { orsUpload } from './routes/ors-upload/index.js'
 import { reportSubmissions } from './routes/report-submissions/index.js'
@@ -57,6 +58,7 @@ export const router = {
         wasteBalanceAvailability,
         linkedOrganisations,
         prnActivity,
+        prnCancel,
         summaryLogUploadsReport,
         orsUpload,
         reportSubmissions,

--- a/src/server/routes/prn-activity/controller.js
+++ b/src/server/routes/prn-activity/controller.js
@@ -12,6 +12,19 @@ function getDisplayName(org) {
   return org.tradingName || org.name || ''
 }
 
+function buildCancelConfirmUrl(prn) {
+  const params = new URLSearchParams({
+    prnNumber: prn.prnNumber || '',
+    organisationName: prn.organisationName || '',
+    issuedTo: getDisplayName(prn.issuedToOrganisation),
+    tonnage: String(prn.tonnage ?? ''),
+    material: prn.material || '',
+    accreditationNumber: prn.accreditationNumber || '',
+    accreditationYear: String(prn.accreditationYear ?? '')
+  })
+  return `/prn-activity/${prn.id}/cancel/confirm?${params}`
+}
+
 function mapPrns(data) {
   const items = data?.items || []
   return items.map((prn) => ({
@@ -30,7 +43,8 @@ function mapPrns(data) {
     accreditationYear: prn.accreditationYear ?? '',
     submittedToRegulator: prn.submittedToRegulator || '',
     organisationName: prn.organisationName || '',
-    wasteProcessingType: prn.wasteProcessingType || ''
+    wasteProcessingType: prn.wasteProcessingType || '',
+    cancelConfirmUrl: buildCancelConfirmUrl(prn)
   }))
 }
 

--- a/src/server/routes/prn-activity/controller.js
+++ b/src/server/routes/prn-activity/controller.js
@@ -15,6 +15,7 @@ function getDisplayName(org) {
 function mapPrns(data) {
   const items = data?.items || []
   return items.map((prn) => ({
+    id: prn.id || '',
     prnNumber: prn.prnNumber || '',
     status: prn.status,
     issuedTo: getDisplayName(prn.issuedToOrganisation),

--- a/src/server/routes/prn-activity/controller.test.js
+++ b/src/server/routes/prn-activity/controller.test.js
@@ -151,6 +151,49 @@ describe('prn-activity controller', () => {
     expect(viewArgs.prns[0].id).toBe('prn-id-1')
   })
 
+  test('Should build the cancel confirm URL from the PRN fields', async () => {
+    mockFetchJsonFromBackend.mockResolvedValue({
+      items: [
+        {
+          id: 'prn-id-1',
+          prnNumber: 'ER26000123',
+          status: 'accepted',
+          tonnage: 5,
+          material: 'plastic',
+          accreditationNumber: 'ACC-2026-001',
+          accreditationYear: 2026,
+          organisationName: 'ACME Ltd',
+          issuedToOrganisation: { name: 'Some Producer' }
+        }
+      ]
+    })
+
+    await prnActivityController.handler(mockRequest, mockH)
+
+    const viewArgs = mockH.view.mock.calls[0][1]
+    expect(viewArgs.prns[0].cancelConfirmUrl).toBe(
+      '/prn-activity/prn-id-1/cancel/confirm?prnNumber=ER26000123&organisationName=ACME+Ltd&issuedTo=Some+Producer&tonnage=5&material=plastic&accreditationNumber=ACC-2026-001&accreditationYear=2026'
+    )
+  })
+
+  test('Should build the cancel confirm URL with empty tonnage/year when they are missing', async () => {
+    mockFetchJsonFromBackend.mockResolvedValue({
+      items: [
+        {
+          id: 'prn-id-1',
+          status: 'accepted'
+        }
+      ]
+    })
+
+    await prnActivityController.handler(mockRequest, mockH)
+
+    const viewArgs = mockH.view.mock.calls[0][1]
+    expect(viewArgs.prns[0].cancelConfirmUrl).toBe(
+      '/prn-activity/prn-id-1/cancel/confirm?prnNumber=&organisationName=&issuedTo=&tonnage=&material=&accreditationNumber=&accreditationYear='
+    )
+  })
+
   test('Should handle empty items array', async () => {
     mockFetchJsonFromBackend.mockResolvedValue({ items: [] })
 

--- a/src/server/routes/prn-activity/controller.test.js
+++ b/src/server/routes/prn-activity/controller.test.js
@@ -121,6 +121,7 @@ describe('prn-activity controller', () => {
     await prnActivityController.handler(mockRequest, mockH)
 
     const viewArgs = mockH.view.mock.calls[0][1]
+    expect(viewArgs.prns[0].id).toBe('')
     expect(viewArgs.prns[0].prnNumber).toBe('')
     expect(viewArgs.prns[0].material).toBe('')
     expect(viewArgs.prns[0].issuedAt).toBe('')
@@ -131,6 +132,23 @@ describe('prn-activity controller', () => {
     expect(viewArgs.prns[0].organisationName).toBe('')
     expect(viewArgs.prns[0].wasteProcessingType).toBe('')
     expect(viewArgs.prns[0].processToBeUsed).toBe('')
+  })
+
+  test('Should map id through from the backend', async () => {
+    mockFetchJsonFromBackend.mockResolvedValue({
+      items: [
+        {
+          id: 'prn-id-1',
+          status: 'accepted',
+          tonnage: 10
+        }
+      ]
+    })
+
+    await prnActivityController.handler(mockRequest, mockH)
+
+    const viewArgs = mockH.view.mock.calls[0][1]
+    expect(viewArgs.prns[0].id).toBe('prn-id-1')
   })
 
   test('Should handle empty items array', async () => {

--- a/src/server/routes/prn-activity/index.flag-off.integration.test.js
+++ b/src/server/routes/prn-activity/index.flag-off.integration.test.js
@@ -1,0 +1,65 @@
+import { vi } from 'vitest'
+import * as cheerio from 'cheerio'
+import { config } from '#config/config.js'
+import { mockUserSession } from '#server/common/test-helpers/fixtures.js'
+import { getUserSession } from '#server/common/helpers/auth/get-user-session.js'
+import { createMockOidcServer } from '#server/common/test-helpers/mock-oidc.js'
+import { http, server as mswServer, HttpResponse } from '#vite/setup-msw.js'
+import { createServer } from '#server/server.js'
+
+vi.mock('#server/common/helpers/auth/get-user-session.js', () => ({
+  getUserSession: vi.fn().mockReturnValue(null)
+}))
+
+vi.mock('#server/common/helpers/feature-flags.js', () => ({
+  FEATURE_FLAGS: { prnAdminCancellation: false }
+}))
+
+describe('prn-activity Cancel link, feature flag off', () => {
+  const backendUrl = config.get('eprBackendUrl')
+
+  let server
+
+  beforeAll(async () => {
+    createMockOidcServer()
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    await server.stop({ timeout: 0 })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('hides the Cancel link for an accepted PRN with admin.write when the flag is off', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+    mswServer.use(
+      http.get(`${backendUrl}/v1/admin/packaging-recycling-notes`, () =>
+        HttpResponse.json({
+          items: [
+            {
+              id: 'prn-id-1',
+              prnNumber: 'ER26000123',
+              status: 'accepted',
+              tonnage: 5
+            }
+          ],
+          hasMore: false
+        })
+      )
+    )
+
+    const { result, statusCode } = await server.inject({
+      method: 'GET',
+      url: '/prn-activity',
+      auth: { strategy: 'session', credentials: mockUserSession }
+    })
+
+    expect(statusCode).toBe(200)
+    const $ = cheerio.load(result)
+    expect($('a:contains("Cancel")')).toHaveLength(0)
+  })
+})

--- a/src/server/routes/prn-activity/index.integration.test.js
+++ b/src/server/routes/prn-activity/index.integration.test.js
@@ -1,0 +1,104 @@
+import { vi } from 'vitest'
+import * as cheerio from 'cheerio'
+import { config } from '#config/config.js'
+import { mockUserSession } from '#server/common/test-helpers/fixtures.js'
+import { getUserSession } from '#server/common/helpers/auth/get-user-session.js'
+import { createMockOidcServer } from '#server/common/test-helpers/mock-oidc.js'
+import { http, server as mswServer, HttpResponse } from '#vite/setup-msw.js'
+import { createServer } from '#server/server.js'
+
+vi.mock('#server/common/helpers/auth/get-user-session.js', () => ({
+  getUserSession: vi.fn().mockReturnValue(null)
+}))
+
+vi.mock('#server/common/helpers/feature-flags.js', () => ({
+  FEATURE_FLAGS: { prnAdminCancellation: true }
+}))
+
+describe('prn-activity Cancel link visibility', () => {
+  const backendUrl = config.get('eprBackendUrl')
+  const readOnlySession = { ...mockUserSession, scopes: ['admin.read'] }
+
+  const buildPrn = (overrides = {}) => ({
+    id: 'prn-id-1',
+    prnNumber: 'ER26000123',
+    status: 'accepted',
+    tonnage: 5,
+    material: 'plastic',
+    accreditationNumber: 'ACC-2026-001',
+    accreditationYear: 2026,
+    organisationName: 'ACME Ltd',
+    issuedToOrganisation: { name: 'Some Producer' },
+    ...overrides
+  })
+
+  const stubPrnList = (prn) =>
+    mswServer.use(
+      http.get(`${backendUrl}/v1/admin/packaging-recycling-notes`, () =>
+        HttpResponse.json({ items: [prn], hasMore: false })
+      )
+    )
+
+  let server
+
+  beforeAll(async () => {
+    createMockOidcServer()
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    await server.stop({ timeout: 0 })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('shows the Cancel link for an accepted PRN when the session has admin.write', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+    stubPrnList(buildPrn())
+
+    const { result, statusCode } = await server.inject({
+      method: 'GET',
+      url: '/prn-activity',
+      auth: { strategy: 'session', credentials: mockUserSession }
+    })
+
+    expect(statusCode).toBe(200)
+    const $ = cheerio.load(result)
+    expect($('a:contains("Cancel")').attr('href')).toBe(
+      '/prn-activity/prn-id-1/cancel/confirm?prnNumber=ER26000123&organisationName=ACME%20Ltd&issuedTo=Some%20Producer&tonnage=5&material=plastic&accreditationNumber=ACC-2026-001&accreditationYear=2026'
+    )
+  })
+
+  test('hides the Cancel link when the PRN status is not accepted', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+    stubPrnList(buildPrn({ status: 'cancelled' }))
+
+    const { result, statusCode } = await server.inject({
+      method: 'GET',
+      url: '/prn-activity',
+      auth: { strategy: 'session', credentials: mockUserSession }
+    })
+
+    expect(statusCode).toBe(200)
+    const $ = cheerio.load(result)
+    expect($('a:contains("Cancel")')).toHaveLength(0)
+  })
+
+  test('hides the Cancel link for a read-only (admin.read only) session', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(readOnlySession)
+    stubPrnList(buildPrn())
+
+    const { result, statusCode } = await server.inject({
+      method: 'GET',
+      url: '/prn-activity',
+      auth: { strategy: 'session', credentials: readOnlySession }
+    })
+
+    expect(statusCode).toBe(200)
+    const $ = cheerio.load(result)
+    expect($('a:contains("Cancel")')).toHaveLength(0)
+  })
+})

--- a/src/server/routes/prn-activity/index.integration.test.js
+++ b/src/server/routes/prn-activity/index.integration.test.js
@@ -17,6 +17,7 @@ vi.mock('#server/common/helpers/feature-flags.js', () => ({
 
 describe('prn-activity Cancel link visibility', () => {
   const backendUrl = config.get('eprBackendUrl')
+  const prnActivityUrl = '/prn-activity'
   const readOnlySession = { ...mockUserSession, scopes: ['admin.read'] }
 
   const buildPrn = (overrides = {}) => ({
@@ -61,7 +62,7 @@ describe('prn-activity Cancel link visibility', () => {
 
     const { result, statusCode } = await server.inject({
       method: 'GET',
-      url: '/prn-activity',
+      url: prnActivityUrl,
       auth: { strategy: 'session', credentials: mockUserSession }
     })
 
@@ -78,7 +79,7 @@ describe('prn-activity Cancel link visibility', () => {
 
     const { result, statusCode } = await server.inject({
       method: 'GET',
-      url: '/prn-activity',
+      url: prnActivityUrl,
       auth: { strategy: 'session', credentials: mockUserSession }
     })
 
@@ -93,7 +94,7 @@ describe('prn-activity Cancel link visibility', () => {
 
     const { result, statusCode } = await server.inject({
       method: 'GET',
-      url: '/prn-activity',
+      url: prnActivityUrl,
       auth: { strategy: 'session', credentials: readOnlySession }
     })
 

--- a/src/server/routes/prn-activity/index.integration.test.js
+++ b/src/server/routes/prn-activity/index.integration.test.js
@@ -69,7 +69,7 @@ describe('prn-activity Cancel link visibility', () => {
     expect(statusCode).toBe(200)
     const $ = cheerio.load(result)
     expect($('a:contains("Cancel")').attr('href')).toBe(
-      '/prn-activity/prn-id-1/cancel/confirm?prnNumber=ER26000123&organisationName=ACME%20Ltd&issuedTo=Some%20Producer&tonnage=5&material=plastic&accreditationNumber=ACC-2026-001&accreditationYear=2026'
+      '/prn-activity/prn-id-1/cancel/confirm?prnNumber=ER26000123&organisationName=ACME+Ltd&issuedTo=Some+Producer&tonnage=5&material=plastic&accreditationNumber=ACC-2026-001&accreditationYear=2026'
     )
   })
 

--- a/src/server/routes/prn-activity/index.njk
+++ b/src/server/routes/prn-activity/index.njk
@@ -33,6 +33,19 @@
         {% for prn in prns %}
           {% set statusCell = { html: govukTag({ text: prn.status | replace("_", " ") }) } %}
 
+          {% set actionCell = { html: '' } %}
+          {% if FEATURE_FLAGS.prnAdminCancellation and prn.status == 'accepted' and SCOPES.adminWrite in scopes %}
+            {% set confirmUrl = "/prn-activity/" + prn.id + "/cancel/confirm"
+              + "?prnNumber=" + (prn.prnNumber | urlencode)
+              + "&organisationName=" + (prn.organisationName | urlencode)
+              + "&issuedTo=" + (prn.issuedTo | urlencode)
+              + "&tonnage=" + (prn.tonnage | string | urlencode)
+              + "&material=" + (prn.material | urlencode)
+              + "&accreditationNumber=" + (prn.accreditationNumber | urlencode)
+              + "&accreditationYear=" + (prn.accreditationYear | string | urlencode) %}
+            {% set actionCell = { html: '<a class="govuk-link" href="' + confirmUrl + '">Cancel<span class="govuk-visually-hidden"> PRN ' + prn.prnNumber + '</span></a>' } %}
+          {% endif %}
+
           {% set row = [
             { text: prn.prnNumber },
             statusCell,
@@ -48,7 +61,8 @@
             { text: prn.accreditationYear },
             { text: prn.submittedToRegulator },
             { text: prn.organisationName },
-            { text: prn.wasteProcessingType }
+            { text: prn.wasteProcessingType },
+            actionCell
           ] %}
           {% set tableRows = tableRows.concat([row]) %}
         {% endfor %}
@@ -71,7 +85,8 @@
             { text: "Accreditation Year" },
             { text: "Submitted To Regulator" },
             { text: "Organisation" },
-            { text: "Waste Processing Type" }
+            { text: "Waste Processing Type" },
+            { text: "Action" }
           ],
           rows: tableRows
         }) }}

--- a/src/server/routes/prn-activity/index.njk
+++ b/src/server/routes/prn-activity/index.njk
@@ -35,15 +35,7 @@
 
           {% set actionCell = { html: '' } %}
           {% if FEATURE_FLAGS.prnAdminCancellation and prn.status == 'accepted' and SCOPES.adminWrite in scopes %}
-            {% set confirmUrl = "/prn-activity/" + prn.id + "/cancel/confirm"
-              + "?prnNumber=" + (prn.prnNumber | urlencode)
-              + "&organisationName=" + (prn.organisationName | urlencode)
-              + "&issuedTo=" + (prn.issuedTo | urlencode)
-              + "&tonnage=" + (prn.tonnage | string | urlencode)
-              + "&material=" + (prn.material | urlencode)
-              + "&accreditationNumber=" + (prn.accreditationNumber | urlencode)
-              + "&accreditationYear=" + (prn.accreditationYear | string | urlencode) %}
-            {% set actionCell = { html: '<a class="govuk-link" href="' + confirmUrl + '">Cancel<span class="govuk-visually-hidden"> PRN ' + prn.prnNumber + '</span></a>' } %}
+            {% set actionCell = { html: '<a class="govuk-link" href="' + prn.cancelConfirmUrl + '">Cancel<span class="govuk-visually-hidden"> PRN ' + prn.prnNumber + '</span></a>' } %}
           {% endif %}
 
           {% set row = [

--- a/src/server/routes/prn-cancel/confirm.njk
+++ b/src/server/routes/prn-cancel/confirm.njk
@@ -1,0 +1,49 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">{{ heading }} {{ prnNumber }}</h1>
+
+      {{ govukSummaryList({
+        rows: [
+          { key: { text: "PRN number" }, value: { text: prnNumber } },
+          { key: { text: "Organisation" }, value: { text: organisationName } },
+          { key: { text: "Issued to" }, value: { text: issuedTo } },
+          { key: { text: "Tonnage" }, value: { text: tonnage } },
+          { key: { text: "Material" }, value: { text: material } },
+          { key: { text: "Accreditation number" }, value: { text: accreditationNumber } },
+          { key: { text: "Accreditation year" }, value: { text: accreditationYear } }
+        ]
+      }) }}
+
+      {{ govukWarningText({
+        text: "Cancelling this PRN cannot be undone. " + tonnage + " tonnes will be credited back to the operator's waste balance immediately.",
+        iconFallbackText: "Warning"
+      }) }}
+
+      {% if SCOPES.adminWrite in scopes %}
+        <form method="POST" action="{{ postUrl }}">
+          <input type="hidden" name="crumb" value="{{ crumb }}" />
+          <input type="hidden" name="prnNumber" value="{{ prnNumber }}" />
+          <input type="hidden" name="organisationName" value="{{ organisationName }}" />
+          <input type="hidden" name="issuedTo" value="{{ issuedTo }}" />
+          <input type="hidden" name="tonnage" value="{{ tonnage }}" />
+          <input type="hidden" name="material" value="{{ material }}" />
+          <input type="hidden" name="accreditationNumber" value="{{ accreditationNumber }}" />
+          <input type="hidden" name="accreditationYear" value="{{ accreditationYear }}" />
+          {{ govukButton({
+            text: "Yes, cancel this PRN",
+            classes: "govuk-button--warning"
+          }) }}
+          <p class="govuk-body">
+            <a class="govuk-link" href="{{ overviewUrl }}">Return without cancelling</a>
+          </p>
+        </form>
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}

--- a/src/server/routes/prn-cancel/constants.js
+++ b/src/server/routes/prn-cancel/constants.js
@@ -1,0 +1,1 @@
+export const PAGE_TITLE = 'Cancel PRN'

--- a/src/server/routes/prn-cancel/controller.get-confirm.js
+++ b/src/server/routes/prn-cancel/controller.get-confirm.js
@@ -1,0 +1,38 @@
+import { PAGE_TITLE } from './constants.js'
+
+/**
+ * Renders the confirmation page from the display values carried on the query
+ * string by the Cancel link in `/prn-activity` — there is no backend
+ * single-PRN admin GET endpoint to re-fetch them from. This is display only:
+ * the backend independently re-checks the PRN's status and cancellation
+ * window on POST, so a tampered query string cannot cause a bad cancellation.
+ */
+export const prnCancelConfirmGetController = {
+  async handler(request, h) {
+    const { prnId } = request.params
+    const {
+      prnNumber,
+      organisationName,
+      issuedTo,
+      tonnage,
+      material,
+      accreditationNumber,
+      accreditationYear
+    } = request.query
+
+    return h.view('routes/prn-cancel/confirm', {
+      pageTitle: request.route.settings.app?.pageTitle,
+      heading: PAGE_TITLE,
+      breadcrumbs: [{ text: 'PRN activity', href: '/prn-activity' }],
+      overviewUrl: '/prn-activity',
+      postUrl: `/prn-activity/${prnId}/cancel`,
+      prnNumber,
+      organisationName,
+      issuedTo,
+      tonnage,
+      material,
+      accreditationNumber,
+      accreditationYear
+    })
+  }
+}

--- a/src/server/routes/prn-cancel/controller.post.js
+++ b/src/server/routes/prn-cancel/controller.post.js
@@ -1,0 +1,71 @@
+import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
+import { statusCodes } from '#server/common/constants/status-codes.js'
+
+const GENERIC_FAILURE_REASON =
+  'There was a problem cancelling the PRN. Please try again.'
+
+/**
+ * The backend returns a specific, human-readable message for both refusal
+ * cases it can produce (wrong status, past the cancellation deadline) as a
+ * 409 Conflict — surface it verbatim. Any other failure (5xx, network) falls
+ * back to a generic message. `fetchJsonFromBackend` always throws a Boom
+ * error (it re-throws Boom as-is, wraps anything else), so `error.output` is
+ * always present here.
+ * @param {*} error
+ */
+const failureReason = (error) => {
+  const { statusCode, payload } = error.output
+  return statusCode < statusCodes.internalServerError && payload?.message
+    ? payload.message
+    : GENERIC_FAILURE_REASON
+}
+
+export const prnCancelPostController = {
+  async handler(request, h) {
+    const { prnId } = request.params
+    const {
+      prnNumber,
+      organisationName,
+      issuedTo,
+      tonnage,
+      material,
+      accreditationNumber,
+      accreditationYear
+    } = request.payload
+
+    const displayFields = {
+      prnNumber,
+      organisationName,
+      issuedTo,
+      tonnage,
+      material,
+      accreditationNumber,
+      accreditationYear
+    }
+
+    try {
+      await fetchJsonFromBackend(
+        request,
+        `/v1/admin/packaging-recycling-notes/${prnId}/cancel`,
+        { method: 'POST' }
+      )
+
+      return h.view('routes/prn-cancel/result', {
+        pageTitle: 'Cancel PRN',
+        success: true,
+        overviewUrl: '/prn-activity',
+        ...displayFields
+      })
+    } catch (error) {
+      request.logger.error({ err: error, message: 'Cancel PRN failed' })
+
+      return h.view('routes/prn-cancel/result', {
+        pageTitle: 'Cancel PRN',
+        success: false,
+        reason: failureReason(error),
+        overviewUrl: '/prn-activity',
+        ...displayFields
+      })
+    }
+  }
+}

--- a/src/server/routes/prn-cancel/index.integration.test.js
+++ b/src/server/routes/prn-cancel/index.integration.test.js
@@ -1,0 +1,208 @@
+import { vi } from 'vitest'
+import * as cheerio from 'cheerio'
+import { config } from '#config/config.js'
+import { statusCodes } from '#server/common/constants/status-codes.js'
+import { mockUserSession } from '#server/common/test-helpers/fixtures.js'
+import { getUserSession } from '#server/common/helpers/auth/get-user-session.js'
+import { createMockOidcServer } from '#server/common/test-helpers/mock-oidc.js'
+import { getCsrfToken } from '#server/common/test-helpers/csrf-helper.js'
+import { http, server as mswServer, HttpResponse } from '#vite/setup-msw.js'
+import { createServer } from '#server/server.js'
+
+vi.mock('#server/common/helpers/auth/get-user-session.js', () => ({
+  getUserSession: vi.fn().mockReturnValue(null)
+}))
+
+describe('prn-cancel', () => {
+  const backendUrl = config.get('eprBackendUrl')
+  const prnId = 'aaa111bbb222ccc333ddd4444'
+  const confirmUrl = `/prn-activity/${prnId}/cancel/confirm`
+  const postUrl = `/prn-activity/${prnId}/cancel`
+
+  const displayFields = {
+    prnNumber: 'ER26000123',
+    organisationName: 'ACME Ltd',
+    issuedTo: 'Some Producer',
+    tonnage: '500',
+    material: 'plastic',
+    accreditationNumber: 'ACC-2026-001',
+    accreditationYear: '2026'
+  }
+
+  const confirmQuery = new URLSearchParams(displayFields).toString()
+
+  const readOnlySession = { ...mockUserSession, scopes: ['admin.read'] }
+
+  let server
+
+  beforeAll(async () => {
+    createMockOidcServer()
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    await server.stop({ timeout: 0 })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const stubCancelSuccess = () =>
+    mswServer.use(
+      http.post(
+        `${backendUrl}/v1/admin/packaging-recycling-notes/${prnId}/cancel`,
+        () =>
+          HttpResponse.json({
+            id: prnId,
+            prnNumber: displayFields.prnNumber,
+            status: 'cancelled',
+            tonnage: 500
+          })
+      )
+    )
+
+  const stubCancelFailure = (status, message) =>
+    mswServer.use(
+      http.post(
+        `${backendUrl}/v1/admin/packaging-recycling-notes/${prnId}/cancel`,
+        () => HttpResponse.json({ message }, { status })
+      )
+    )
+
+  const writeAuth = { strategy: 'session', credentials: mockUserSession }
+  const readAuth = { strategy: 'session', credentials: readOnlySession }
+
+  const postCancel = async () => {
+    const { cookie, crumb } = await getCsrfToken(
+      server,
+      `${confirmUrl}?${confirmQuery}`,
+      writeAuth
+    )
+    return server.inject({
+      method: 'POST',
+      url: postUrl,
+      auth: writeAuth,
+      headers: { cookie },
+      payload: { crumb, ...displayFields }
+    })
+  }
+
+  test('confirm page is rejected with 401 when unauthenticated', async () => {
+    const { statusCode } = await server.inject({
+      method: 'GET',
+      url: `${confirmUrl}?${confirmQuery}`
+    })
+    expect(statusCode).toBe(statusCodes.unauthorised)
+  })
+
+  test('confirm page returns 403 for a read-only admin', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(readOnlySession)
+    const { statusCode } = await server.inject({
+      method: 'GET',
+      url: `${confirmUrl}?${confirmQuery}`,
+      auth: readAuth
+    })
+    expect(statusCode).toBe(statusCodes.forbidden)
+  })
+
+  test('confirm page renders the PRN details, warning and form', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+
+    const { result, statusCode } = await server.inject({
+      method: 'GET',
+      url: `${confirmUrl}?${confirmQuery}`,
+      auth: writeAuth
+    })
+
+    expect(statusCode).toBe(statusCodes.ok)
+    const $ = cheerio.load(result)
+    expect($('h1').text()).toContain(displayFields.prnNumber)
+    expect(result).toContain('cannot be undone')
+    expect($('form').attr('action')).toBe(postUrl)
+    expect($('a:contains("Return without cancelling")').attr('href')).toBe(
+      '/prn-activity'
+    )
+  })
+
+  test('POST is rejected with 401 when unauthenticated', async () => {
+    const { statusCode } = await server.inject({
+      method: 'POST',
+      url: postUrl
+    })
+    expect(statusCode).toBe(statusCodes.unauthorised)
+  })
+
+  test('POST is rejected with 403 for a read-only admin', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(readOnlySession)
+    const { cookie, crumb } = await getCsrfToken(
+      server,
+      `${confirmUrl}?${confirmQuery}`,
+      readAuth
+    )
+    const { statusCode } = await server.inject({
+      method: 'POST',
+      url: postUrl,
+      auth: readAuth,
+      headers: { cookie },
+      payload: { crumb, ...displayFields }
+    })
+    expect(statusCode).toBe(statusCodes.forbidden)
+  })
+
+  test('successful cancellation renders the confirmation panel', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+    stubCancelSuccess()
+
+    const response = await postCancel()
+
+    expect(response.statusCode).toBe(statusCodes.ok)
+    const $ = cheerio.load(response.result)
+    expect($('.govuk-panel--confirmation h1').text()).toBe('PRN cancelled')
+    expect(response.result).toContain(displayFields.prnNumber)
+    expect(response.result).toContain('credited back')
+  })
+
+  test('a 409 deadline refusal from the backend is shown verbatim', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+    const deadlineMessage =
+      'The deadline for a 2026 relevant year was 31 January 2027.'
+    stubCancelFailure(409, deadlineMessage)
+
+    const response = await postCancel()
+
+    expect(response.statusCode).toBe(statusCodes.ok)
+    const $ = cheerio.load(response.result)
+    expect($('.app-panel--error h1').text()).toBe('Cancellation failed')
+    expect(response.result).toContain(deadlineMessage)
+  })
+
+  test('a backend 500 falls back to a generic failure message', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+    stubCancelFailure(500, 'Internal error detail the user should not see')
+
+    const response = await postCancel()
+
+    expect(response.statusCode).toBe(statusCodes.ok)
+    expect(response.result).toContain('There was a problem cancelling the PRN')
+    expect(response.result).not.toContain(
+      'Internal error detail the user should not see'
+    )
+  })
+
+  test('a backend-unreachable failure falls back to a generic failure message', async () => {
+    vi.mocked(getUserSession).mockResolvedValue(mockUserSession)
+    mswServer.use(
+      http.post(
+        `${backendUrl}/v1/admin/packaging-recycling-notes/${prnId}/cancel`,
+        () => HttpResponse.error()
+      )
+    )
+
+    const response = await postCancel()
+
+    expect(response.statusCode).toBe(statusCodes.ok)
+    expect(response.result).toContain('There was a problem cancelling the PRN')
+  })
+})

--- a/src/server/routes/prn-cancel/index.js
+++ b/src/server/routes/prn-cancel/index.js
@@ -1,0 +1,47 @@
+import Joi from 'joi'
+
+import { prnCancelConfirmGetController } from './controller.get-confirm.js'
+import { prnCancelPostController } from './controller.post.js'
+import { requireScope } from '#server/common/helpers/auth/require-scope.js'
+import { SCOPES } from '#server/common/helpers/auth/scopes.js'
+import { PAGE_TITLE } from './constants.js'
+
+const BASE = '/prn-activity/{prnId}/cancel'
+const requireWrite = [requireScope(SCOPES.adminWrite)]
+
+const idParam = Joi.string()
+  .pattern(/^[\w-]+$/)
+  .required()
+
+export const prnCancel = {
+  plugin: {
+    name: 'prn-cancel',
+    register(server) {
+      server.route([
+        {
+          method: 'GET',
+          path: `${BASE}/confirm`,
+          ...prnCancelConfirmGetController,
+          options: {
+            pre: requireWrite,
+            app: { pageTitle: PAGE_TITLE },
+            validate: {
+              params: Joi.object({ prnId: idParam })
+            }
+          }
+        },
+        {
+          method: 'POST',
+          path: BASE,
+          ...prnCancelPostController,
+          options: {
+            pre: requireWrite,
+            validate: {
+              params: Joi.object({ prnId: idParam })
+            }
+          }
+        }
+      ])
+    }
+  }
+}

--- a/src/server/routes/prn-cancel/result.njk
+++ b/src/server/routes/prn-cancel/result.njk
@@ -19,7 +19,7 @@
             <strong>Tonnage:</strong> {{ tonnage }}
           </p>
           <p class="govuk-body">
-            The waste balance has been credited back to the operator immediately.
+            {{ tonnage }} tonnes have been credited back to the operator's waste balance.
           </p>
         {% else %}
           <div class="govuk-panel app-panel--error">

--- a/src/server/routes/prn-cancel/result.njk
+++ b/src/server/routes/prn-cancel/result.njk
@@ -1,0 +1,41 @@
+{% extends 'layout.njk' %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="app-content-width">
+
+        {% if success %}
+          <div class="govuk-panel govuk-panel--confirmation">
+            <h1 class="govuk-panel__title">PRN cancelled</h1>
+          </div>
+          <p class="govuk-body govuk-!-margin-top-6">
+            <strong>PRN number:</strong> {{ prnNumber }}
+          </p>
+          <p class="govuk-body">
+            <strong>Organisation:</strong> {{ organisationName }}
+          </p>
+          <p class="govuk-body">
+            <strong>Tonnage:</strong> {{ tonnage }}
+          </p>
+          <p class="govuk-body">
+            The waste balance has been credited back to the operator immediately.
+          </p>
+        {% else %}
+          <div class="govuk-panel app-panel--error">
+            <h1 class="govuk-panel__title">Cancellation failed</h1>
+          </div>
+          <p class="govuk-body govuk-!-margin-top-6">
+            <strong>PRN number:</strong> {{ prnNumber }}
+          </p>
+          <p class="govuk-body">{{ reason if reason else "The PRN could not be cancelled." }}</p>
+        {% endif %}
+
+        <p class="govuk-body govuk-!-margin-top-6">
+          <a class="govuk-link" href="{{ overviewUrl }}">Back to PRN activity</a>
+        </p>
+
+      </div>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
Ticket: [PAE-1823](https://eaflood.atlassian.net/browse/PAE-1823)
- Adds a Cancel action to the PRN activity table for accepted PRNs, gated by a new `FEATURE_FLAG_PRN_ADMIN_CANCELLATION` flag and the `admin.write` scope
- Follows the report-unsubmit confirm-then-POST pattern: a dedicated confirmation page summarises the PRN before the admin commits, then a result page shows success or surfaces the backend's refusal reason verbatim
- The backend's response is the sole source of truth for whether a cancellation succeeds — the button is offered on any accepted PRN, and any refusal (wrong status, past the compliance-year deadline) is only discovered on submit, matching the existing unsubmit flow's UX
- Adds render-level integration test coverage for the Cancel link's visibility (accepted status, write scope, feature flag) that this page previously had none of


<img width="3790" height="877" alt="image" src="https://github.com/user-attachments/assets/49da6628-048e-4dce-83df-21b5dc5c4c9a" />


<img width="1709" height="1253" alt="image" src="https://github.com/user-attachments/assets/77a6ca6e-beab-46d3-9c0a-a8e249a575d4" />


<img width="1186" height="830" alt="image" src="https://github.com/user-attachments/assets/439ddc35-14b0-41fa-aed9-6c724de799da" />

<img width="1577" height="844" alt="image" src="https://github.com/user-attachments/assets/49b08488-6f36-4d23-a012-05714d00c460" />


[PAE-1823]: https://eaflood.atlassian.net/browse/PAE-1823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ