### PR TITLE
PAE-1826: Read the waste balance ledger from its new address

### DIFF
--- a/src/server/routes/waste-balance-events/controller.get.js
+++ b/src/server/routes/waste-balance-events/controller.get.js
@@ -5,6 +5,38 @@ import {
 } from '#server/common/helpers/fetch-organisation-overview.js'
 
 /**
+ * One entry of a waste balance ledger, as the backend answers it.
+ *
+ * An event concerns a waste report or a note, never both, and states that one
+ * subject under a key that names it.
+ * @typedef {{
+ *   id: string,
+ *   number: number,
+ *   kind: string,
+ *   createdAt: string,
+ *   createdBy: { id: string, name?: string, email?: string },
+ *   balance: {
+ *     opening: { total: number, available: number },
+ *     closing: { total: number, available: number }
+ *   },
+ *   summaryLog?: { id: string, creditTotal: number },
+ *   prn?: { id: string, tonnage: number }
+ * }} LedgerEvent
+ */
+
+/**
+ * The thing the event concerns, under the key that names it. The page shows it
+ * raw, so the key has to travel with the value: an `id` alone says which
+ * record without saying which kind of record.
+ * @param {LedgerEvent} event
+ * @returns {string}
+ */
+const subjectOf = (event) =>
+  JSON.stringify(
+    event.summaryLog ? { summaryLog: event.summaryLog } : { prn: event.prn }
+  )
+
+/**
  * Format an actor for display: "Name (email)", "Name", "email", or "".
  * @param {{ id: string, name?: string, email?: string }} actor
  * @returns {string}
@@ -28,10 +60,12 @@ export const wasteBalanceEventsGETController = {
       registrationId
     )
 
-    const events = await fetchJsonFromBackend(
-      request,
-      `/v1/admin/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/waste-balance-events`,
-      {}
+    const { events } = /** @type {{ events: LedgerEvent[] }} */ (
+      await fetchJsonFromBackend(
+        request,
+        `/v1/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/waste-balance-ledger`,
+        {}
+      )
     )
 
     const heading = `${overview.companyName} - ${registration.accreditation?.accreditationNumber}`
@@ -41,9 +75,9 @@ export const wasteBalanceEventsGETController = {
       kind: event.kind,
       createdAt: event.createdAt,
       createdBy: formatActor(event.createdBy),
-      payload: JSON.stringify(event.payload),
-      closingAmount: event.closingBalance.amount,
-      closingAvailableAmount: event.closingBalance.availableAmount
+      subject: subjectOf(event),
+      closingAmount: event.balance.closing.total,
+      closingAvailableAmount: event.balance.closing.available
     }))
 
     return h.view('routes/waste-balance-events/index', {

--- a/src/server/routes/waste-balance-events/controller.get.js
+++ b/src/server/routes/waste-balance-events/controller.get.js
@@ -7,7 +7,7 @@ import {
 /**
  * One entry of a waste balance ledger, as the backend answers it.
  *
- * An event concerns a waste report or a note, never both, and states that one
+ * An event concerns a summary log or a note, never both, and states that one
  * subject under a key that names it.
  * @typedef {{
  *   number: number,

--- a/src/server/routes/waste-balance-events/controller.get.js
+++ b/src/server/routes/waste-balance-events/controller.get.js
@@ -10,7 +10,6 @@ import {
  * An event concerns a waste report or a note, never both, and states that one
  * subject under a key that names it.
  * @typedef {{
- *   id: string,
  *   number: number,
  *   kind: string,
  *   createdAt: string,

--- a/src/server/routes/waste-balance-events/get.integration.test.js
+++ b/src/server/routes/waste-balance-events/get.integration.test.js
@@ -73,14 +73,13 @@ describe('#wasteBalanceEventsController', () => {
   const mockEvents = [
     {
       id: 'evt-1',
-      registrationId: 'reg-001',
-      accreditationId,
-      organisationId,
       number: 1,
-      kind: 'SUMMARY_LOG_SUBMITTED',
-      payload: { summaryLogId: 'sl-1', creditTotal: 100 },
-      openingBalance: { amount: 0, availableAmount: 0 },
-      closingBalance: { amount: 100, availableAmount: 100 },
+      kind: 'summary-log-submitted',
+      summaryLog: { id: 'sl-1', creditTotal: 100 },
+      balance: {
+        opening: { total: 0, available: 0 },
+        closing: { total: 100, available: 100 }
+      },
       createdAt: '2026-01-15T10:00:00.000Z',
       createdBy: {
         id: 'user-1',
@@ -90,14 +89,13 @@ describe('#wasteBalanceEventsController', () => {
     },
     {
       id: 'evt-2',
-      registrationId: 'reg-001',
-      accreditationId,
-      organisationId,
       number: 2,
-      kind: 'PRN_CREATED',
-      payload: { prnId: 'prn-1', amount: 50 },
-      openingBalance: { amount: 100, availableAmount: 100 },
-      closingBalance: { amount: 100, availableAmount: 50 },
+      kind: 'prn-created',
+      prn: { id: 'prn-1', tonnage: 50 },
+      balance: {
+        opening: { total: 100, available: 100 },
+        closing: { total: 100, available: 50 }
+      },
       createdAt: '2026-01-16T14:30:00.000Z',
       createdBy: { id: 'user-1', name: 'Test User' }
     }
@@ -126,8 +124,12 @@ describe('#wasteBalanceEventsController', () => {
         () => HttpResponse.json(overviewResponse)
       ),
       http.get(
-        `${backendUrl}/v1/admin/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/waste-balance-events`,
-        () => HttpResponse.json(eventsResponse)
+        `${backendUrl}/v1/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/waste-balance-ledger`,
+        () =>
+          HttpResponse.json({
+            ledger: { organisationId, registrationId, accreditationId },
+            events: eventsResponse
+          })
       )
     )
   }
@@ -237,7 +239,7 @@ describe('#wasteBalanceEventsController', () => {
         'Kind',
         'Date',
         'Created by',
-        'Payload',
+        'Subject',
         'Closing balance',
         'Closing available'
       ])
@@ -259,7 +261,7 @@ describe('#wasteBalanceEventsController', () => {
 
       const firstCells = getAllByRole(rows[0], 'cell')
       expect(firstCells[0]).toHaveTextContent('1')
-      expect(firstCells[1]).toHaveTextContent('SUMMARY_LOG_SUBMITTED')
+      expect(firstCells[1]).toHaveTextContent('summary-log-submitted')
       expect(firstCells[3]).toHaveTextContent(
         'Test User (test.user@example.com)'
       )
@@ -268,13 +270,13 @@ describe('#wasteBalanceEventsController', () => {
 
       const secondCells = getAllByRole(rows[1], 'cell')
       expect(secondCells[0]).toHaveTextContent('2')
-      expect(secondCells[1]).toHaveTextContent('PRN_CREATED')
+      expect(secondCells[1]).toHaveTextContent('prn-created')
       expect(secondCells[3]).toHaveTextContent('Test User')
       expect(secondCells[5]).toHaveTextContent('100')
       expect(secondCells[6]).toHaveTextContent('50')
     })
 
-    it('should render the payload as json inside a code element', async () => {
+    it('should render the subject as json inside a code element', async () => {
       useMockBackend()
 
       const { result } = await server.inject({
@@ -285,29 +287,28 @@ describe('#wasteBalanceEventsController', () => {
 
       const body = renderPage(result)
       const [firstRow] = getDataRows(getEventsTable(body))
-      const payloadCell = getAllByRole(firstRow, 'cell')[4]
+      const subjectCell = getAllByRole(firstRow, 'cell')[4]
 
-      expect(payloadCell.querySelector('code')?.textContent).toBe(
-        '{"summaryLogId":"sl-1","creditTotal":100}'
+      expect(subjectCell.querySelector('code')?.textContent).toBe(
+        '{"summaryLog":{"id":"sl-1","creditTotal":100}}'
       )
     })
 
-    it('should render a payload carrying markup as text, not markup', async () => {
-      const payload = {
-        summaryLogId: '</code><img src="x" onerror="alert(1)">',
+    it('should render a subject carrying markup as text, not markup', async () => {
+      const summaryLog = {
+        id: '</code><img src="x" onerror="alert(1)">',
         creditTotal: 100
       }
       useMockBackend(mockOverview, [
         {
           id: 'evt-5',
-          registrationId: 'reg-001',
-          accreditationId,
-          organisationId,
           number: 5,
-          kind: 'SUMMARY_LOG_SUBMITTED',
-          payload,
-          openingBalance: { amount: 0, availableAmount: 0 },
-          closingBalance: { amount: 100, availableAmount: 100 },
+          kind: 'summary-log-submitted',
+          summaryLog,
+          balance: {
+            opening: { total: 0, available: 0 },
+            closing: { total: 100, available: 100 }
+          },
           createdAt: '2026-01-19T10:00:00.000Z',
           createdBy: {
             id: 'user-1',
@@ -325,24 +326,23 @@ describe('#wasteBalanceEventsController', () => {
 
       const body = renderPage(result)
       const [firstRow] = getDataRows(getEventsTable(body))
-      const payloadCell = getAllByRole(firstRow, 'cell')[4]
+      const subjectCell = getAllByRole(firstRow, 'cell')[4]
 
-      expect(payloadCell.querySelector('img')).toBeNull()
-      expect(payloadCell.textContent).toBe(JSON.stringify(payload))
+      expect(subjectCell.querySelector('img')).toBeNull()
+      expect(subjectCell.textContent).toBe(JSON.stringify({ summaryLog }))
     })
 
     test('Should render empty Created by when actor has only id', async () => {
       useMockBackend(mockOverview, [
         {
           id: 'evt-3',
-          registrationId: 'reg-001',
-          accreditationId,
-          organisationId,
           number: 3,
-          kind: 'PRN_CREATED',
-          payload: { prnId: 'prn-2', amount: 10 },
-          openingBalance: { amount: 50, availableAmount: 50 },
-          closingBalance: { amount: 50, availableAmount: 40 },
+          kind: 'prn-created',
+          prn: { id: 'prn-2', tonnage: 10 },
+          balance: {
+            opening: { total: 50, available: 50 },
+            closing: { total: 50, available: 40 }
+          },
           createdAt: '2026-01-17T09:00:00.000Z',
           createdBy: /** @type {any} */ ({ id: 'user-2' })
         }
@@ -365,14 +365,13 @@ describe('#wasteBalanceEventsController', () => {
       useMockBackend(mockOverview, [
         {
           id: 'evt-4',
-          registrationId: 'reg-001',
-          accreditationId,
-          organisationId,
           number: 4,
-          kind: 'PRN_ISSUED',
-          payload: { prnId: 'prn-3', amount: 20 },
-          openingBalance: { amount: 50, availableAmount: 40 },
-          closingBalance: { amount: 50, availableAmount: 40 },
+          kind: 'prn-issued',
+          prn: { id: 'prn-3', tonnage: 20 },
+          balance: {
+            opening: { total: 50, available: 40 },
+            closing: { total: 50, available: 40 }
+          },
           createdAt: '2026-01-18T11:00:00.000Z',
           createdBy: /** @type {any} */ ({
             id: 'user-3',

--- a/src/server/routes/waste-balance-events/get.integration.test.js
+++ b/src/server/routes/waste-balance-events/get.integration.test.js
@@ -72,7 +72,6 @@ describe('#wasteBalanceEventsController', () => {
 
   const mockEvents = [
     {
-      id: 'evt-1',
       number: 1,
       kind: 'summary-log-submitted',
       summaryLog: { id: 'sl-1', creditTotal: 100 },
@@ -88,7 +87,6 @@ describe('#wasteBalanceEventsController', () => {
       }
     },
     {
-      id: 'evt-2',
       number: 2,
       kind: 'prn-created',
       prn: { id: 'prn-1', tonnage: 50 },
@@ -301,7 +299,6 @@ describe('#wasteBalanceEventsController', () => {
       }
       useMockBackend(mockOverview, [
         {
-          id: 'evt-5',
           number: 5,
           kind: 'summary-log-submitted',
           summaryLog,
@@ -335,7 +332,6 @@ describe('#wasteBalanceEventsController', () => {
     test('Should render empty Created by when actor has only id', async () => {
       useMockBackend(mockOverview, [
         {
-          id: 'evt-3',
           number: 3,
           kind: 'prn-created',
           prn: { id: 'prn-2', tonnage: 10 },
@@ -364,7 +360,6 @@ describe('#wasteBalanceEventsController', () => {
     test('Should render email as Created by when actor has no name', async () => {
       useMockBackend(mockOverview, [
         {
-          id: 'evt-4',
           number: 4,
           kind: 'prn-issued',
           prn: { id: 'prn-3', tonnage: 20 },

--- a/src/server/routes/waste-balance-events/index.njk
+++ b/src/server/routes/waste-balance-events/index.njk
@@ -10,13 +10,13 @@
         {% if eventRows and eventRows.length %}
           {% set tableRows = [] %}
           {% for row in eventRows %}
-            {% set payloadHtml %}<code>{{ row.payload }}</code>{% endset %}
+            {% set subjectHtml %}<code>{{ row.subject }}</code>{% endset %}
             {% set tableRows = tableRows.concat([[
               { text: row.number },
               { text: row.kind },
               { text: row.createdAt },
               { text: row.createdBy },
-              { html: payloadHtml },
+              { html: subjectHtml },
               { text: row.closingAmount },
               { text: row.closingAvailableAmount }
             ]]) %}
@@ -30,7 +30,7 @@
               { text: "Kind" },
               { text: "Date" },
               { text: "Created by" },
-              { text: "Payload" },
+              { text: "Subject" },
               { text: "Closing balance" },
               { text: "Closing available" }
             ],


### PR DESCRIPTION
Ticket: [PAE-1826](https://eaflood.atlassian.net/browse/PAE-1826)
The waste balance events page now reads the backend ledger at /v1/organisations/{organisationId}/registrations/{registrationId}/accreditations/{accreditationId}/waste-balance-ledger, which answers a `ledger` object and an `events` array in place of the raw stored documents it used to return. Each event states its balances as `balance.closing.total` and `balance.closing.available`, and states the one thing it concerns as either a `summaryLog` or a `prn`, so the column that showed a `payload` blob now shows that subject and is headed Subject. The backend change is a migration rather than an expand and contract, because this endpoint serves service maintainers and regulators and no operator, so this must deploy together with DEFRA/epr-backend#1652.

[PAE-1826]: https://eaflood.atlassian.net/browse/PAE-1826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ